### PR TITLE
Update to use latest no-OS, several additions and minor changes

### DIFF
--- a/LTSketchbook/Active Learning/LT1054_voltage_mode_buck_DC_ctrl/LT1054_voltage_mode_buck_DC_ctrl.ino
+++ b/LTSketchbook/Active Learning/LT1054_voltage_mode_buck_DC_ctrl/LT1054_voltage_mode_buck_DC_ctrl.ino
@@ -1,0 +1,187 @@
+/*
+  Control system for a simple voltage-mode buck converter based on
+  the LT1054. ATMega-based Arduinos (such as the Linduino) only.
+
+  Reads an analog input pin, compares to desired setpoint, integrates the error,
+  maps the integral to a range from 0 to 255 and uses
+  the result to set the pulse width modulation (PWM) of an output pin.
+  Also prints the results to the Serial Monitor.
+
+  The circuit:
+  - LT1054 clock overdrive circuit, driven by Digital Pin 3 (PWM capable)
+  - Analog Input 0 connected to buck converter output.
+
+
+  Derived from AnalogInOutSerial example:
+  http://www.arduino.cc/en/Tutorial/AnalogInOutSerial
+  PWM frequency adjustment function from:
+  https://playground.arduino.cc/Code/PwmFrequency
+  
+Copyright 2018(c) Analog Devices, Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ - Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ - Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+ - Neither the name of Analog Devices, Inc. nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+ - The use of this software may or may not infringe the patent rights
+   of one or more patent holders.  This license does not release you
+   from the requirement that you obtain separate licenses from these
+   patent holders to use this software.
+ - Use of the software either in source or binary form, must be run
+   on or directly connected to an Analog Devices Inc. component.
+
+THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+// These constants won't change. They're used to give names to the pins used:
+const int analogInPin = A0;  // Analog input pin that the potentiometer is attached to
+const int analogOutPin = 3; // Analog output pin that the LED is attached to
+#define fixed 0
+#define closed_loop 1
+
+float vout = 3.3; // Floating poiont output voltage.
+int setpoint = int (vout * 1024.0 / 5.0);
+//int setpoint = 512; // 1.25V
+int feedback = 0;        // value read from the pot
+int outputValue = 0;        // value output to the PWM (analog out)
+int error = 0;
+int integral = 128;
+
+#define verbose
+
+void setup() {
+  // initialize serial communications at 115200 bps:
+#ifdef verbose  
+  Serial.begin(115200);
+#endif
+  setPwmFrequency(analogOutPin, 1);
+}
+
+uint8_t state = closed_loop;
+void loop() {
+  char ch;
+  if(Serial.available()){
+    ch = Serial.read();
+    switch(ch) {
+      case '0': state = fixed; analogWrite(analogOutPin, 0); break;
+      case '1': state = fixed; analogWrite(analogOutPin, 26); break;
+      case '2': state = fixed; analogWrite(analogOutPin, 51); break;
+      case '3': state = fixed; analogWrite(analogOutPin, 77); break;
+      case '4': state = fixed; analogWrite(analogOutPin, 102); break;
+      case '5': state = fixed; analogWrite(analogOutPin, 128); break;
+      case '6': state = fixed; analogWrite(analogOutPin, 153); break;
+      case '7': state = fixed; analogWrite(analogOutPin, 179); break;
+      case '8': state = fixed; analogWrite(analogOutPin, 204); break;
+      case '9': state = fixed; analogWrite(analogOutPin, 230); break;
+      case 'A': state = fixed; analogWrite(analogOutPin, 255); break;
+      default: state = closed_loop;
+    }
+  }
+  if(state == closed_loop){
+    // read the analog in value:
+    feedback = analogRead(analogInPin);
+    error = setpoint - feedback;
+    integral = integral + error/4; //kI = 0.25
+    if(integral > 1023) integral = 1023;
+    if(integral < 0) integral = 0;
+    
+    // map it to the range of the analog out
+    // (could probably just right-shift by two...)
+    outputValue = map(integral, 0, 1023, 0, 255);
+    // change the analog out value:
+    analogWrite(analogOutPin, outputValue);
+  #ifdef verbose
+    // print the results to the Serial Monitor:
+    Serial.print("feedback = ");
+    Serial.print(feedback);
+    Serial.print("\t output = ");
+    Serial.println(outputValue);
+  #endif
+    // wait some milliseconds before the next loop for the analog-to-digital
+    // converter to settle after the last reading:
+    delay(10);
+  }
+}
+
+
+/**
+ * Divides a given PWM pin frequency by a divisor.
+ * 
+ * The resulting frequency is equal to the base frequency divided by
+ * the given divisor:
+ *   - Base frequencies:
+ *      o The base frequency for pins 3, 9, 10, and 11 is 31250 Hz.
+ *      o The base frequency for pins 5 and 6 is 62500 Hz.
+ *   - Divisors:
+ *      o The divisors available on pins 5, 6, 9 and 10 are: 1, 8, 64,
+ *        256, and 1024.
+ *      o The divisors available on pins 3 and 11 are: 1, 8, 32, 64,
+ *        128, 256, and 1024.
+ * 
+ * PWM frequencies are tied together in pairs of pins. If one in a
+ * pair is changed, the other is also changed to match:
+ *   - Pins 5 and 6 are paired on timer0
+ *   - Pins 9 and 10 are paired on timer1
+ *   - Pins 3 and 11 are paired on timer2
+ * 
+ * Note that this function will have side effects on anything else
+ * that uses timers:
+ *   - Changes on pins 3, 5, 6, or 11 may cause the delay() and
+ *     millis() functions to stop working. Other timing-related
+ *     functions may also be affected.
+ *   - Changes on pins 9 or 10 will cause the Servo library to function
+ *     incorrectly.
+ * 
+ * Thanks to macegr of the Arduino forums for his documentation of the
+ * PWM frequency divisors. His post can be viewed at:
+ *   http://forum.arduino.cc/index.php?topic=16612#msg121031
+ */
+void setPwmFrequency(int pin, int divisor) {
+  byte mode;
+  if(pin == 5 || pin == 6 || pin == 9 || pin == 10) {
+    switch(divisor) {
+      case 1: mode = 0x01; break;
+      case 8: mode = 0x02; break;
+      case 64: mode = 0x03; break;
+      case 256: mode = 0x04; break;
+      case 1024: mode = 0x05; break;
+      default: return;
+    }
+    if(pin == 5 || pin == 6) {
+      TCCR0B = TCCR0B & 0b11111000 | mode;
+    } else {
+      TCCR1B = TCCR1B & 0b11111000 | mode;
+    }
+  } else if(pin == 3 || pin == 11) {
+    switch(divisor) {
+      case 1: mode = 0x01; break;
+      case 8: mode = 0x02; break;
+      case 32: mode = 0x03; break;
+      case 64: mode = 0x04; break;
+      case 128: mode = 0x05; break;
+      case 256: mode = 0x06; break;
+      case 1024: mode = 0x07; break;
+      default: return;
+    }
+    TCCR2B = TCCR2B & 0b11111000 | mode;
+  }
+}

--- a/LTSketchbook/Example Designs/CN0416_SerialPassthrough/CN0416_SerialPassthrough.ino
+++ b/LTSketchbook/Example Designs/CN0416_SerialPassthrough/CN0416_SerialPassthrough.ino
@@ -36,9 +36,9 @@ void setup() {
 void loop() {
   if (Serial.available()) {      // If anything comes in Serial (USB),
     digitalWrite(2, HIGH);
+    delay(1);
     Serial1.write(Serial.read());   // read it and send it out Serial1 (pins 0 & 1)
-	delay(2);
-	digitalWrite(2, LOW);
+    digitalWrite(2, LOW);
   }
 
   if (Serial1.available()) {     // If anything comes in Serial1 (pins 0 & 1)

--- a/LTSketchbook/Example Designs/CN0416_SerialPassthrough/CN0416_SerialPassthrough.ino
+++ b/LTSketchbook/Example Designs/CN0416_SerialPassthrough/CN0416_SerialPassthrough.ino
@@ -1,0 +1,47 @@
+/*
+  Modified from:
+  SerialPassthrough sketch
+
+  Added assertion of Enable signal to RS485 driver.
+  
+  
+  Some boards, like the Arduino 101, the MKR1000, Zero, or the Micro, have one
+  hardware serial port attached to Digital pins 0-1, and a separate USB serial
+  port attached to the IDE Serial Monitor. This means that the "serial
+  passthrough" which is possible with the Arduino UNO (commonly used to interact
+  with devices/shields that require configuration via serial AT commands) will
+  not work by default.
+
+  This sketch allows you to emulate the serial passthrough behaviour. Any text
+  you type in the IDE Serial monitor will be written out to the serial port on
+  Digital pins 0 and 1, and vice-versa.
+
+  On the 101, MKR1000, Zero, and Micro, "Serial" refers to the USB Serial port
+  attached to the Serial Monitor, and "Serial1" refers to the hardware serial
+  port attached to pins 0 and 1. This sketch will emulate Serial passthrough
+  using those two Serial ports on the boards mentioned above, but you can change
+  these names to connect any two serial ports on a board that has multiple ports.
+
+  created 23 May 2016
+  by Erik Nyquist
+*/
+
+void setup() {
+  pinMode(2, OUTPUT);
+  digitalWrite(2, LOW);
+  Serial.begin(9600);
+  Serial1.begin(9600);
+}
+
+void loop() {
+  if (Serial.available()) {      // If anything comes in Serial (USB),
+    digitalWrite(2, HIGH);
+    Serial1.write(Serial.read());   // read it and send it out Serial1 (pins 0 & 1)
+	delay(2);
+	digitalWrite(2, LOW);
+  }
+
+  if (Serial1.available()) {     // If anything comes in Serial1 (pins 0 & 1)
+    Serial.write(Serial1.read());   // read it and send it out Serial (USB)
+  }
+}

--- a/LTSketchbook/Example Designs/CN0416_capitalizer/CN0416_capitalizer.ino
+++ b/LTSketchbook/Example Designs/CN0416_capitalizer/CN0416_capitalizer.ino
@@ -4,6 +4,42 @@ Incoming characters are echoed back, with lower-case
 characters converted to upper case. This allows the observation
 of simultaneous traffic being transmitted and recieved, ensuring
 that the characters are different (no cheating!)
+
+
+
+Copyright 2018(c) Analog Devices, Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ - Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ - Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+ - Neither the name of Analog Devices, Inc. nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+ - The use of this software may or may not infringe the patent rights
+   of one or more patent holders.  This license does not release you
+   from the requirement that you obtain separate licenses from these
+   patent holders to use this software.
+ - Use of the software either in source or binary form, must be run
+   on or directly connected to an Analog Devices Inc. component.
+
+THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 */
 
 

--- a/LTSketchbook/Example Designs/CN0416_capitalizer/CN0416_capitalizer.ino
+++ b/LTSketchbook/Example Designs/CN0416_capitalizer/CN0416_capitalizer.ino
@@ -1,0 +1,60 @@
+/*
+Very simple RS485 full-duplex example for CN0416.
+Incoming characters are echoed back, with lower-case
+characters converted to upper case. This allows the observation
+of simultaneous traffic being transmitted and recieved, ensuring
+that the characters are different (no cheating!)
+*/
+
+
+#include <stdint.h>
+#include <Arduino.h>
+
+#define DE 2 // RS485 Driver Enable pin
+
+const uint8_t addr2ch[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'}; // number to character
+
+char chaddr;
+
+void setup() {
+  uint8_t addr = 0;
+  pinMode(DE, OUTPUT);
+  digitalWrite(DE, HIGH);
+	
+  pinMode(A0, INPUT);
+  pinMode(A1, INPUT);
+  pinMode(A2, INPUT);
+  pinMode(A3, INPUT);
+  
+  addr += digitalRead(A3);
+  addr << 1;
+  addr += digitalRead(A2);
+  addr << 1;
+  addr += digitalRead(A1);
+  addr << 1;
+  addr += digitalRead(A0);
+  
+  if (addr > 15) {addr = 15;} // just in case...
+  chaddr = addr2ch[addr];
+  Serial.begin(9600);
+  delay(2);
+  digitalWrite(DE, HIGH);
+  Serial.print("Hello, I am node ");
+  Serial.println(chaddr);
+  Serial.flush();
+  delay(2);
+  digitalWrite(DE, LOW);
+}
+
+
+void loop() {
+char ch;
+  if (Serial.available()) {      // If anything comes in Serial (USB),
+    ch = Serial.read();
+    if(ch >= 'a' && ch <= 'z')
+    {
+      ch -= 32; // Convert lower-case to capital
+    }
+	Serial.write(ch); // Convert lower-case to capital
+	}
+}

--- a/LTSketchbook/Example Designs/CN0416_echo_node/CN0416_echo_node.ino
+++ b/LTSketchbook/Example Designs/CN0416_echo_node/CN0416_echo_node.ino
@@ -54,6 +54,7 @@ char ch;
     ch = Serial.read();
 	if(ch == chaddr){
 	  digitalWrite(DE, HIGH);
+	  delay(1);
       Serial.print("Hello from node "); // read it and send it out Serial1 (pins 0 & 1)
 	  Serial.print(ch);
 	  Serial.println("!");

--- a/LTSketchbook/Example Designs/CN0416_echo_node/CN0416_echo_node.ino
+++ b/LTSketchbook/Example Designs/CN0416_echo_node/CN0416_echo_node.ino
@@ -1,0 +1,65 @@
+/*
+Very simple RS485 node example for CN0416.
+Reads address switch on power-up, and reports address. Once a network is assembled,
+reset node boards one-by-one to verify addresses.
+
+Once running, main loop looks for a single ASCII HEX character representing the address,
+if it matches, report "Hello, I am node X"
+*/
+
+
+#include <stdint.h>
+#include <Arduino.h>
+
+#define DE 2 // RS485 Driver Enable pin
+
+const uint8_t addr2ch[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'}; // number to character
+
+char chaddr;
+
+void setup() {
+  uint8_t addr = 0;
+  pinMode(DE, OUTPUT);
+  digitalWrite(DE, LOW);
+	
+  pinMode(A0, INPUT);
+  pinMode(A1, INPUT);
+  pinMode(A2, INPUT);
+  pinMode(A3, INPUT);
+  
+  addr += digitalRead(A3);
+  addr << 1;
+  addr += digitalRead(A2);
+  addr << 1;
+  addr += digitalRead(A1);
+  addr << 1;
+  addr += digitalRead(A0);
+  
+  if (addr > 15) {addr = 15;} // just in case...
+  chaddr = addr2ch[addr];
+  Serial.begin(9600);
+  delay(2);
+  digitalWrite(DE, HIGH);
+  Serial.print("Hello, I am node ");
+  Serial.println(chaddr);
+  Serial.flush();
+  delay(2);
+  digitalWrite(DE, LOW);
+}
+
+
+void loop() {
+char ch;
+  if (Serial.available()) {      // If anything comes in Serial (USB),
+    ch = Serial.read();
+	if(ch == chaddr){
+	  digitalWrite(DE, HIGH);
+      Serial.print("Hello from node "); // read it and send it out Serial1 (pins 0 & 1)
+	  Serial.print(ch);
+	  Serial.println("!");
+	  Serial.flush();
+      delay(2);
+	  digitalWrite(DE, LOW);
+	}
+  }
+}

--- a/LTSketchbook/Example Designs/CN0416_echo_node/CN0416_echo_node.ino
+++ b/LTSketchbook/Example Designs/CN0416_echo_node/CN0416_echo_node.ino
@@ -4,7 +4,42 @@ Reads address switch on power-up, and reports address. Once a network is assembl
 reset node boards one-by-one to verify addresses.
 
 Once running, main loop looks for a single ASCII HEX character representing the address,
-if it matches, report "Hello, I am node X"
+if it matches, report "Hello, from node X"
+
+
+Copyright 2018(c) Analog Devices, Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ - Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ - Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+ - Neither the name of Analog Devices, Inc. nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+ - The use of this software may or may not infringe the patent rights
+   of one or more patent holders.  This license does not release you
+   from the requirement that you obtain separate licenses from these
+   patent holders to use this software.
+ - Use of the software either in source or binary form, must be run
+   on or directly connected to an Analog Devices Inc. component.
+
+THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 */
 
 

--- a/LTSketchbook/Example Designs/LTC2492_Panel_Meter/LTC2492_Panel_Meter.ino
+++ b/LTSketchbook/Example Designs/LTC2492_Panel_Meter/LTC2492_Panel_Meter.ino
@@ -174,29 +174,33 @@ void setup()
 
   lcd.begin(16,2);
   lcd.setCursor(0, 0);
-  lcd.print("Hello, APDoods");
+  lcd.print("Hello, DC2132");
   lcd.setCursor(0, 1);
   lcd.print("Power Supply! :)");
 
   delay(2000);
+  lcd.setCursor(0, 0);
+  lcd.print("                ");
+  lcd.setCursor(0, 1);
+  lcd.print("                ");
   char demo_name[]="DC1011";    // Demo Board Name stored in QuikEval EEPROM
   quikeval_SPI_init();          // Configure the spi port for 4MHz SCK
   quikeval_SPI_connect();       // Connect SPI to main data port
   quikeval_I2C_init();          // Configure the EEPROM I2C port for 100kHz
   Serial.begin(115200);         // Initialize the serial port to the PC
-  print_title();
+//  print_title();
 
   demo_board_connected = discover_demo_board(demo_name);
-  if (demo_board_connected)
-  {
-    print_prompt();
-  }
-  else
-  {
-    Serial.println(F("EEPROM not detected, will attempt to proceed"));
-    demo_board_connected = 1;
-    print_prompt();
-  }
+  // if (demo_board_connected)
+  // {
+    // print_prompt();
+  // }
+  // else
+  // {
+    // Serial.println(F("EEPROM not detected, will attempt to proceed"));
+    // demo_board_connected = 1;
+    // print_prompt();
+  // }
   quikeval_SPI_connect();       //Initialize for SPI
 }
 
@@ -208,7 +212,7 @@ void loop()
   int16_t user_command;                 // The user input command
   uint8_t ack_EOC = 0;                  // Keeps track of the EOC timeout
   int32_t adc_code = 0;            // The LTC2498 code
-  float temperature, adc_voltage, vout_voltage;
+  float temperature, adc_voltage, vout_voltage, iout_current;
 
 // Program channel 1, read channel 0
   adc_command_high = BUILD_COMMAND_SINGLE_ENDED[1];     // Build ADC command for channel 0
@@ -218,6 +222,8 @@ void loop()
   adc_voltage = LTC2498_code_to_voltage(adc_code, LTC2498_vref);
   vout_voltage = adc_voltage * vdiv_gain;
   lcd.setCursor(0, 0);
+  lcd.print("        ");
+  lcd.setCursor(0, 0);
   lcd.print("V=");
   lcd.print(vout_voltage, 2);
 // Program temperature, read channel 1
@@ -226,9 +232,12 @@ void loop()
   LTC2498_EOC_timeout(LTC2498_CS, eoc_timeout);
   LTC2498_read(LTC2498_CS, adc_command_high, adc_command_low, &adc_code);   // Throws out last reading
   adc_voltage = LTC2498_code_to_voltage(adc_code, LTC2498_vref);
+  iout_current = adc_voltage * 10.0;
+  lcd.setCursor(8, 0);
+  lcd.print("        ");
   lcd.setCursor(8, 0);
   lcd.print("I=");
-  lcd.print(adc_voltage, 2);
+  lcd.print(iout_current, 2);
 
 
 // Program channel 0, read temperature
@@ -241,344 +250,10 @@ void loop()
   adc_voltage = LTC2498_code_to_voltage(adc_code, LTC2498_vref);
   temperature = (adc_voltage/93.5e-6)-273.15;
   lcd.setCursor(0, 1);
-  lcd.print("T=");
+  lcd.print("        ");
+  lcd.setCursor(0, 1);
+  lcd.print("Ta=");
   lcd.print(temperature, 2);
 
-
-
-
 }
 
-// Function Definitions
-
-//! Prints the title block when program first starts.
-void print_title()
-{
-  Serial.print(F("\n*****************************************************************\n"));
-  Serial.print(F("* DC1011A-A Demonstration Program                               *\n"));
-  Serial.print(F("*                                                               *\n"));
-  Serial.print(F("* This program demonstrates how to send data and receive data   *\n"));
-  Serial.print(F("* from the 24-bit ADC.                                          *\n"));
-  Serial.print(F("*                                                               *\n"));
-  Serial.print(F("*                                                               *\n"));
-  Serial.print(F("* Set the baud rate to 115200 and select the newline terminator.*\n"));
-  Serial.print(F("*                                                               *\n"));
-  Serial.print(F("*****************************************************************\n"));
-}
-
-//! Prints main menu.
-void print_prompt()
-{
-  Serial.print(F("\n1-Read Single-Ended\n"));
-  Serial.print(F("2-Read Differential\n"));
-  Serial.print(F("3-Read Temperature\n"));
-  Serial.print(F("4-2X Mode Settings\n"));
-  Serial.print(F("Enter a Command: "));
-}
-
-//! Display selected differential channels. Displaying single-ended channels is
-//! straightforward; not so with differential because the inputs can take either polarity.
-void print_user_command(uint8_t menu)
-{
-  switch (menu)
-  {
-    case 0:
-      Serial.print(F("0P-1N"));
-      break;
-    case 1:
-      Serial.print(F("2P-3N"));
-      break;
-    case 2:
-      Serial.print(F("4P-5N"));
-      break;
-    case 3:
-      Serial.print(F("6P-7N"));
-      break;
-    case 4:
-      Serial.print(F("8P-9N"));
-      break;
-    case 5:
-      Serial.print(F("10P-11N"));
-      break;
-    case 6:
-      Serial.print(F("12P-13N"));
-      break;
-    case 7:
-      Serial.print(F("14P-15N"));
-      break;
-    case 8:
-      Serial.print(F("1P-0N"));
-      break;
-    case 9:
-      Serial.print(F("3P-2N"));
-      break;
-    case 10:
-      Serial.print(F("5P-4N"));
-      break;
-    case 11:
-      Serial.print(F("7P-6N"));
-      break;
-    case 12:
-      Serial.print(F("9P-8N"));
-      break;
-    case 13:
-      Serial.print(F("11P-10N"));
-      break;
-    case 14:
-      Serial.print(F("13P-12N"));
-      break;
-    case 15:
-      Serial.print(F("15P-14N"));
-      break;
-  }
-  Serial.print(F(": "));
-}
-
-//! Read channels in single-ended mode
-//! @return Returns 0=successful, 1=unsuccessful (exceeded timeout)
-uint8_t menu_1_read_single_ended()
-{
-  uint8_t adc_command_high; // The LTC2498 command high byte
-  uint8_t adc_command_low;  // The LTC2498 command low byte
-  int16_t user_command;     // The user input command
-  int32_t adc_code = 0;     // The LTC2498 code
-  float adc_voltage = 0;    // The LTC2498 voltage
-
-  while (1)
-  {
-    Serial.print(F("*************************\n\n"));
-    Serial.print(F("0-CH0  8-CH8\n"));
-    Serial.print(F("1-CH1  9-CH9\n"));
-    Serial.print(F("2-CH2  10-CH10\n"));
-    Serial.print(F("3-CH3  11-CH11\n"));
-    Serial.print(F("4-CH4  12-CH12\n"));
-    Serial.print(F("5-CH5  13-CH13\n"));
-    Serial.print(F("6-CH6  14-CH14\n"));
-    Serial.print(F("7-CH7  15-CH15\n"));
-    Serial.print(F("16-ALL\n"));
-    Serial.print(F("m-Main Menu\n"));
-    Serial.print(F("Enter a Command: "));
-
-    user_command = read_int();                              // Read the single command
-    if (user_command == 'm')
-      break;
-    Serial.println(user_command);
-
-    if (user_command == 16)
-    {
-      Serial.print(F("ALL\n"));
-      adc_command_high = BUILD_COMMAND_SINGLE_ENDED[0];     // Build ADC command for channel 0
-      adc_command_low = rejection_mode | two_x_mode;
-      if (LTC2498_EOC_timeout(LTC2498_CS, eoc_timeout))
-        return 1;
-      LTC2498_read(LTC2498_CS, adc_command_high, adc_command_low, &adc_code);   // Throws out last reading
-
-      for (int8_t x = 0; x <= 15; x++)                      // Read all channels in single-ended mode
-      {
-
-
-        adc_command_high = BUILD_COMMAND_SINGLE_ENDED[(x + 1) % 16];
-        if (LTC2498_EOC_timeout(LTC2498_CS, eoc_timeout))
-          return 1;
-        LTC2498_read(LTC2498_CS, adc_command_high, adc_command_low, &adc_code);
-        adc_voltage = LTC2498_code_to_voltage(adc_code, LTC2498_vref);
-
-        Serial.print(F("  ****"));
-        Serial.print(F("CH"));
-        Serial.print(x);
-        Serial.print(F(": "));
-        Serial.print(adc_voltage, 4);
-        Serial.print(F("V\n\n"));
-      }
-    }
-    else
-    {
-      adc_command_high = BUILD_COMMAND_SINGLE_ENDED[user_command];
-      adc_command_low = rejection_mode | two_x_mode;
-      Serial.print(F("ADC Command: 0x"));
-      Serial.println((adc_command_high<<8) | adc_command_low, HEX);
-
-      quikeval_SPI_connect();
-      if (LTC2498_EOC_timeout(LTC2498_CS, eoc_timeout))
-        return 1;
-      LTC2498_read(LTC2498_CS, adc_command_high, adc_command_low, &adc_code);     // Throws out last reading
-      if (LTC2498_EOC_timeout(LTC2498_CS, eoc_timeout))
-        return 1;
-      LTC2498_read(LTC2498_CS, adc_command_high, adc_command_low, &adc_code);     // Now we're ready to read the desired data
-
-      Serial.print(F("Received Code: 0x"));
-      Serial.println(adc_code, HEX);
-      adc_voltage = LTC2498_code_to_voltage(adc_code, LTC2498_vref);
-      Serial.print(F("  ****"));
-      Serial.print(F("CH"));
-      Serial.print(user_command);
-      Serial.print(F(": "));
-      Serial.print(adc_voltage, 4);
-      Serial.print(F("V\n\n"));
-    }
-  }
-  return 0;
-}
-
-//! Read channels in differential mode
-//! @return Returns 0=successful, 1=unsuccessful (exceeded timeout)
-uint8_t menu_2_read_differential()
-{
-  int8_t y;                 // Offset into differential channel array to select polarity
-  uint8_t adc_command_high; // The LTC2498 command high byte
-  uint8_t adc_command_low;  // The LTC2498 command low byte
-  int16_t user_command;     // The user input command
-  int32_t adc_code = 0;    // The LTC2498 code
-  float adc_voltage;        // The LTC2498 voltage
-
-  while (1)
-  {
-    Serial.print(F("\n*************************\n\n")); // Display  differential menu
-    Serial.print(F("0-0P-1N     8-1P-0N\n"));
-    Serial.print(F("1-2P-3N     9-3P-2N\n"));
-    Serial.print(F("2-4P-5N     10-5P-4N\n"));
-    Serial.print(F("3-6P-7N     11-7P-6N\n"));
-    Serial.print(F("4-8P-9N     12-9P-8N\n"));
-    Serial.print(F("5-10P-11N   13-11P-10N\n"));
-    Serial.print(F("6-12P_13N   14-13P-12N\n"));
-    Serial.print(F("7-14P-15N   15-15P-14N\n"));
-    Serial.print(F("16-ALL Even_P-Odd_N\n"));
-    Serial.print(F("17-ALL Odd_P-Even_N\n"));
-    Serial.print(F("m-Main Menu\n"));
-
-    user_command = read_int();                              // Read the single command
-    if (user_command == 'm')
-      break;
-    Serial.println(user_command);
-
-    if ((user_command == 16) || (user_command == 17))
-    {
-      if (user_command == 16)
-      {
-        Serial.print(F("ALL Even_P-Odd_N\n"));              // Cycles through options 0-7
-        y = 0;
-      }
-      if (user_command == 17)
-      {
-        Serial.print(F("ALL Odd_P-Even_N\n"));              // Cycles through options 8-15
-        y = 8;
-      }
-
-      adc_command_high = BUILD_COMMAND_DIFF[y];             // Build the channel 0 and 1 for differential mode
-      adc_command_low = rejection_mode |  two_x_mode;
-
-      if (LTC2498_EOC_timeout(LTC2498_CS, eoc_timeout))
-        return 1;
-      LTC2498_read(LTC2498_CS, adc_command_high, adc_command_low, &adc_code);   // Throws out reading
-      for (int8_t x = 0; x < 8; x++)                        // Read all channels in differential mode. All even channels are positive and odd channels are negative
-      {
-
-
-
-
-        adc_command_high = BUILD_COMMAND_DIFF[((x + 1) % 8) + y];
-
-        if (LTC2498_EOC_timeout(LTC2498_CS, eoc_timeout))
-          return 1;
-        LTC2498_read(LTC2498_CS, adc_command_high, adc_command_low, &adc_code);
-
-        Serial.print(F("Received Code: 0x"));
-        Serial.println((adc_command_high<<8) | adc_command_low, HEX);
-        adc_voltage = LTC2498_code_to_voltage(adc_code, LTC2498_vref);
-        Serial.print(F("\n  ****"));
-        print_user_command(x + y);
-        Serial.print(F(": "));
-        Serial.print(adc_voltage, 4);
-        Serial.print(F("V\n"));
-
-      }
-    }
-    else
-    {
-      // Reads and displays a selected channel
-      adc_command_high = BUILD_COMMAND_DIFF[user_command];
-      adc_command_low = rejection_mode | two_x_mode;
-      Serial.print(F("ADC Command: 0x"));
-      Serial.println((adc_command_high<<8) | adc_command_low, HEX);
-
-      if (LTC2498_EOC_timeout(LTC2498_CS, eoc_timeout))
-        return 1;
-      LTC2498_read(LTC2498_CS, adc_command_high, adc_command_low, &adc_code);     // Throws out last reading
-
-
-
-      if (LTC2498_EOC_timeout(LTC2498_CS, eoc_timeout))
-        return 1;
-      LTC2498_read(LTC2498_CS, adc_command_high, adc_command_low, &adc_code);     // Now we're ready to read the desired data
-
-      Serial.print(F("Received Code: 0x"));
-      Serial.println(adc_code, HEX);
-      adc_voltage = LTC2498_code_to_voltage(adc_code, LTC2498_vref);
-      Serial.print(F("\n  ****"));
-      print_user_command(user_command);
-      Serial.print(adc_voltage, 4);
-      Serial.print(F("V\n"));
-
-    }
-  }
-  return 0;
-}
-
-//! Read Temperature
-//! @return Returns 0=successful, 1=unsuccessful (exceeded timeout)
-uint8_t menu_3_read_temperature()
-{
-  uint8_t adc_command_high; // The LTC2498 command high byte
-  uint8_t adc_command_low;  // The LTC2498 command low byte
-
-  int32_t adc_code = 0;            // The LTC2498 code
-  float adc_voltage;                // The LTC2498 voltage
-
-  //Command byte for temperature read
-  adc_command_high = BUILD_COMMAND_DIFF[0]; // Any channel can be selected
-  adc_command_low = LTC2498_INTERNAL_TEMP | rejection_mode;
-
-  if (LTC2498_EOC_timeout(LTC2498_CS, eoc_timeout))
-    return 1;
-  LTC2498_read(LTC2498_CS,adc_command_high, adc_command_low, &adc_code);     // Throws out last reading
-  if (LTC2498_EOC_timeout(LTC2498_CS, eoc_timeout))
-    return 1;
-  LTC2498_read(LTC2498_CS,adc_command_high, adc_command_low, &adc_code);     // Now we're ready to read the desired data
-
-  Serial.print(F("Received Code: 0x"));
-  Serial.println(adc_code, HEX);
-  adc_voltage = LTC2498_code_to_voltage(adc_code, LTC2498_vref);
-  Serial.print(F("\n  ****"));
-  Serial.print(adc_voltage, 4);
-  Serial.print(F("V\n"));
-  Serial.print(F("This equals to: "));
-  float temperature = (adc_voltage/93.5e-6);
-  Serial.print(temperature, DEC);
-  Serial.print(F(" K\n"));
-  return 0;
-}
-
-//! Set 1X or 2X mode
-void menu_4_set_1X2X()
-{
-  int16_t user_command; // The user input command
-
-  // 2X Mode
-  Serial.print(F("2X Mode Settings\n\n"));
-  Serial.print(F("0-Disable\n"));
-  Serial.print(F("1-Enable\n"));
-  Serial.print(F("Enter a Command: "));
-  user_command = read_int();
-  Serial.println(user_command);
-
-  if (user_command == 0)
-  {
-    two_x_mode = LTC2498_SPEED_1X;
-    Serial.print(F("2X Mode Disabled\n"));
-  }
-  else
-  {
-    two_x_mode = LTC2498_SPEED_2X;
-    Serial.print(F("2X Mode Enabled\n"));
-  }
-}

--- a/LTSketchbook/Example Designs/LTC2492_Panel_Meter/LTC2492_Panel_Meter.ino
+++ b/LTSketchbook/Example Designs/LTC2492_Panel_Meter/LTC2492_Panel_Meter.ino
@@ -21,7 +21,7 @@ LCD pin mapping is designed to be "minimally obtrusive", not interfering
 with an Uno's SPI, I2C or UART. Since we're using an external,
 high-performance ADC, the "analog" pins can be re-used as digital outputs.
 
-LiquidCrystal lcd(2, 3, 4, A0, A1, A2, A3); // RS, RW, EN, D4:D7. 
+LiquidCrystal lcd(2, 3, 4, A0, A1, A2, A3); // RS, RW, EN, D4:D7.
 
 For reference, the standard character LCD pinout is as follows:
 1 GROUND
@@ -40,7 +40,7 @@ For reference, the standard character LCD pinout is as follows:
 14 D7
 15 - Pins 15, 16 are often used for backlight.
 16 - Check datasheet for voltage / polarity.
- 
+
 
 
   Setup:
@@ -99,16 +99,16 @@ are permitted provided that the following conditions are met:
       patent holders to use this software.
     - Use of the software either in source or binary form, must be run
       on or directly connected to an Analog Devices Inc. component.
-   
+
 THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
 INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
 PARTICULAR PURPOSE ARE DISCLAIMED.
 
 IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
 EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
-RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
 BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF 
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
@@ -156,8 +156,8 @@ const uint8_t BUILD_COMMAND_DIFF[16] = {LTC2498_P0_N1, LTC2498_P2_N3, LTC2498_P4
 //! Lookup table to build 1X / 2X bits
 const uint8_t BUILD_1X_2X_COMMAND[2] = {LTC2498_SPEED_1X, LTC2498_SPEED_2X};   //!< Build the command for 1x or 2x mode
 
-  LiquidCrystal lcd(2, 3, 4, A0, A1, A2, A3); // RS, RW, EN, D4:D7. This pinout does not
-                                          // interfere with any Linduino functionality.
+LiquidCrystal lcd(2, 3, 4, A0, A1, A2, A3); // RS, RW, EN, D4:D7. This pinout does not
+// interfere with any Linduino functionality.
 
 //! Initialize Linduino
 void setup()
@@ -183,13 +183,13 @@ void setup()
   demo_board_connected = discover_demo_board(demo_name);
   // if (demo_board_connected)
   // {
-    // print_prompt();
+  // print_prompt();
   // }
   // else
   // {
-    // Serial.println(F("EEPROM not detected, will attempt to proceed"));
-    // demo_board_connected = 1;
-    // print_prompt();
+  // Serial.println(F("EEPROM not detected, will attempt to proceed"));
+  // demo_board_connected = 1;
+  // print_prompt();
   // }
   quikeval_SPI_connect();       //Initialize for SPI
 }
@@ -244,7 +244,7 @@ void loop()
   lcd.setCursor(0, 1);
   lcd.print("Ta=");
   lcd.print(temperature, 1);
-  
+
 // Program channel 0, read channel 2
   adc_command_high = BUILD_COMMAND_SINGLE_ENDED[0]; // Any channel can be selected
   adc_command_low = rejection_mode | two_x_mode;
@@ -257,8 +257,8 @@ void loop()
   lcd.setCursor(8, 1);
   lcd.print("Tj=");
   lcd.print(tj, 1);
-  
-  
+
+
 
 }
 

--- a/LTSketchbook/Part Number/ADI-Parts/EVAL-AD5686R/EVAL-AD5686R.ino
+++ b/LTSketchbook/Part Number/ADI-Parts/EVAL-AD5686R/EVAL-AD5686R.ino
@@ -53,25 +53,14 @@ extern "C" {
 /******************************************************************************/
 
 // Converts our DAC code into letters of which DAC is selected
-const String dac_selection[16] =
+const String dac_selection[4] =
 {
-  "None",
   "A",
   "B",
-  "A,B",
   "C",
-  "A,C",
-  "B,C",
-  "A,B,C",
-  "D",
-  "A,D",
-  "B,D",
-  "A,B,D",
-  "C,D",
-  "A,C,D",
-  "B,C,D",
-  "All"
+  "D"
 };
+
 
 i2c_init_param i2c_params =
 {
@@ -103,9 +92,9 @@ ad5686_dev *device;
 
 gpio_desc gpio_gain =
 {
-  GENERIC_GPIO,
-  0,
-  2,
+  GENERIC_GPIO,   // type
+  0,              // ID
+  2,              // Number
 };
 
 int32_t connected = -1;
@@ -156,8 +145,9 @@ void loop()
   //   1010 = B & D
   //   1101 = A, C & D
   //   1111 = All
-  static int16_t selected_dac = 1;
+  static uint8_t selected_dac = 0;
   static float ref_voltage = 2.5;
+
 
   // Switch menu based on user's input
   print_prompt(selected_dac, ref_voltage);
@@ -183,7 +173,7 @@ void loop()
       break;
 
     case 5:
-      menu_5_power_down_mode(selected_dac);
+      menu_5_set_DAC_power_mode(selected_dac);
       break;
 
     case 6:
@@ -220,6 +210,10 @@ void loop()
   }
 }
 
+
+
+
+
 //! Prints the title block
 void print_title()
 {
@@ -234,7 +228,7 @@ void print_title()
 }
 
 // Prints the "main menu" prompt to the console
-void print_prompt(int16_t selected_dac, float ref_voltage) //!< this parameter is passed so that it can be printed at the bottom of the menu.
+void print_prompt(uint8_t selected_dac, float ref_voltage) //!< this parameter is passed so that it can be printed at the bottom of the menu.
 {
   Serial.println(F("\nCommand Summary:"));
 
@@ -253,10 +247,7 @@ void print_prompt(int16_t selected_dac, float ref_voltage) //!< this parameter i
   Serial.println();
 
   Serial.print(F("  Selected DAC: "));
-  if (selected_dac < 2) Serial.print(0); // Print leading zeroes
-  if (selected_dac < 4) Serial.print(0);
-  if (selected_dac < 8) Serial.print(0);
-  Serial.print(selected_dac, BIN);
+  Serial.print(selected_dac, DEC);
   Serial.print(F(" "));
   Serial.println(dac_selection[selected_dac]);
 
@@ -270,24 +261,24 @@ void print_prompt(int16_t selected_dac, float ref_voltage) //!< this parameter i
 
 // Menu for user to select a DAC
 // @param selected_dac - Reference of DAC identifier
-uint8_t menu_1_select_dac(int16_t *selected_dac)
+uint8_t menu_1_select_dac(uint8_t *selected_dac)
 {
-  Serial.println(F("  DAC selections are represented in binary with"));
-  Serial.println(F("  bits corresponding to: DCBA"));
-  Serial.println(F("  (See datasheet for details and explanation)"));
-  Serial.println(F("  For example:"));
-  Serial.println(F("    B0001 - DAC A"));
-  Serial.println(F("    B0010 - DAC B"));
-  Serial.println(F("    B0100 - DAC C"));
-  Serial.println(F("    B1000 - DAC D"));
-  Serial.println(F("    B0101 - DAC A&C"));
-  Serial.println(F("    B1111 - ALL"));
-  Serial.print(F("  Enter any combination of DAC(s): "));
+  // Serial.println(F("  DAC selections are represented in binary with"));
+  // Serial.println(F("  bits corresponding to: DCBA"));
+  // Serial.println(F("  (See datasheet for details and explanation)"));
+  // Serial.println(F("  For example:"));
+  // Serial.println(F("    B0001 - DAC A"));
+  // Serial.println(F("    B0010 - DAC B"));
+  // Serial.println(F("    B0100 - DAC C"));
+  // Serial.println(F("    B1000 - DAC D"));
+  // Serial.println(F("    B0101 - DAC A&C"));
+  // Serial.println(F("    B1111 - ALL"));
+  Serial.print(F("  Enter DAC to select (0 - 3, corresponding to DAC A - D)"));
 
-  *selected_dac = read_int();
+  *selected_dac = (uint8_t)read_int();
 
-  if (*selected_dac > 15)
-    *selected_dac = 15; // If user enters and invalid option, default to ALL.
+  if (*selected_dac > 3)
+    *selected_dac = 3; // If user enters and invalid option, default to 3.
   if (*selected_dac < 0)
     *selected_dac = 0;
 
@@ -300,17 +291,17 @@ uint8_t menu_1_select_dac(int16_t *selected_dac)
 
 //! Menu 2: Write to input register only.  Does not update the output voltage.
 //! @return Returns the state of the acknowledge bit after the I2C address write. 0=acknowledge, 1=no acknowledge.
-uint8_t menu_2_write_to_input_register(int16_t selected_dac, float vref) //!< DAC to be updated. 0=A, 1=B, 2=All
+uint8_t menu_2_write_to_input_register(uint8_t selected_dac, float vref) //!< DAC to be updated. 0=A, 1=B, 2=All
 {
   unsigned short vdata = get_voltage_code(vref);
 
   ad5686_write_register(device, selected_dac, vdata);
 
-  return SUCCESS;
+  return SUCCESS;// Always returns success, consider adding a fail code later.
 }
 
 // Updates DAC outputs from its input registers
-uint8_t menu_3_update_dac(int16_t selected_dac)
+uint8_t menu_3_update_dac(uint8_t selected_dac)
 {
   //AD568X_WriteFunction(AD568X_CMD_UPDATE_DAC_N, selected_dac, 0);
   ad5686_update_register(device, selected_dac);
@@ -322,7 +313,7 @@ uint8_t menu_3_update_dac(int16_t selected_dac)
 // Menu for user to change a DAC's output voltage
 // @param selected_dac - Reference of DAC identifier to update,
 // corresponding to 0=A, 1=B, 2=C, 3=D, 4=A&B, 5=ALL
-uint8_t menu_4_write_and_update_dac(int16_t selected_dac, float vref) //!< DAC to be updated. 0=A, 1=B, 2=All
+uint8_t menu_4_write_and_update_dac(uint8_t selected_dac, float vref) //!< DAC to be updated. 0=A, 1=B, 2=All
 {
   unsigned short vdata = get_voltage_code(vref);
 
@@ -335,7 +326,7 @@ uint8_t menu_4_write_and_update_dac(int16_t selected_dac, float vref) //!< DAC t
 }
 
 
-uint8_t menu_5_power_down_mode(int16_t selected_dac)
+uint8_t menu_5_set_DAC_power_mode(uint8_t selected_dac)
 {
   // Cancel if no DAC selected
   if (selected_dac == 0)

--- a/LTSketchbook/Part Number/ADI-Parts/EVAL-AD5686R/EVAL-AD5686R.ino
+++ b/LTSketchbook/Part Number/ADI-Parts/EVAL-AD5686R/EVAL-AD5686R.ino
@@ -397,22 +397,22 @@ uint8_t menu_5_power_down_mode(int16_t selected_dac)
   if (dac1)
   {
     Serial.println(F("  Applying power mode to DAC A..."));
-    ad5686_power_mode(device, AD5686_CH_A, selected_mode);
+    ad5686_power_mode(device, AD5686_CH_0, selected_mode);
   }
   if (dac2)
   {
     Serial.println(F("  Applying power mode to DAC B..."));
-    ad5686_power_mode(device, AD5686_CH_B, selected_mode);
+    ad5686_power_mode(device, AD5686_CH_1, selected_mode);
   }
   if (dac3)
   {
     Serial.println(F("  Applying power mode to DAC C..."));
-    ad5686_power_mode(device, AD5686_CH_C, selected_mode);
+    ad5686_power_mode(device, AD5686_CH_2, selected_mode);
   }
   if (dac4)
   {
     Serial.println(F("  Applying power mode to DAC D..."));
-    ad5686_power_mode(device, AD5686_CH_D, selected_mode);
+    ad5686_power_mode(device, AD5686_CH_3, selected_mode);
   }
 
   Serial.println(F("  Done!"));
@@ -459,10 +459,10 @@ uint8_t menu_6_select_ref_voltage(float *vref)
 // Reads back all DAC registers
 uint8_t menu_7_read_back_registers()
 {
-  uint32_t reg1 = ad5686_read_back_register(device, AD5686_CH_A);
-  uint32_t reg2 = ad5686_read_back_register(device, AD5686_CH_B);
-  uint32_t reg3 = ad5686_read_back_register(device, AD5686_CH_C);
-  uint32_t reg4 = ad5686_read_back_register(device, AD5686_CH_D);
+  uint32_t reg1 = ad5686_read_back_register(device, AD5686_CH_0);
+  uint32_t reg2 = ad5686_read_back_register(device, AD5686_CH_1);
+  uint32_t reg3 = ad5686_read_back_register(device, AD5686_CH_2);
+  uint32_t reg4 = ad5686_read_back_register(device, AD5686_CH_3);
 
   Serial.println(F("\n  All DAC register values:"));
   Serial.print(F("    DAC A - "));
@@ -488,7 +488,7 @@ uint8_t menu_8_set_ldac_mask()
   if (mask > 15) mask = 15; // Clamp at 1111
   Serial.println(mask, BIN);
 
-  ad5686_ldac_mask(device, mask);
+  ad5686_ldac_mask(device, mask, 0x01);
 
   Serial.println(F("  Updated LDAC mask"));
 

--- a/LTSketchbook/Part Number/ADI-Parts/EVAL-AD5696R/EVAL-AD5696R.ino
+++ b/LTSketchbook/Part Number/ADI-Parts/EVAL-AD5696R/EVAL-AD5696R.ino
@@ -403,22 +403,22 @@ uint8_t menu_5_set_DAC_power_mode(int16_t selected_dac)
   if (dac1)
   {
     Serial.println(F("  Applying power mode to DAC A..."));
-    ad5686_power_mode(device, AD5686_CH_A, selected_mode);
+    ad5686_power_mode(device, AD5686_CH_0, selected_mode);
   }
   if (dac2)
   {
     Serial.println(F("  Applying power mode to DAC B..."));
-    ad5686_power_mode(device, AD5686_CH_B, selected_mode);
+    ad5686_power_mode(device, AD5686_CH_1, selected_mode);
   }
   if (dac3)
   {
     Serial.println(F("  Applying power mode to DAC C..."));
-    ad5686_power_mode(device, AD5686_CH_C, selected_mode);
+    ad5686_power_mode(device, AD5686_CH_2, selected_mode);
   }
   if (dac4)
   {
     Serial.println(F("  Applying power mode to DAC D..."));
-    ad5686_power_mode(device, AD5686_CH_D, selected_mode);
+    ad5686_power_mode(device, AD5686_CH_3, selected_mode);
   }
 
   Serial.println(F("  Done!"));
@@ -465,10 +465,10 @@ uint8_t menu_6_select_ref_voltage(float *vref)
 // Reads back all DAC registers
 uint8_t menu_7_read_back_dac_input_registers()
 {
-  uint32_t reg1 = ad5686_read_back_register(device, AD5686_CH_A);
-  uint32_t reg2 = ad5686_read_back_register(device, AD5686_CH_B);
-  uint32_t reg3 = ad5686_read_back_register(device, AD5686_CH_C);
-  uint32_t reg4 = ad5686_read_back_register(device, AD5686_CH_D);
+  uint32_t reg1 = ad5686_read_back_register(device, AD5686_CH_0);
+  uint32_t reg2 = ad5686_read_back_register(device, AD5686_CH_1);
+  uint32_t reg3 = ad5686_read_back_register(device, AD5686_CH_2);
+  uint32_t reg4 = ad5686_read_back_register(device, AD5686_CH_3);
 
   Serial.println(F("\n  All DAC-input register values:"));
   Serial.print(F("    DAC A - "));
@@ -490,7 +490,7 @@ uint8_t menu_old_read_back_dac_input_registers()
     //#define AD5686_CH_ALL            0xF
     //uint32_t read_data = ad5696_read_back_register(device, AD5686_CH_ALL);
     uint32_t reg1 = ad5686_read_back_register(device, AD5686_CH_A);
-    uint32_t reg2 = ad5686_read_back_register(device, AD5686_CH_B);
+    uint32_t reg2 = ad5686_read_back_register(device, AD5686_CH_1);
     uint32_t reg3 = ad5686_read_back_register(device, AD5686_CH_C);
     uint32_t reg4 = ad5686_read_back_register(device, AD5686_CH_D);
     //https://www.tutorialspoint.com/cprogramming/c_return_arrays_from_function.htm
@@ -525,7 +525,7 @@ uint8_t menu_8_set_ldac_mask()
   if (mask > 15) mask = 15; // Clamp at 1111
   Serial.println(mask, BIN);
 
-  ad5686_ldac_mask(device, mask);
+  ad5686_ldac_mask(device, mask, 0x01);
 
   Serial.println(F("  Updated LDAC mask"));
 

--- a/LTSketchbook/Part Number/ADI-Parts/EVAL-AD7124-8/EVAL-AD7124-8.ino
+++ b/LTSketchbook/Part Number/ADI-Parts/EVAL-AD7124-8/EVAL-AD7124-8.ino
@@ -52,64 +52,65 @@ extern "C" {
 /*********************** AD7124 initial configuration *************************/
 /******************************************************************************/
 
-struct ad7124_st_reg my_ad7124_regs[AD7124_REG_NO] = {
-    {0x00, 0x00,   1, 2}, /* AD7124_Status */
-    {0x01, 0x0000, 2, 1}, /* AD7124_ADC_Control */
-    {0x02, 0x0000, 3, 2}, /* AD7124_Data */
-    {0x03, 0x0000, 3, 1}, /* AD7124_IOCon1 */
-    {0x04, 0x0000, 2, 1}, /* AD7124_IOCon2 */
-    {0x05, 0x02,   1, 2}, /* AD7124_ID */
-    {0x06, 0x0000, 3, 2}, /* AD7124_Error */
-    {0x07, 0x0044, 3, 1}, /* AD7124_Error_En */
-    {0x08, 0x00,   1, 2}, /* AD7124_Mclk_Count */
-    {0x09, 0x8013, 2, 1}, /* AD7124_Channel_0 */
-    {0x0A, 0x0001, 2, 1}, /* AD7124_Channel_1 */
-    {0x0B, 0x0001, 2, 1}, /* AD7124_Channel_2 */
-    {0x0C, 0x0001, 2, 1}, /* AD7124_Channel_3 */
-    {0x0D, 0x0001, 2, 1}, /* AD7124_Channel_4 */
-    {0x0E, 0x0001, 2, 1}, /* AD7124_Channel_5 */
-    {0x0F, 0x0001, 2, 1}, /* AD7124_Channel_6 */
-    {0x10, 0x0001, 2, 1}, /* AD7124_Channel_7 */
-    {0x11, 0x0001, 2, 1}, /* AD7124_Channel_8 */
-    {0x12, 0x0001, 2, 1}, /* AD7124_Channel_9 */
-    {0x13, 0x0001, 2, 1}, /* AD7124_Channel_10 */
-    {0x14, 0x0001, 2, 1}, /* AD7124_Channel_11 */
-    {0x15, 0x0001, 2, 1}, /* AD7124_Channel_12 */
-    {0x16, 0x0001, 2, 1}, /* AD7124_Channel_13 */
-    {0x17, 0x0001, 2, 1}, /* AD7124_Channel_14 */
-    {0x18, 0x0001, 2, 1}, /* AD7124_Channel_15 */
-    {0x19, 0x0860, 2, 1}, /* AD7124_Config_0 */
-    {0x1A, 0x0860, 2, 1}, /* AD7124_Config_1 */
-    {0x1B, 0x0860, 2, 1}, /* AD7124_Config_2 */
-    {0x1C, 0x0860, 2, 1}, /* AD7124_Config_3 */
-    {0x1D, 0x0860, 2, 1}, /* AD7124_Config_4 */
-    {0x1E, 0x0860, 2, 1}, /* AD7124_Config_5 */
-    {0x1F, 0x0860, 2, 1}, /* AD7124_Config_6 */
-    {0x20, 0x0860, 2, 1}, /* AD7124_Config_7 */
-    {0x21, 0x060180, 3, 1}, /* AD7124_Filter_0 */
-    {0x22, 0x060180, 3, 1}, /* AD7124_Filter_1 */
-    {0x23, 0x060180, 3, 1}, /* AD7124_Filter_2 */
-    {0x24, 0x060180, 3, 1}, /* AD7124_Filter_3 */
-    {0x25, 0x060180, 3, 1}, /* AD7124_Filter_4 */
-    {0x26, 0x060180, 3, 1}, /* AD7124_Filter_5 */
-    {0x27, 0x060180, 3, 1}, /* AD7124_Filter_6 */
-    {0x28, 0x060180, 3, 1}, /* AD7124_Filter_7 */
-    {0x29, 0x800000, 3, 1}, /* AD7124_Offset_0 */
-    {0x2A, 0x800000, 3, 1}, /* AD7124_Offset_1 */
-    {0x2B, 0x800000, 3, 1}, /* AD7124_Offset_2 */
-    {0x2C, 0x800000, 3, 1}, /* AD7124_Offset_3 */
-    {0x2D, 0x800000, 3, 1}, /* AD7124_Offset_4 */
-    {0x2E, 0x800000, 3, 1}, /* AD7124_Offset_5 */
-    {0x2F, 0x800000, 3, 1}, /* AD7124_Offset_6 */
-    {0x30, 0x800000, 3, 1}, /* AD7124_Offset_7 */
-    {0x31, 0x500000, 3, 1}, /* AD7124_Gain_0 */
-    {0x32, 0x500000, 3, 1}, /* AD7124_Gain_1 */
-    {0x33, 0x500000, 3, 1}, /* AD7124_Gain_2 */
-    {0x34, 0x500000, 3, 1}, /* AD7124_Gain_3 */
-    {0x35, 0x500000, 3, 1}, /* AD7124_Gain_4 */
-    {0x36, 0x500000, 3, 1}, /* AD7124_Gain_5 */
-    {0x37, 0x500000, 3, 1}, /* AD7124_Gain_6 */
-    {0x38, 0x500000, 3, 1}, /* AD7124_Gain_7 */
+struct ad7124_st_reg my_ad7124_regs[AD7124_REG_NO] =
+{
+  {0x00, 0x00,   1, 2}, /* AD7124_Status */
+  {0x01, 0x0000, 2, 1}, /* AD7124_ADC_Control */
+  {0x02, 0x0000, 3, 2}, /* AD7124_Data */
+  {0x03, 0x0000, 3, 1}, /* AD7124_IOCon1 */
+  {0x04, 0x0000, 2, 1}, /* AD7124_IOCon2 */
+  {0x05, 0x02,   1, 2}, /* AD7124_ID */
+  {0x06, 0x0000, 3, 2}, /* AD7124_Error */
+  {0x07, 0x0044, 3, 1}, /* AD7124_Error_En */
+  {0x08, 0x00,   1, 2}, /* AD7124_Mclk_Count */
+  {0x09, 0x8013, 2, 1}, /* AD7124_Channel_0 */
+  {0x0A, 0x0001, 2, 1}, /* AD7124_Channel_1 */
+  {0x0B, 0x0001, 2, 1}, /* AD7124_Channel_2 */
+  {0x0C, 0x0001, 2, 1}, /* AD7124_Channel_3 */
+  {0x0D, 0x0001, 2, 1}, /* AD7124_Channel_4 */
+  {0x0E, 0x0001, 2, 1}, /* AD7124_Channel_5 */
+  {0x0F, 0x0001, 2, 1}, /* AD7124_Channel_6 */
+  {0x10, 0x0001, 2, 1}, /* AD7124_Channel_7 */
+  {0x11, 0x0001, 2, 1}, /* AD7124_Channel_8 */
+  {0x12, 0x0001, 2, 1}, /* AD7124_Channel_9 */
+  {0x13, 0x0001, 2, 1}, /* AD7124_Channel_10 */
+  {0x14, 0x0001, 2, 1}, /* AD7124_Channel_11 */
+  {0x15, 0x0001, 2, 1}, /* AD7124_Channel_12 */
+  {0x16, 0x0001, 2, 1}, /* AD7124_Channel_13 */
+  {0x17, 0x0001, 2, 1}, /* AD7124_Channel_14 */
+  {0x18, 0x0001, 2, 1}, /* AD7124_Channel_15 */
+  {0x19, 0x0860, 2, 1}, /* AD7124_Config_0 */
+  {0x1A, 0x0860, 2, 1}, /* AD7124_Config_1 */
+  {0x1B, 0x0860, 2, 1}, /* AD7124_Config_2 */
+  {0x1C, 0x0860, 2, 1}, /* AD7124_Config_3 */
+  {0x1D, 0x0860, 2, 1}, /* AD7124_Config_4 */
+  {0x1E, 0x0860, 2, 1}, /* AD7124_Config_5 */
+  {0x1F, 0x0860, 2, 1}, /* AD7124_Config_6 */
+  {0x20, 0x0860, 2, 1}, /* AD7124_Config_7 */
+  {0x21, 0x060180, 3, 1}, /* AD7124_Filter_0 */
+  {0x22, 0x060180, 3, 1}, /* AD7124_Filter_1 */
+  {0x23, 0x060180, 3, 1}, /* AD7124_Filter_2 */
+  {0x24, 0x060180, 3, 1}, /* AD7124_Filter_3 */
+  {0x25, 0x060180, 3, 1}, /* AD7124_Filter_4 */
+  {0x26, 0x060180, 3, 1}, /* AD7124_Filter_5 */
+  {0x27, 0x060180, 3, 1}, /* AD7124_Filter_6 */
+  {0x28, 0x060180, 3, 1}, /* AD7124_Filter_7 */
+  {0x29, 0x800000, 3, 1}, /* AD7124_Offset_0 */
+  {0x2A, 0x800000, 3, 1}, /* AD7124_Offset_1 */
+  {0x2B, 0x800000, 3, 1}, /* AD7124_Offset_2 */
+  {0x2C, 0x800000, 3, 1}, /* AD7124_Offset_3 */
+  {0x2D, 0x800000, 3, 1}, /* AD7124_Offset_4 */
+  {0x2E, 0x800000, 3, 1}, /* AD7124_Offset_5 */
+  {0x2F, 0x800000, 3, 1}, /* AD7124_Offset_6 */
+  {0x30, 0x800000, 3, 1}, /* AD7124_Offset_7 */
+  {0x31, 0x500000, 3, 1}, /* AD7124_Gain_0 */
+  {0x32, 0x500000, 3, 1}, /* AD7124_Gain_1 */
+  {0x33, 0x500000, 3, 1}, /* AD7124_Gain_2 */
+  {0x34, 0x500000, 3, 1}, /* AD7124_Gain_3 */
+  {0x35, 0x500000, 3, 1}, /* AD7124_Gain_4 */
+  {0x36, 0x500000, 3, 1}, /* AD7124_Gain_5 */
+  {0x37, 0x500000, 3, 1}, /* AD7124_Gain_6 */
+  {0x38, 0x500000, 3, 1}, /* AD7124_Gain_7 */
 };
 
 
@@ -129,7 +130,7 @@ spi_init_param spi_params =
 };
 
 ad7124_init_param init_params =
- {
+{
   spi_params,     // SPI parameters
   my_ad7124_regs, // declared in ad7124_regs.c
   64000,     // spi_rdy_poll_cnt: # tries before timeout
@@ -150,16 +151,16 @@ void setup()
   char demo_name[] = "AD7124-8";
 
   int32_t x;
-  
+
   Serial.begin(115200);
 
   // Give the serial port a chance to initialize
   // Without this we get some garbage on the console
   delay(100);
 
-  if(false) // Set to true to dump initial values to screen
+  if (false) // Set to true to dump initial values to screen
   {
-   Serial.println(F("Print inital values..."));
+    Serial.println(F("Print inital values..."));
     for (regNr = AD7124_Status; (regNr < AD7124_REG_NO) && !(ret < 0); regNr++)
     {
       //ret = ad7124_read_register(ad7124_handler, &ad7124_regs[regNr]);
@@ -170,10 +171,10 @@ void setup()
       Serial.println(x);
     }
   }
-  
+
   Serial.println(F("Attempting to initialize..."));
   delay(50);
-  
+
   /* Initialize AD7124 device. */
   ret = ad7124_setup(&ad7124_handler, init_params);
   if (ret < 0)
@@ -187,8 +188,8 @@ void setup()
   {
     /* AD7124 initialization OK */
     Serial.println(F("AD7124-8 Initialized!! :)"));
-  } 
- 
+  }
+
   /* Read all registers */
   for (regNr = AD7124_Status; (regNr < AD7124_REG_NO) && !(ret < 0); regNr++)
   {
@@ -199,17 +200,17 @@ void setup()
     x = my_ad7124_regs[regNr].value;
     Serial.println(x);
   }
- 
+
   /* Read data from the ADC */
   ret = ad7124_wait_for_conv_ready(ad7124_handler, timeout);
   if (ret < 0)
   {
-  /* Something went wrong, check the value of ret! */
-  Serial.print("error waiting for conv ready: ");
-  Serial.println(ret);
+    /* Something went wrong, check the value of ret! */
+    Serial.print("error waiting for conv ready: ");
+    Serial.println(ret);
   }
-    ret = ad7124_read_data(ad7124_handler, &sample);
-    if (ret < 0)
+  ret = ad7124_read_data(ad7124_handler, &sample);
+  if (ret < 0)
   {
     /* Something went wrong, check the value of ret! */
     Serial.print("error reading ADC data: ");
@@ -224,12 +225,12 @@ void setup()
 
 void loop()
 {
-while(1)
+  while (1)
   {
     delay(1000);
     Serial.println("Looping...");
     ret = ad7124_read_data(ad7124_handler, &sample);
     Serial.print("ADC data: ");
     Serial.println(sample);
-  } 
+  }
 }

--- a/LTSketchbook/Utilities/DC2741_production_test/DC2741_production_test.ino
+++ b/LTSketchbook/Utilities/DC2741_production_test/DC2741_production_test.ino
@@ -1,0 +1,242 @@
+/*
+DC2741 production program test
+
+This program will run through a battery of tests to verify DC2741 connectivity.
+Test Jig consists of an SDP breakout board (Part Number ADZS-BRKOUT-EX3)
+
+With the following direct connections:
+43 - 45, 10k pulldown (IO2 - AD0)
+44 - 47, 10k pulldown (IO4 - AD2)
+76 - 78, 10k pulldown (IO3~ - AD1)
+74 - 77, 10k pulldown (AD3 - IO5~)
+
+And the following connections with BAT85 Schottky diodes:
+82 - 83 (SCK  ->|- MOSI)
+84 - 83 (MOSI ->|- MISO)
+84 - 83 (CS   ->|- MISO)
+
+**********************************************
+IMPORTANT Note: When testing Assembly Type B,
+R44 on the Linduino must be removed. Keep this
+Linduino set aside, or re-install R44.
+**********************************************
+
+Copyright 2018(c) Analog Devices, Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ - Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ - Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+ - Neither the name of Analog Devices, Inc. nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+ - The use of this software may or may not infringe the patent rights
+   of one or more patent holders.  This license does not release you
+   from the requirement that you obtain separate licenses from these
+   patent holders to use this software.
+ - Use of the software either in source or binary form, must be run
+   on or directly connected to an Analog Devices Inc. component.
+
+THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// set I2C frequency in kHz
+#define SW_I2C_FREQUENCY  400
+
+#include <Arduino.h>
+#include <stdint.h>
+#include "LT_I2C.h"
+#include "LT_SPI.h"
+#include "QuikEval_EEPROM.h"
+#include "UserInterface.h"
+#include "Linduino.h"
+
+// String descriptions for each test:
+char* descr[] = {"SCK - MISO", "MOSI - MISO", "CS - MISO", "IO2 - AD0", "IO3~ - AD1", "IO4 - AD2", "IO5 - AD3"};
+// descr[0] = "SCK - MISO";
+// descr[1] = "MOSI - MISO";
+// descr[2] = "CS - MISO";
+// descr[3] = "IO2 - AD0";
+// descr[4] = "IO3~ - AD1";
+// descr[5] = "IO4 - AD2";
+// descr[6] = "IO5 - AD3";
+
+const uint8_t stimulus[7] = {13, 11, QUIKEVAL_CS, 2, 3, 4, 5};
+const uint8_t readback[7] = {12, 12, 12         , 0, 1, 2, 3};
+
+void print_title()
+// Print the title block
+{
+  Serial.println("");
+  Serial.println("*****************************************************************");
+  Serial.println("* DC2741 production program test                                *");
+  Serial.println("*                                                               *");
+  Serial.println("* Set the baud rate to 115200 select the newline terminator.    *");
+  Serial.println("*                                                               *");
+  Serial.println("*****************************************************************");
+}
+
+void setup()
+// Setup the hardware
+{
+  quikeval_I2C_init();                // Enable the Software I2C
+  quikeval_I2C_connect();         // Connects to main I2C port
+  pinMode(2, INPUT); //GPIOs
+  pinMode(3, INPUT);
+  pinMode(4, INPUT);
+  pinMode(5, INPUT);
+  pinMode(12, INPUT);
+  pinMode(13, OUTPUT); //SCK
+  pinMode(11, OUTPUT); //MOSI
+  pinMode(QUIKEVAL_CS, OUTPUT); //
+  output_high(13);
+  output_high(11);
+  output_high(QUIKEVAL_CS);
+
+
+  Serial.begin(115200);        // Initialize the serial port to the PC
+  print_title();
+}
+
+void loop()
+{
+  unsigned char ack;
+  unsigned char address;
+  unsigned char ackaddr;
+  unsigned char ack_count;
+  unsigned char fail_count;
+  unsigned char i;
+  uint16_t voltage;
+  Serial.println("\nSend any character to start the test. (Press enter in Arduino Serial Monitor.)");
+  read_int();
+  Serial.println("Testing...");
+  delay(500); // Delay necessary to indicate to user that something's going on...
+  ack_count = 0;
+  fail_count = 0;
+  ackaddr = 0;
+  quikeval_I2C_connect();
+  for (address = 0; address < 128; address++)
+  {
+    i2c_start();
+    ack = i2c_write(address << 1);
+    i2c_stop();
+    if (!ack)
+    {
+      ack_count++;
+      ackaddr = address;
+      Serial.print("Acknowledge received from address : 0x");
+      Serial.print(address, HEX);
+      Serial.print(" (7 bit) 0x:");
+      Serial.print(address<<1, HEX);
+      Serial.println(" (8-bit)");
+    }
+  }
+  if (ackaddr != 0x50)
+  {
+    Serial.println("Didn't find an EEPROM at address 0x50, FAIL");
+    ++fail_count;
+  }
+  quikeval_SPI_connect();
+
+// First, test SPI port (digital levels only)
+  for(i=0; i<=2; i++)
+  {
+    output_low(stimulus[i]); //! 1) Pull Low
+    delay(1);
+    if(digitalRead(readback[i]) == HIGH)
+    {
+      Serial.print("Fail test low: ");
+      ++fail_count;
+    }
+    else
+    {
+      Serial.print("Pass test low: ");
+    }
+
+    Serial.println(descr[i]);
+    output_high(stimulus[i]); //! 1) Pull High
+    delay(1);
+    if(digitalRead(readback[i]) == LOW)
+    {
+      Serial.print("Fail test high: ");
+      ++fail_count;
+    }
+    else
+    {
+      Serial.print("Pass test high: ");
+      
+    }
+    Serial.println(descr[i]);
+    
+
+  }
+  
+// Next, test GPIO / Analog connectivity
+  for(i=3; i<=6; i++)
+  {
+    pinMode(stimulus[i], INPUT);
+    delay(1);
+    voltage = analogRead(readback[i]);
+    Serial.print("Voltage: ");
+    Serial.println(voltage);
+    if(voltage < 512)
+    {
+      Serial.print("Fail test high: ");
+      ++fail_count;
+    }
+    else
+    {
+      Serial.print("Pass test high: ");
+      
+    }
+    Serial.println(descr[i]);
+    
+    pinMode(stimulus[i], OUTPUT);
+    output_low(stimulus[i]); //! 1) Pull Low
+    delay(1);
+    voltage = analogRead(readback[i]);
+    Serial.print("Voltage: ");
+    Serial.println(voltage);
+    if(voltage > 512)
+    {
+      Serial.print("Fail test low: ");
+      ++fail_count;
+    }
+    else
+    {
+      Serial.print("Pass test low: ");
+    }
+    Serial.println(descr[i]);
+  }
+  
+  if(fail_count == 0)
+  {
+    Serial.println("All tests PASS!!");
+    Serial.println("All tests PASS!!");
+    Serial.println("All tests PASS!!");
+  }
+  else
+  {
+    Serial.println("Board FAILS!!");
+    Serial.println("Board FAILS!!");
+    Serial.print("Error Count: ");
+    Serial.println(fail_count);
+  }
+}
+
+

--- a/LTSketchbook/libraries/platform_drivers/platform_drivers.cpp
+++ b/LTSketchbook/libraries/platform_drivers/platform_drivers.cpp
@@ -58,14 +58,14 @@
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t i2c_init(i2c_desc **desc,
-		 i2c_init_param param)
+		 const struct i2c_init_param *param)
 {
 	// Create the i2c description object for the device
 	i2c_desc * new_desc = (i2c_desc*) malloc(sizeof(*new_desc));
-	new_desc->type = param.type;
-	new_desc->id = param.id;
-	new_desc->max_speed_hz = param.max_speed_hz;
-	new_desc->slave_address = param.slave_address;
+	new_desc->type = param->type;
+	new_desc->id = param->id;
+	new_desc->max_speed_hz = param->max_speed_hz;
+	new_desc->slave_address = param->slave_address;
 	
 	*desc = new_desc;
 	
@@ -145,13 +145,13 @@ const uint8_t arduino_spi_modes[4] = {
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t spi_init(spi_desc **desc,
-		 spi_init_param param)
+		 const struct spi_init_param *param)
 {
 	// Create the spi description object for the device
 	spi_desc * new_desc = (spi_desc*) malloc(sizeof(*new_desc));
-	new_desc->chip_select = param.chip_select;
-	new_desc->mode = param.mode;
-	new_desc->max_speed_hz = param.max_speed_hz;
+	new_desc->chip_select = param->chip_select;
+	new_desc->mode = param->mode;
+	new_desc->max_speed_hz = param->max_speed_hz;
 	
 	*desc = new_desc;
 	

--- a/LTSketchbook/libraries/platform_drivers/platform_drivers.h
+++ b/LTSketchbook/libraries/platform_drivers/platform_drivers.h
@@ -70,25 +70,25 @@ extern "C" {
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
-typedef enum {
+typedef enum i2c_type{
 	GENERIC_I2C
 } i2c_type;
 
-typedef struct {
+typedef struct i2c_init_param{
 	i2c_type	type;
 	uint32_t	id;
 	uint32_t	max_speed_hz;
 	uint8_t		slave_address;
 } i2c_init_param;
 
-typedef struct {
+typedef struct i2c_desc{
 	i2c_type	type;
 	uint32_t	id;
 	uint32_t	max_speed_hz;
 	uint8_t		slave_address;
 } i2c_desc;
 
-typedef enum {
+typedef enum spi_type{
 	GENERIC_SPI
 } spi_type;
 
@@ -101,7 +101,7 @@ typedef enum {
 
 
 
-typedef struct {
+typedef struct spi_init_param{
 	spi_type	type;
 	uint32_t	id;
 	uint32_t	max_speed_hz;
@@ -133,7 +133,7 @@ typedef struct {
 
 /* Initialize the I2C communication peripheral. */
 int32_t i2c_init(i2c_desc **desc,
-		 i2c_init_param param);
+		 const struct i2c_init_param *param);
 
 /* Free the resources allocated by i2c_init(). */
 int32_t i2c_remove(i2c_desc *desc);
@@ -152,7 +152,7 @@ int32_t i2c_read(i2c_desc *desc,
 
 /* Initialize the SPI communication peripheral. */
 int32_t spi_init(spi_desc **desc,
-		 spi_init_param param);
+		 const struct spi_init_param *param);
 
 /* Free the resources allocated by spi_init() */
 int32_t spi_remove(spi_desc *desc);


### PR DESCRIPTION
Update AD5686, 5696 sketches and platform_driver for compatibility with latest no-OS drivers.
Minor updates to CN0416 test sketches.
Updates to panel meter example - add die temperature display.
Add DC2741 production test (x-duino to QuikEval, SDP, PMOD adapter).