### PR TITLE
Updated code for I2C communication via GPOI pins and cosmetic changes…

### DIFF
--- a/LTSketchbook/Part Number/6000/6810/DC2515/DC2515.ino
+++ b/LTSketchbook/Part Number/6000/6810/DC2515/DC2515.ino
@@ -57,61 +57,66 @@
     @ingroup LTC6810-1
 */
 
-/*
-NOTES
- Setup:
-   Set the terminal baud rate to 115200 and select the newline terminator.
-   Ensure all jumpers on the demo board are installed in their default positions from the factory.
-   Refer to Demo Manual.
+/************************************* Read me *******************************************
+In this sketch book:
+  -All Global Variables are in Upper casing
+  -All Local Variables are in lower casing
+  -The Function wakeup_sleep(TOTAL_IC) : is used to wake the LTC681x from sleep state.
+   It is defined in LTC681x.cpp
+  -The Function wakeup_idle(TOTAL_IC) : is used to wake the ICs connected in daisy chain 
+   via the LTC6820 by initiating a dummy SPI communication. It is defined in LTC681x.cpp 
+*******************************************************************************************/
 
-USER INPUT DATA FORMAT:
- decimal : 1024
- hex     : 0x400
- octal   : 02000  (leading 0)
- binary  : B10000000000
- float   : 1024.0
- */
-
+/************************* Includes ***************************/
 #include <Arduino.h>
 #include <stdint.h>
+#include <SPI.h>
 #include "Linduino.h"
 #include "LT_SPI.h"
 #include "UserInterface.h"
 #include "LTC681x.h"
 #include "LTC6810.h"
-#include <SPI.h>
 
+/************************* Defines *****************************/
 #define ENABLED 1
 #define DISABLED 0
-
 #define DATALOG_ENABLED 1
 #define DATALOG_DISABLED 0
 
-char get_char();
-void print_menu();
+/**************** Local Function Declaration *******************/
+void measurement_loop(uint8_t datalog_en);
+void print_menu(void);
+void print_wrconfig(void);
+void print_rxconfig(void);
 void print_cells(uint8_t datalog_en);
-void print_open();
-void print_config();
-void print_rxconfig();
 void print_aux(uint8_t datalog_en);
-void print_aux1();
-void print_stat();
-void print_statsoc();
-void print_pwm();
-void print_rxpwm();
-void print_comm();
-void print_rxcomm();
-void print_sid();
-void print_pec();
-void serial_print_hex(uint8_t data);
+void print_stat(void);
+void print_sumofcells(void);
+void print_svolt(uint8_t datalog_en);
+void check_mux_fail(void);
+void print_selftest_errors(uint8_t adc_reg ,int8_t error);
+void print_digital_redundancy_errors(uint8_t adc_reg ,int8_t error);
+void print_open_wires(void);
+void print_pec_error_count(void);
+int8_t select_s_pin(void);
+void print_wrpwm(void);
+void print_rxpwm(void);
+void print_wrcomm(void);
+void print_rxcomm(void);
+void print_sid(void);
+void reverse_isospi_direction(void);
+void check_mute_bit(void);
+void print_conv_time(uint32_t conv_time);
 void check_error(int error);
+void serial_print_text(char data[]);
+void serial_print_hex(uint8_t data);
+char read_hex(void);
+char get_char(void);
 
-/**********************************************************
+/********************************************************************
   Setup Variables
-  The following variables can be modified to
-  configure the software.
-
-***********************************************************/
+  The following variables can be modified to configure the software.
+*********************************************************************/
 const uint8_t TOTAL_IC = 2;//!< Number of ICs in the daisy chain
 
 //ADC Command Configurations. See LTC681x.h for options.
@@ -121,20 +126,23 @@ const uint8_t ADC_DCP = DCP_DISABLED; //!< Discharge Permitted
 const uint8_t CELL_CH_TO_CONVERT = CELL_CH_ALL; //!< Channel Selection for ADC conversion
 const uint8_t AUX_CH_TO_CONVERT = AUX_CH_ALL; //!< Channel Selection for ADC conversion
 const uint8_t STAT_CH_TO_CONVERT = STAT_CH_ALL; //!< Channel Selection for ADC conversion
-
-const uint16_t MEASUREMENT_LOOP_TIME = 500; //!< Loop Time in milliseconds(ms)
+const uint8_t SEL_ALL_REG = REG_ALL; //!< Register Selection 
+const uint8_t SEL_REG_A = REG_1; //!< Register Selection 
+const uint8_t SEL_REG_B = REG_2; //!< Register Selection 
 
 //Under Voltage and Over Voltage Thresholds
 const uint16_t OV_THRESHOLD = 41000; //!< Over voltage threshold ADC Code. LSB = 0.0001 ---(4.1V)
-const uint16_t UV_THRESHOLD = 10000; //!< Under voltage threshold ADC Code. LSB = 0.0001 ---(1V)
+const uint16_t UV_THRESHOLD = 30000; //!< Under voltage threshold ADC Code. LSB = 0.0001 ---(1V)
+
+const uint16_t MEASUREMENT_LOOP_TIME = 500; //!< Loop Time in milliseconds(ms)
 
 //Loop Measurement Setup. These Variables are ENABLED or DISABLED Remember ALL CAPS
-const uint8_t WRITE_CONFIG = DISABLED; //!< This is ENABLED or DISABLED
-const uint8_t READ_CONFIG = DISABLED; //!< This is ENABLED or DISABLED
-const uint8_t MEASURE_CELL = ENABLED; //!< This is ENABLED or DISABLED
-const uint8_t MEASURE_AUX = DISABLED; //!< This is ENABLED or DISABLED
-const uint8_t MEASURE_STAT = DISABLED; //!< This is ENABLED or DISABLED
-const uint8_t PRINT_PEC = DISABLED; //!< This is ENABLED or DISABLED
+const uint8_t WRITE_CONFIG = DISABLED; //!< This is to ENABLED or DISABLED writing into to configuration registers in a continuous loop
+const uint8_t READ_CONFIG = DISABLED; //!< This is to ENABLED or DISABLED reading the configuration registers in a continuous loop
+const uint8_t MEASURE_CELL = ENABLED; //!< This is to ENABLED or DISABLED measuring the cell voltages in a continuous loop
+const uint8_t MEASURE_AUX = DISABLED; //!< This is to ENABLED or DISABLED reading the auxiliary registers in a continuous loop
+const uint8_t MEASURE_STAT = DISABLED; //!< This is to ENABLED or DISABLED reading the status registers in a continuous loop
+const uint8_t PRINT_PEC = DISABLED; //!< This is to ENABLED or DISABLED printing the PEC Error Count in a continuous loop
 /************************************
   END SETUP
 *************************************/
@@ -145,27 +153,26 @@ const uint8_t PRINT_PEC = DISABLED; //!< This is ENABLED or DISABLED
  register reads and the array lengths must be based
  on the number of ICs on the stack
  ******************************************************/
+cell_asic BMS_IC[TOTAL_IC];//!< Global Battery Variable
 
-cell_asic bms_ic[TOTAL_IC];//!< Global Battery Variable
-
-bool isospi_dir=bms_ic[0].isospi_reverse;
+bool ISOSPI_DIR=BMS_IC[0].isospi_reverse;
 
 /*************************************************************************
  Set configuration register. Refer to the data sheet
 **************************************************************************/
 bool ADCOPT = false; //!< ADC Mode option bit
 bool REFON = true; //!< Reference Powered Up Bit
-bool gpioBits[4] = {false,false,false,false}; //!< GPIO Pin Control // Gpio 1,2,3,4
+bool GPIOBITS[4] = {false,true,true,true}; //!< GPIO Pin Control // Gpio 1,2,3,4
 uint16_t UV=UV_THRESHOLD; //!< Under voltage Comparison Voltage
 uint16_t OV=OV_THRESHOLD; //!< Over voltage Comparison Voltage
-bool dccBits[6] = {false,false,false,false,false,false}; //!< Discharge cell switch //Dcc 1,2,3,4,5,6
-bool dccBit_0= false; //!< Discharge cell switch //Dcc 0
+bool DCCBITS[6] = {false,false,false,false,false,false}; //!< Discharge cell switch //Dcc 1,2,3,4,5,6
+bool DCCBIT_0= false; //!< Discharge cell switch //Dcc 0 // For discharging optional 7th cell
 bool MCAL = false; //!< Enable Multi-Calibration
 bool EN_DTMEN = true; //!< Enable Discharge timer monitor
 bool DIS_RED = false; //!< Disable Digital Redundancy Check
 bool FDRF = false; //!< Force digital Redundancy Failure
 bool SCONV = true; //!< Enable Cell Measurement Redundancy using S Pin
-bool dctoBits[4] = {true,false,true,false}; //!<  Discharge Time Out Value //Dcto 0,1,2,3 
+bool DCTOBITS[4] = {true,false,true,false}; //!<  Discharge Time Out Value //Dcto 0,1,2,3 // Programed for 4 min 
 /*Ensure that Dcto bits are set according to the required discharge time. Refer to the data sheet */
 
 /*!**********************************************************************
@@ -177,17 +184,16 @@ void setup()
   Serial.begin(115200);
   quikeval_SPI_connect();
   spi_enable(SPI_CLOCK_DIV16); // This will set the Linduino to have a 1MHz Clock
-  LTC6810_init_cfg(TOTAL_IC, bms_ic);
-  for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
+  LTC6810_init_cfg(TOTAL_IC, BMS_IC);
+  for (uint8_t current_ic = 0; current_ic<TOTAL_IC; current_ic++) 
   {
-    LTC6810_set_cfgr(current_ic, bms_ic, REFON, ADCOPT, gpioBits, dccBits, dccBit_0, MCAL, EN_DTMEN, DIS_RED, FDRF, SCONV, dctoBits, UV, OV);   
+    LTC6810_set_cfgr(current_ic, BMS_IC, REFON, ADCOPT, GPIOBITS, DCCBITS, DCCBIT_0, MCAL, EN_DTMEN, DIS_RED, FDRF, SCONV, DCTOBITS, UV, OV);   
   }   
-  LTC6810_reset_crc_count(TOTAL_IC,bms_ic);
-  LTC6810_init_reg_limits(TOTAL_IC,bms_ic);
+  LTC6810_reset_crc_count(TOTAL_IC,BMS_IC);
+  LTC6810_init_reg_limits(TOTAL_IC,BMS_IC);
   print_menu();
 }
 
-  
 /*!*********************************************************************
   \brief main loop
   @return void
@@ -203,7 +209,6 @@ void loop()
   }
 }
 
-
 /*!*****************************************
   \brief executes the user command
   @return void
@@ -212,26 +217,23 @@ void run_command(uint32_t cmd)
 {
   int8_t error = 0;
   uint32_t conv_time = 0;
-  uint32_t user_command;
-  int8_t readIC=0;
-  char input = 0;
+  int8_t s_pin_read=0;
   
   switch (cmd)
   {
-
     case 1: // Write and Read Configuration Register
       wakeup_sleep(TOTAL_IC);
-      LTC6810_wrcfg(TOTAL_IC,bms_ic); // Write into Configuration Register
-      print_config();
+      LTC6810_wrcfg(TOTAL_IC,BMS_IC); // Write into Configuration Register
+      print_wrconfig();
       wakeup_idle(TOTAL_IC);
-      error = LTC6810_rdcfg(TOTAL_IC,bms_ic); // Read Configuration Register
+      error = LTC6810_rdcfg(TOTAL_IC,BMS_IC); // Read Configuration Register
       check_error(error);
       print_rxconfig();
       break;
 
     case 2: // Read Configuration Register
       wakeup_sleep(TOTAL_IC);
-      error = LTC6810_rdcfg(TOTAL_IC,bms_ic); // Read Configuration Register
+      error = LTC6810_rdcfg(TOTAL_IC,BMS_IC); 
       check_error(error);
       print_rxconfig();
       break;
@@ -240,32 +242,26 @@ void run_command(uint32_t cmd)
       wakeup_sleep(TOTAL_IC);
       LTC6810_adcv(ADC_CONVERSION_MODE,ADC_DCP,CELL_CH_TO_CONVERT);
       conv_time = LTC6810_pollAdc();
-      Serial.print(F("cell conversion completed in:"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("mS"));
-      Serial.println();
+      print_conv_time(conv_time);
       break;
 
     case 4: // Read Cell Voltage Registers
       wakeup_sleep(TOTAL_IC);
-      error = LTC6810_rdcv(0, TOTAL_IC,bms_ic); // Set to read back all cell voltage registers
+      error = LTC6810_rdcv(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all cell voltage registers
       check_error(error);
       print_cells(DATALOG_DISABLED);
       break;
 
     case 5: // Start GPIO ADC Measurement
       wakeup_sleep(TOTAL_IC);
-      LTC6810_adax(ADC_CONVERSION_MODE , AUX_CH_TO_CONVERT);
+      LTC6810_adax(ADC_CONVERSION_MODE, AUX_CH_TO_CONVERT);
       conv_time = LTC6810_pollAdc();
-      Serial.print(F("Aux conversion completed in: "));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F(" ms"));    
-      Serial.println(); 
+      print_conv_time(conv_time);
       break;
 
     case 6: // Read AUX Voltage Registers
       wakeup_sleep(TOTAL_IC);
-      error = LTC6810_rdaux(0,TOTAL_IC,bms_ic); // Set to read back all aux registers
+      error = LTC6810_rdaux(SEL_ALL_REG, TOTAL_IC,BMS_IC); // Set to read back all aux registers
       check_error(error);
       print_aux(DATALOG_DISABLED);
       break;
@@ -274,15 +270,12 @@ void run_command(uint32_t cmd)
       wakeup_sleep(TOTAL_IC);
       LTC6810_adstat(ADC_CONVERSION_MODE, STAT_CH_TO_CONVERT);
       conv_time=LTC6810_pollAdc();
-      Serial.print(F("Stat conversion completed in "));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F(" ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       break;
 
     case 8: // Read Status registers
       wakeup_sleep(TOTAL_IC);
-      error = LTC6810_rdstat(0,TOTAL_IC,bms_ic); // Set to read back all aux registers
+      error = LTC6810_rdstat(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all Status registers
       check_error(error);
       print_stat();
       break;
@@ -291,476 +284,490 @@ void run_command(uint32_t cmd)
       wakeup_sleep(TOTAL_IC);
       LTC6810_adcvax(ADC_CONVERSION_MODE,ADC_DCP);
       conv_time = LTC6810_pollAdc();
-      Serial.print(F("Start Combined Cell Voltage, SV0 and GPIO conversion completed in:"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       wakeup_idle(TOTAL_IC);
-      error =LTC6810_rdcv(0, TOTAL_IC,bms_ic); // Set to read back all cell voltage registers
+      error =LTC6810_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC); // Set to read back all cell voltage registers
       check_error(error);
       print_cells(DATALOG_DISABLED);     
       wakeup_idle(TOTAL_IC);
-      error = LTC6810_rdaux(1,TOTAL_IC,bms_ic); // Set to read back aux register A
+      error = LTC6810_rdaux(SEL_REG_A,TOTAL_IC,BMS_IC); // Set to read back aux register A
       check_error(error);
-      print_aux1();
-      Serial.println();
+      print_aux(DATALOG_DISABLED);
       break;
 
-      case 10: //Start Combined Cell Voltage and Sum of cells
+    case 10: //Start Combined Cell Voltage and Sum of cells
       wakeup_sleep(TOTAL_IC);
       LTC6810_adcvsc(ADC_CONVERSION_MODE,ADC_DCP);
       conv_time = LTC6810_pollAdc();
-      Serial.print(F("Combined Cell Voltage conversion completed in:"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       wakeup_idle(TOTAL_IC);
-      error = LTC6810_rdcv(0,TOTAL_IC,bms_ic); // Set to read back all cell voltage registers
+      error = LTC6810_rdcv(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all cell voltage registers
       check_error(error);
       print_cells(DATALOG_DISABLED);
       wakeup_idle(TOTAL_IC);
-      error = LTC6810_rdstat(1,TOTAL_IC,bms_ic); // Set to read back stat register A
+      error = LTC6810_rdstat(SEL_REG_A,TOTAL_IC,BMS_IC); // Set to read back stat register A
       check_error(error);
-      print_statsoc();
-      Serial.println();
+      print_sumofcells();
       break;
-
-    case 11: // Loop Measurements
-      Serial.println(F("transmit 'm' to quit"));
+       
+    case 11: // Read S Voltage Registers
+    /****************************************************************
+     Ensure that the SCONV bit in the configuration register is set. 
+     ****************************************************************/
       wakeup_sleep(TOTAL_IC);
-      LTC6810_wrcfg(TOTAL_IC,bms_ic);
-      while (input != 'm')
-      {
-        if (Serial.available() > 0)
-        {
-          input = read_char();
-        }
-
-        measurement_loop(DATALOG_DISABLED);
-
-        delay(MEASUREMENT_LOOP_TIME);
-      }
-      print_menu();
-      break;
-
-    case 12: //Data-log print option Loop Measurements
-      Serial.println(F("transmit 'm' to quit"));
-      wakeup_sleep(TOTAL_IC);
-      LTC6810_wrcfg(TOTAL_IC,bms_ic);
-      while (input != 'm')
-      {
-        if (Serial.available() > 0)
-        {
-          input = read_char();
-        }
-
-        measurement_loop(DATALOG_ENABLED);
-
-        delay(MEASUREMENT_LOOP_TIME);
-      }
-      Serial.println("");
-      print_menu();
-      break;
-
-    case 13: // Run the Mux Decoder Self Test
-      wakeup_sleep(TOTAL_IC);
-      LTC6810_diagn();
+      LTC6810_wrcfg(TOTAL_IC,BMS_IC); // Write into Configuration Register
+      LTC6810_adcv(ADC_CONVERSION_MODE,ADC_DCP,CELL_CH_TO_CONVERT);
       conv_time = LTC6810_pollAdc();
-      Serial.print(F("DIAGN  conversion completed in: "));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F(" ms"));    
-      Serial.println(); 
-      error = LTC6810_rdstat(0,TOTAL_IC,bms_ic); // Set to read back all aux registers
+      print_conv_time(conv_time);
+      wakeup_idle(TOTAL_IC);
+      error = LTC6810_rds(SEL_ALL_REG, TOTAL_IC,BMS_IC); // Set to read back all S voltage registers
       check_error(error);
-      for (int ic = 0; ic<TOTAL_IC; ic++)
-        { error = 0;
-          Serial.print(" IC ");
-          Serial.println(ic+1,DEC);
-          if (bms_ic[ic].stat.mux_fail[0] != 0) error++;
-        
-          if (error==0) Serial.println(F("Mux Test: PASS "));
-          else Serial.println(F("Mux Test: FAIL "));
-        }
-      Serial.println("");
+      print_svolt(DATALOG_DISABLED);
       break;
 
-    case 14:  // Run the ADC/Memory Self Test
+    case 12: // Loop Measurements of configuration register or cell voltages or auxiliary register or status register without data-log output
       wakeup_sleep(TOTAL_IC);
-      error = LTC6810_run_cell_adc_st(CELL,TOTAL_IC,bms_ic,ADC_CONVERSION_MODE, ADCOPT );
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in Digital Filter and CELL Memory \n"));
-
-      wakeup_sleep(TOTAL_IC);
-      error = LTC6810_run_cell_adc_st(AUX,TOTAL_IC,bms_ic,ADC_CONVERSION_MODE, ADCOPT);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in Digital Filter and AUX Memory \n"));
-
-      wakeup_sleep(TOTAL_IC);
-      error = LTC6810_run_cell_adc_st(STAT,TOTAL_IC,bms_ic,ADC_CONVERSION_MODE, ADCOPT);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in Digital Filter and STAT Memory \n"));
+      LTC6810_wrcfg(TOTAL_IC,BMS_IC);
+      measurement_loop(DATALOG_DISABLED);
       print_menu();
-    break;
-
-    case 15: // Run ADC Redundancy self test
-      wakeup_sleep(TOTAL_IC);
-      error = LTC6810_run_adc_redundancy_st(ADC_CONVERSION_MODE,AUX,TOTAL_IC, bms_ic);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in AUX Measurement \n"));
-
-      wakeup_sleep(TOTAL_IC);
-      error = LTC6810_run_adc_redundancy_st(ADC_CONVERSION_MODE,STAT,TOTAL_IC, bms_ic);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in STAT Measurement \n"));
       break;
 
-    case 16: // Open Wire test for single cell detection
+    case 13: // Data-log print option Loop Measurements of configuration register or cell voltages or auxiliary register or status register
       wakeup_sleep(TOTAL_IC);
-      LTC6810_run_openwire_single(TOTAL_IC, bms_ic);
-      print_open();
-    break;
-
-    case 17: // Open Wire test for multiple cell and two consecutive cells detection
-      wakeup_sleep(TOTAL_IC);         
-      LTC6810_run_openwire_multi(TOTAL_IC, bms_ic);
-      Serial.println();    
-      break;
-    
-    case 18: // PEC Errors Detected
-      print_pec(); 
-    break;
-
-    case 19: //Reset PEC Counter
-       LTC6810_reset_crc_count(TOTAL_IC,bms_ic);
-       Serial.print("PEC Counters Reset");
-       Serial.println("");
-    break;
-
-    case 20: // Enable a discharge transistor
-      Serial.print(F("Please enter the Spin number: "));
-      readIC = (int8_t)read_int();
-      Serial.println(readIC);
-      LTC6810_set_discharge(readIC,TOTAL_IC,bms_ic);
-      wakeup_sleep(TOTAL_IC);
-      LTC6810_wrcfg(TOTAL_IC,bms_ic);
-      print_config();
-      wakeup_idle(TOTAL_IC);
-      error = LTC6810_rdcfg(TOTAL_IC,bms_ic);
-      check_error(error);
-      print_rxconfig();
-      break;
-
-    case 21: // Clear all discharge transistors
-      LTC6810_clear_discharge(TOTAL_IC,bms_ic);
-      wakeup_sleep(TOTAL_IC);
-      LTC6810_wrcfg(TOTAL_IC,bms_ic);
-      print_config();
-      wakeup_idle(TOTAL_IC);
-      error = LTC6810_rdcfg(TOTAL_IC,bms_ic);
-      check_error(error);
-      print_rxconfig();
-      break;
-
-    case 22://Write read pwm configuration     
-      /*****************************************************
-        Choose the value to be configured depending on the
-        required duty cycle. 
-        Refer to the data sheet. 
-      *******************************************************/ 
-      wakeup_sleep(TOTAL_IC);
-
-    for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
-    {
-      bms_ic[current_ic].pwm.tx_data[0]= 0x88; // PWM Duty cycle for cell 2 and 1
-      bms_ic[current_ic].pwm.tx_data[1]= 0x88; // PWM Duty cycle for cell 4 and 3
-      bms_ic[current_ic].pwm.tx_data[2]= 0x88; // PWM Duty cycle for cell 6 and 5
-    }          
-      LTC6810_wrpwm(TOTAL_IC,0,bms_ic);
-      print_pwmconfig(); 
-
-      wakeup_idle(TOTAL_IC);
-      error=LTC6810_rdpwm(TOTAL_IC,0,bms_ic); 
-      check_error(error);      
-      print_rxpwmconfig();                              
-      break;
-
-    case 23://Start SPI Communication on the GPIO Ports
-      wakeup_sleep(TOTAL_IC);
-      /************************************************************
-         Communication control bits and communication data bytes. 
-         Refer to the data sheet. 
-      *************************************************************/  
-      for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
-    {                        
-      bms_ic[current_ic].com.tx_data[0]= 0x80;
-      bms_ic[current_ic].com.tx_data[1]= 0x00;
-      bms_ic[current_ic].com.tx_data[2]= 0x02;
-      bms_ic[current_ic].com.tx_data[3]= 0x20;
-      bms_ic[current_ic].com.tx_data[4]= 0x03;
-      bms_ic[current_ic].com.tx_data[5]= 0x39;
-    }    
-      LTC6810_wrcomm(TOTAL_IC,bms_ic);               
-
-      wakeup_idle(TOTAL_IC);
-      LTC6810_stcomm(); 
-
-      wakeup_idle(TOTAL_IC);
-      error = LTC6810_rdcomm(TOTAL_IC,bms_ic);                       
-      check_error(error);
-      print_rxcomm();        
-      break;
-
-    case 24: // Write byte I2C Communication on the GPIO Ports(using eeprom 24AA01)
-      wakeup_sleep(TOTAL_IC);
-      /************************************************************
-         Communication control bits and communication data bytes. 
-         Refer to the data sheet. 
-      *************************************************************/ 
-     for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
-    {
-      bms_ic[current_ic].com.tx_data[0]= 0x6A; // Icom(6)Start + I2C_address D0 (1010 0000)
-      bms_ic[current_ic].com.tx_data[1]= 0x00; // Fcom master ack  
-      bms_ic[current_ic].com.tx_data[2]= 0x00; // eeprom address D1 (0000 0000)
-      bms_ic[current_ic].com.tx_data[3]= 0x00; // Fcom master ack 
-      bms_ic[current_ic].com.tx_data[4]= 0x01; // Icom BLANCK D2 (0Xxx)
-      bms_ic[current_ic].com.tx_data[5]= 0x29; // Fcom master nack+stop 
-    }             
-             
-      LTC6810_wrcomm(TOTAL_IC,bms_ic);// write comm register    
-
-      wakeup_idle(TOTAL_IC);
-      LTC6810_stcomm();// start I2C to write data into slave device
-      
-      wakeup_idle(TOTAL_IC);
-      error = LTC6810_rdcomm(TOTAL_IC,bms_ic); // Read comm register                       
-      check_error(error);
-      print_rxcomm(); // Print comm register  
+      LTC6810_wrcfg(TOTAL_IC,BMS_IC);
+      measurement_loop(DATALOG_ENABLED);
+      print_menu();
       break;
       
-    case 25: // Read byte data I2C Communication on the GPIO Ports(using eeprom 24AA01)
-      wakeup_sleep(TOTAL_IC);
-      /************************************************************
-         Communication control bits and communication data bytes. 
-         Refer to the data sheet. 
-      *************************************************************/         
-      for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
-      {        
-        bms_ic[current_ic].com.tx_data[0]= 0x6A; // Icom(6)Start + I2C_address D0 (1010 0000)
-        bms_ic[current_ic].com.tx_data[1]= 0x10; // Fcom master ack 
-        bms_ic[current_ic].com.tx_data[2]= 0x60; // again start I2C with I2C_address (1010 0001)
-        bms_ic[current_ic].com.tx_data[3]= 0x19; // fcom master nack + stop  
-      }            
-      LTC6810_wrcomm(TOTAL_IC,bms_ic);
-
-      wakeup_idle(TOTAL_IC); 
-      LTC6810_stcomm();// I2C for write data in slave device 
-      LTC6810_pollAdc();   
-      Serial.println(F("I2C Communication completed"));
-      Serial.println(); 
-
-      wakeup_idle(TOTAL_IC); 
-      error = LTC6810_rdcomm(TOTAL_IC,bms_ic); // Read comm register                 
-      check_error(error);
-      print_rxcomm(); // Print comm register   
-      break; 
-
-    case 26: // Reverse ISOSPI
-      Serial.print(F("ISOSPI: "));
-      Serial.println(isospi_dir);
-      bms_ic[0].isospi_reverse =(bool)(!( isospi_dir));
-      isospi_dir=bms_ic[0].isospi_reverse;
-      Serial.print(F("Current ISOSPI Direction: "));
-      Serial.println(bms_ic[0].isospi_reverse);
-      Serial.println();
-    break;
-    
-    case 27: // Read S Voltage Registers
-      wakeup_sleep(TOTAL_IC);
-      error = LTC6810_rds(0, TOTAL_IC,bms_ic); // Set to read back all cell voltage registers
-      check_error(error);
-      print_Svolt(DATALOG_DISABLED);
-      break;
-
-    case 28: // Read SID Register Group
-      wakeup_sleep(TOTAL_IC);
-      error = LTC6810_rdsid(TOTAL_IC,bms_ic); // Set to read back all cell voltage registers
-      check_error(error);
-      print_sid();
-      break;
-
-    case 29: // To Mute discharging
-      wakeup_sleep(TOTAL_IC);
-      LTC6810_mute();  
-      wakeup_idle(TOTAL_IC);
-      error = LTC6810_rdstat(0,TOTAL_IC,bms_ic);
-      check_error(error);
-      for (int current_ic = 0 ; current_ic < TOTAL_IC; current_ic++)
-      {
-      Serial.print(F(" Mute bit in Status Register B:"));
-      Serial.print(F(" 0x"));
-      serial_print_hex((bms_ic[current_ic].stat.flags[1])&(0x10));
-      Serial.println();
-      }
-      Serial.println();
-      break;
-
-    case 30: // To Unmute discharging
-      wakeup_sleep(TOTAL_IC);
-      LTC6810_unmute();
-      wakeup_idle(TOTAL_IC);
-      error = LTC6810_rdstat(0,TOTAL_IC,bms_ic);
-      check_error(error);
-      for (int current_ic = 0 ; current_ic < TOTAL_IC; current_ic++)
-      {
-      Serial.print(F(" Mute bit in Status Register B:"));
-      Serial.print(F(" 0x"));
-      serial_print_hex((bms_ic[current_ic].stat.flags[1])&(0x10));
-      Serial.println();
-      }
-      Serial.println();
-      break;  
-
-    case 31: // Clear all ADC measurement registers
+    case 14: // Clear all ADC measurement registers
       wakeup_sleep(TOTAL_IC);
       LTC6810_clrcell();
       LTC6810_clraux();
       LTC6810_clrstat();
-      Serial.println(F("All Registers Cleared"));
       wakeup_sleep(TOTAL_IC);
-      error = LTC6810_rdcv(0 , TOTAL_IC,bms_ic); // read back all cell voltage registers
-      check_error(error);
+      LTC6810_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC); // Set to read back all cell voltage registers
       print_cells(DATALOG_DISABLED);
 
       wakeup_idle(TOTAL_IC);
-      error = LTC6810_rdaux(0,TOTAL_IC,bms_ic); // read back all aux registers
-      check_error(error);
+      LTC6810_rdaux(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all aux registers
       print_aux(DATALOG_DISABLED);
 
       wakeup_idle(TOTAL_IC);
-      error = LTC6810_rdstat(0,TOTAL_IC,bms_ic); // read back all stat 
-      check_error(error);
+      LTC6810_rdstat(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all status registers 
       print_stat();  
       break;
 
-    case 32: // Set or reset the gpio pins(to drive output on gpio pins)
+    case 15: // Run the Mux Decoder Self Test
+      wakeup_sleep(TOTAL_IC);
+      LTC6810_diagn();
+      conv_time = LTC6810_pollAdc();
+      print_conv_time(conv_time);
+      error = LTC6810_rdstat(SEL_REG_B,TOTAL_IC,BMS_IC); // Set to read back Status registers B
+      check_error(error);
+      check_mux_fail();
+      break;
+
+    case 16: // Run the ADC/Memory Self Test
+      error =0;
+      wakeup_sleep(TOTAL_IC);
+      error = LTC6810_run_cell_adc_st(CELL,TOTAL_IC,BMS_IC,ADC_CONVERSION_MODE, ADCOPT );
+      print_selftest_errors(CELL, error);
+
+      error =0;
+      wakeup_sleep(TOTAL_IC);
+      error = LTC6810_run_cell_adc_st(AUX,TOTAL_IC,BMS_IC,ADC_CONVERSION_MODE, ADCOPT);
+      print_selftest_errors(AUX, error);
+
+      error =0;
+      wakeup_sleep(TOTAL_IC);
+      error = LTC6810_run_cell_adc_st(STAT,TOTAL_IC,BMS_IC,ADC_CONVERSION_MODE, ADCOPT);
+      print_selftest_errors(STAT, error);
+      print_menu();
+      break;
+
+    case 17: // Run ADC Digital Redundancy test
+      error =0;
+      wakeup_sleep(TOTAL_IC);
+      error = LTC6810_run_adc_redundancy_st(ADC_CONVERSION_MODE,AUX,TOTAL_IC, BMS_IC);
+      print_digital_redundancy_errors(AUX , error);
+      
+      error =0;
+      wakeup_sleep(TOTAL_IC);
+      error = LTC6810_run_adc_redundancy_st(ADC_CONVERSION_MODE,STAT,TOTAL_IC, BMS_IC);
+      print_digital_redundancy_errors(STAT , error);
+      break;
+
+    case 18: // Open Wire test for single cell detection
+      wakeup_sleep(TOTAL_IC);
+      LTC6810_run_openwire_single(TOTAL_IC,BMS_IC);
+      print_open_wires();
+      break;
+
+    case 19: // Open Wire test for multiple cell and two consecutive cells detection
+      wakeup_sleep(TOTAL_IC);         
+      LTC6810_run_openwire_multi(TOTAL_IC,BMS_IC);  
+      break;
+      
+    case 20: // Open wire Diagnostic for Auxiliary Measurements
+      wakeup_sleep(TOTAL_IC);
+      LTC6810_run_gpio_openwire(TOTAL_IC,BMS_IC);
+      print_open_wires();
+      break;
+    
+    case 21: // PEC Errors Detected
+      print_pec_error_count(); 
+      break;
+
+    case 22: //Reset PEC Counter
+      LTC6810_reset_crc_count(TOTAL_IC,BMS_IC);
+      print_pec_error_count();
+      break;
+
+    case 23: // Enable a discharge transistor
+      s_pin_read = select_s_pin();
+      LTC6810_set_discharge(s_pin_read,TOTAL_IC,BMS_IC);
+      wakeup_sleep(TOTAL_IC);
+      LTC6810_wrcfg(TOTAL_IC,BMS_IC);
+      print_wrconfig();
+      wakeup_idle(TOTAL_IC);
+      error = LTC6810_rdcfg(TOTAL_IC,BMS_IC);
+      check_error(error);
+      print_rxconfig();
+      break;
+
+    case 24: // Clear all discharge transistors
+      LTC6810_clear_discharge(TOTAL_IC,BMS_IC);
+      wakeup_sleep(TOTAL_IC);
+      LTC6810_wrcfg(TOTAL_IC,BMS_IC);
+      print_wrconfig();
+      wakeup_idle(TOTAL_IC);
+      error = LTC6810_rdcfg(TOTAL_IC,BMS_IC);
+      check_error(error);
+      print_rxconfig();
+      break;
+
+    case 25://Write and read pwm configuration     
+      /*****************************************************
+        Choose the value to be configured depending on the
+        required duty cycle. Refer to the data sheet.
+        Ensure that the DCTO value in the Configuration 
+        Register Group is set to a non-zero value.
+      *******************************************************/ 
+      wakeup_sleep(TOTAL_IC);
+
+      for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
+      {
+        BMS_IC[current_ic].pwm.tx_data[0]= 0x88; // PWM Duty cycle for cell 2 and 1
+        BMS_IC[current_ic].pwm.tx_data[1]= 0x88; // PWM Duty cycle for cell 4 and 3
+        BMS_IC[current_ic].pwm.tx_data[2]= 0x88; // PWM Duty cycle for cell 6 and 5
+      }          
+      LTC6810_wrpwm(TOTAL_IC,0,BMS_IC);
+      print_wrpwm(); 
+
+      wakeup_idle(TOTAL_IC);
+      error=LTC6810_rdpwm(TOTAL_IC,0,BMS_IC); 
+      check_error(error);      
+      print_rxpwm();                              
+      break;
+
+   case 26://SPI Communication 
+      /**************************************************************
+       Ensure to set the GPIO bits to 1 in the CFG register group.
+      ****************************************************************/  
+      for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
+      {
+        //Communication control bits and communication data bytes. Refer to the data sheet.
+        BMS_IC[current_ic].com.tx_data[0]= 0x81; // Icom CSBM Low(8) + data D0 (0x11)
+        BMS_IC[current_ic].com.tx_data[1]= 0x10; // Fcom CSBM Low(0) 
+        BMS_IC[current_ic].com.tx_data[2]= 0xA2; // Icom CSBM Falling Edge (A) +  D1 (0x25)
+        BMS_IC[current_ic].com.tx_data[3]= 0x50; // Fcom CSBM Low(0)    
+        BMS_IC[current_ic].com.tx_data[4]= 0xA1; // Icom CSBM Falling Edge (A) +  D2 (0x17)
+        BMS_IC[current_ic].com.tx_data[5]= 0x79; // Fcom CSBM High(9)
+      }
+      wakeup_sleep(TOTAL_IC);   
+      LTC6810_wrcomm(TOTAL_IC,BMS_IC); // write to comm register                
+      print_wrcomm(); // print data in the comm register
+
+      wakeup_idle(TOTAL_IC);
+      LTC6810_stcomm(3); // data length=3 // initiates communication between master and the I2C slave
+
+      wakeup_idle(TOTAL_IC);
+      error = LTC6810_rdcomm(TOTAL_IC,BMS_IC); // read from comm register                        
+      check_error(error);
+      print_rxcomm(); // print received data into the comm register
+      break;
+
+   case 27: // Write byte I2C Communication on the GPIO Ports(using I2C eeprom 24LC025)
+       /************************************************************
+         Ensure to set the GPIO bits to 1 in the CFG register group. 
+      *************************************************************/   
+      for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
+      {
+        //Communication control bits and communication data bytes. Refer to the data sheet.
+        BMS_IC[current_ic].com.tx_data[0]= 0x6A; // Icom Start(6) + I2C_address D0 (0xA0)
+        BMS_IC[current_ic].com.tx_data[1]= 0x08; // Fcom master NACK(8)  
+        BMS_IC[current_ic].com.tx_data[2]= 0x00; // Icom Blank (0) + eeprom address D1 (0x00)
+        BMS_IC[current_ic].com.tx_data[3]= 0x08; // Fcom master NACK(8)   
+        BMS_IC[current_ic].com.tx_data[4]= 0x01; // Icom Blank (0) + data D2 (0x10)
+        BMS_IC[current_ic].com.tx_data[5]= 0x09; // Fcom master NACK + Stop(9) 
+      }
+      wakeup_sleep(TOTAL_IC);       
+      LTC6810_wrcomm(TOTAL_IC,BMS_IC);// write to comm register    
+      print_wrcomm(); // print data from the comm register
+
+      wakeup_idle(TOTAL_IC);
+      LTC6810_stcomm(3); // data length=3 // initiates communication between master and the I2C slave
+
+      wakeup_idle(TOTAL_IC);
+      error = LTC6810_rdcomm(TOTAL_IC,BMS_IC); // read from comm register               
+      check_error(error);
+      print_rxcomm(); // print received data into the comm register
+      break; 
+
+    case 28: // Read byte data I2C Communication on the GPIO Ports(using I2C eeprom 24LC025 )
+      /************************************************************
+         Ensure to set the GPIO bits to 1 in the CFG register group. 
+      *************************************************************/     
+      for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
+      {
+        //Communication control bits and communication data bytes. Refer to the data sheet.       
+        BMS_IC[current_ic].com.tx_data[0]= 0x6A; // Icom Start (6) + I2C_address D0 (A0) (Write operation to set the word address)
+        BMS_IC[current_ic].com.tx_data[1]= 0x08; // Fcom master NACK(8)  
+        BMS_IC[current_ic].com.tx_data[2]= 0x00; // Icom Blank (0) + eeprom address(word address) D1 (0x00)
+        BMS_IC[current_ic].com.tx_data[3]= 0x08; // Fcom master NACK(8)
+        BMS_IC[current_ic].com.tx_data[4]= 0x6A; // Icom Start (6) + I2C_address D2 (0xA1)(Read operation)
+        BMS_IC[current_ic].com.tx_data[5]= 0x18; // Fcom master NACK(8)  
+      }
+      wakeup_sleep(TOTAL_IC);         
+      LTC6810_wrcomm(TOTAL_IC,BMS_IC); // write to comm register 
+
+      wakeup_idle(TOTAL_IC);            
+      LTC6810_stcomm(3); // data length=3 // initiates communication between master and the I2C slave 
+
+      for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
+      { 
+        //Communication control bits and communication data bytes. Refer to the data sheet.       
+        BMS_IC[current_ic].com.tx_data[0]= 0x0F; // Icom Blank (0) + data D0 (FF)
+        BMS_IC[current_ic].com.tx_data[1]= 0xF9; // Fcom master NACK + Stop(9) 
+        BMS_IC[current_ic].com.tx_data[2]= 0x7F; // Icom No Transmit (7) + data D1 (FF)
+        BMS_IC[current_ic].com.tx_data[3]= 0xF9; // Fcom master NACK + Stop(9) 
+        BMS_IC[current_ic].com.tx_data[4]= 0x7F; // Icom No Transmit (7) + data D2 (FF)
+        BMS_IC[current_ic].com.tx_data[5]= 0xF9; // Fcom master NACK + Stop(9)    
+      }  
+      wakeup_idle(TOTAL_IC);     
+      LTC6810_wrcomm(TOTAL_IC,BMS_IC); // write to comm register
+
+      wakeup_idle(TOTAL_IC);
+      LTC6810_stcomm(1); // data length=1 // initiates communication between master and the I2C slave 
+
+      wakeup_idle(TOTAL_IC);
+      error = LTC6810_rdcomm(TOTAL_IC,BMS_IC); // read from comm register                 
+      check_error(error);
+      print_rxcomm(); // print received data from the comm register  
+      break;
+      
+    case 29: // To Reverse the direction of ISOSPI communication in a daisy chain connection 
+      reverse_isospi_direction();
+      break;
+
+    case 30: // Read SID Register Group
+      wakeup_sleep(TOTAL_IC);
+      error = LTC6810_rdsid(TOTAL_IC,BMS_IC);
+      check_error(error);
+      print_sid();
+      break;
+
+    case 31: // To Mute discharging
+      wakeup_sleep(TOTAL_IC);
+      LTC6810_mute();  
+      wakeup_idle(TOTAL_IC);
+      error = LTC6810_rdstat(SEL_REG_B,TOTAL_IC,BMS_IC); // Set to read back Status registers B
+      check_error(error);
+      check_mute_bit();
+      break;
+
+    case 32: // To Unmute discharging
+      wakeup_sleep(TOTAL_IC);
+      LTC6810_unmute();
+      wakeup_idle(TOTAL_IC);
+      error = LTC6810_rdstat(SEL_REG_B,TOTAL_IC,BMS_IC); // Set to read back Status registers B
+      check_error(error);
+      check_mute_bit();
+      break;  
+
+    case 33: // Set or reset the gpio pins(to drive output on gpio pins)
       /***********************************************************************
        Please ensure you have set the GPIO bits according to your requirement 
-       in the configuration register.( check the global variable gpioBits_a )
+       in the configuration register.( check the global variable GPIOBITS )
       ************************************************************************/   
       wakeup_sleep(TOTAL_IC);
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        LTC6810_set_cfgr(current_ic, bms_ic, REFON, ADCOPT, gpioBits, dccBits, dccBit_0, MCAL, EN_DTMEN, DIS_RED, FDRF, SCONV, dctoBits, UV, OV); 
+        LTC6810_set_cfgr(current_ic, BMS_IC, REFON, ADCOPT, GPIOBITS, DCCBITS, DCCBIT_0, MCAL, EN_DTMEN, DIS_RED, FDRF, SCONV, DCTOBITS, UV, OV); 
       } 
       wakeup_idle(TOTAL_IC);
-      LTC6810_wrcfg(TOTAL_IC,bms_ic);
-      print_config();
+      LTC6810_wrcfg(TOTAL_IC,BMS_IC);
+      print_wrconfig();
       break;
-
-    case 33: // Open wire Diagnostic for Auxiliary Measurements
-      wakeup_sleep(TOTAL_IC);
-      LTC6810_run_gpio_openwire(TOTAL_IC, bms_ic);
-      print_open();
-      Serial.println();
-      break;
-      
+  
     case 'm': //prints menu
       print_menu();
       break;
 
     default:
-      Serial.println(F("Incorrect Option"));
-      Serial.println();
+      char str_error[]="Incorrect Option \n";
+      serial_print_text(str_error);
       break;
   }
 }
 
-/*!*********************************
-  \brief For Loop Measurement
+/*!**********************************************************************************************************************************************
+ \brief For writing/reading configuration data or measuring cell voltages or reading aux register or reading status register in a continuous loop  
  @return void
-***********************************/
+*************************************************************************************************************************************************/
 void measurement_loop(uint8_t datalog_en)
 {
   int8_t error = 0;
+  char input = 0;
   
-  if (WRITE_CONFIG == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    LTC6810_wrcfg(TOTAL_IC,bms_ic);
-    print_config();
-  }
-
-  if (READ_CONFIG == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    error = LTC6810_rdcfg(TOTAL_IC,bms_ic); 
-    check_error(error);
-    print_rxconfig();
-  }
-
-  if (MEASURE_CELL == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    LTC6810_adcv(ADC_CONVERSION_MODE,ADC_DCP,CELL_CH_TO_CONVERT);
-    LTC6810_pollAdc();
-    wakeup_idle(TOTAL_IC);
-    error = LTC6810_rdcv(0, TOTAL_IC,bms_ic);
-    check_error(error);
-    print_cells(datalog_en);
-
-  }
-
-  if (MEASURE_AUX == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    LTC6810_adax(ADC_CONVERSION_MODE , AUX_CH_ALL);
-    LTC6810_pollAdc();
-    wakeup_idle(TOTAL_IC);
-    error = LTC6810_rdaux(0,TOTAL_IC,bms_ic); // Set to read back all aux registers
-    check_error(error);
-    print_aux(datalog_en);
-  }
-
-  if (MEASURE_STAT == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    LTC6810_adstat(ADC_CONVERSION_MODE, STAT_CH_ALL);
-    LTC6810_pollAdc();
-    wakeup_idle(TOTAL_IC);
-    error = LTC6810_rdstat(0,TOTAL_IC,bms_ic); // Set to read back all aux registers
-    check_error(error);
-    print_stat();
-  }
-
-  if(PRINT_PEC == ENABLED)
-  {
-    print_pec();
-  }
+  Serial.println(F("Transmit 'm' to quit"));
   
+  while (input != 'm')
+  {
+     if (Serial.available() > 0)
+      {
+        input = read_char();
+      }      
+
+      if (WRITE_CONFIG == ENABLED)
+      {
+        wakeup_idle(TOTAL_IC);
+        LTC6810_wrcfg(TOTAL_IC,BMS_IC);
+        print_wrconfig();
+      }
+    
+      if (READ_CONFIG == ENABLED)
+      {
+        wakeup_idle(TOTAL_IC);
+        error = LTC6810_rdcfg(TOTAL_IC,BMS_IC); 
+        check_error(error);
+        print_rxconfig();
+      }
+    
+      if (MEASURE_CELL == ENABLED)
+      {
+        wakeup_idle(TOTAL_IC);
+        LTC6810_adcv(ADC_CONVERSION_MODE,ADC_DCP,CELL_CH_TO_CONVERT);
+        LTC6810_pollAdc();
+        wakeup_idle(TOTAL_IC);
+        error = LTC6810_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC);
+        check_error(error);
+        print_cells(datalog_en);
+      }
+    
+      if (MEASURE_AUX == ENABLED)
+      {
+        wakeup_idle(TOTAL_IC);
+        LTC6810_adax(ADC_CONVERSION_MODE , AUX_CH_ALL);
+        LTC6810_pollAdc();
+        wakeup_idle(TOTAL_IC);
+        error = LTC6810_rdaux(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all aux registers
+        check_error(error);
+        print_aux(datalog_en);
+      }
+    
+      if (MEASURE_STAT == ENABLED)
+      {
+        wakeup_idle(TOTAL_IC);
+        LTC6810_adstat(ADC_CONVERSION_MODE, STAT_CH_ALL);
+        LTC6810_pollAdc();
+        wakeup_idle(TOTAL_IC);
+        error = LTC6810_rdstat(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all stat registers
+        check_error(error);
+        print_stat();
+      }
+    
+      if(PRINT_PEC == ENABLED)
+      {
+        print_pec_error_count();
+      }   
+     delay(MEASUREMENT_LOOP_TIME);
+   } 
 }
 
 /*!*********************************
   \brief Prints the main menu
    @return void
 ***********************************/
-void print_menu()
+void print_menu(void)
 {
   Serial.println(F("Please enter LTC6810 Command"));
-  Serial.println(F("Write and Read Configuration: 1                            |Loop measurements with datalog output : 12                             |SPI Communication  : 23"));
-  Serial.println(F("Read Configuration: 2                                      |Run Mux Self Test: 13                                                  |I2C Communication Write to Slave :24"));
-  Serial.println(F("Start Cell Voltage Conversion: 3                           |Run ADC Self Test: 14                                                  |I2C Communication Read from Slave :25"));
-  Serial.println(F("Read Cell Voltages: 4                                      |Run Digital Redundancy Test: 15                                        |Reverse ISOSPI : 26"));
-  Serial.println(F("Start Aux Voltage Conversion: 5                            |Open Wire Test for single cell detection: 16                           |Read S Voltage Registers : 27"));
-  Serial.println(F("Read Aux Voltages: 6                                       |Open Wire Test for multiple cell or two consecutive cells detection:17 |Read Serial ID : 28"));
-  Serial.println(F("Start Stat Voltage Conversion: 7                           |Print PEC Counter: 18                                                  |Enable MUTE : 29"));
-  Serial.println(F("Read Stat Voltages: 8                                      |Reset PEC Counter: 19                                                  |Disable MUTE : 30"));
-  Serial.println(F("Start Combined Cell Voltage and GPIO1, GPIO2 Conversion: 9 |Set Discharge: 20                                                      |Clear Registers: 31"));
-  Serial.println(F("Start Cell Voltage and Sum of cells : 10                   |Clear Discharge: 21                                                    |Set or reset the gpio pins: 32"));
-  Serial.println(F("Loop Measurements: 11                                      |Write and Read of PWM : 22                                             |Openwire for Auxiliary Measurement: 33"));
-  Serial.println();
+  Serial.println(F("Write and Read Configuration: 1                            |Loop Measurements: 12                                                  |Set Discharge: 23"));    
+  Serial.println(F("Read Configuration: 2                                      |Loop Measurements with Data Log output : 13                            |Clear Discharge: 24")); 
+  Serial.println(F("Start Cell Voltage Conversion: 3                           |Clear all ADC Measurement Registers: 14                                |Write and Read of PWM : 25"));  
+  Serial.println(F("Read Cell Voltages: 4                                      |Run Mux Self Test: 15                                                  |SPI Communication  : 26"));
+  Serial.println(F("Start Aux Voltage Conversion: 5                            |Run ADC Self Test: 16                                                  |I2C Communication Write to Slave :27"));
+  Serial.println(F("Read Aux Voltages: 6                                       |Run Digital Redundancy Test: 17                                        |I2C Communication Read from Slave :28"));
+  Serial.println(F("Start Stat Voltage Conversion: 7                           |Open Wire Test for single cell detection: 18                           |Reverse ISOSPI : 29"));
+  Serial.println(F("Read Stat Voltages: 8                                      |Open Wire Test for multiple cell or two consecutive cells detection: 19|Read Serial ID : 30"));
+  Serial.println(F("Start Combined Cell Voltage and Cell 0, GPIO2 Conversion: 9|Open wire for Auxiliary Measurement: 20                                |Enable MUTE : 31"));
+  Serial.println(F("Start Cell Voltage and Sum of cells: 10                    |Print PEC Counter: 21                                                  |Disable MUTE : 32"));
+  Serial.println(F("Read S Voltage Registers: 11                               |Reset PEC Counter: 22                                                  |Set or reset the gpio pins: 33 \n"));                                                                               
   Serial.println(F("Print 'm' for menu"));
-  Serial.println(F("Please enter command: "));
-  Serial.println();;
+  Serial.println(F("Please enter command: \n"));
+}
+
+/*!******************************************************************************
+ \brief Prints the configuration data that is going to be written to the LTC6810
+ to the serial port.
+  @return void
+ ********************************************************************************/
+void print_wrconfig(void)
+{
+  int cfg_pec;
+
+  Serial.println(F("Written Configuration: "));
+  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.print(F("CFGA IC "));
+    Serial.print(current_ic+1,DEC);
+    for(int i = 0;i<6;i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].config.tx_data[i]);
+    }
+    Serial.print(F(", Calculated PEC: 0x"));
+    cfg_pec = pec15_calc(6,&BMS_IC[current_ic].config.tx_data[0]);
+    serial_print_hex((uint8_t)(cfg_pec>>8));
+    Serial.print(F(", 0x"));
+    serial_print_hex((uint8_t)(cfg_pec));
+    Serial.println("\n");
+  }
+}
+
+/*!*****************************************************************
+ \brief Prints the configuration data that was read back from the
+ LTC6810 to the serial port.
+  @return void
+ *******************************************************************/
+void print_rxconfig(void)
+{
+  Serial.println(F("Received Configuration "));
+  for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.print(F("CFGA IC "));
+    Serial.print(current_ic+1,DEC);
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].config.rx_data[i]);
+    }
+    Serial.print(F(", Received PEC: 0x"));
+    serial_print_hex(BMS_IC[current_ic].config.rx_data[6]);
+    Serial.print(F(", 0x"));
+    serial_print_hex(BMS_IC[current_ic].config.rx_data[7]);
+    Serial.println("\n");
+  }
 }
 
 /*!************************************************************
@@ -769,45 +776,133 @@ void print_menu()
  *************************************************************/
 void print_cells(uint8_t datalog_en)
 {
-
-
   for (int current_ic = 0 ; current_ic < TOTAL_IC; current_ic++)
   {
     if (datalog_en == 0)
     {
       Serial.print(" IC ");
       Serial.print(current_ic+1,DEC);
-      Serial.print(": ");
-      for (int i=0; i<bms_ic[0].ic_reg.cell_channels; i++)
+      Serial.print(": ");      for (int i=0; i< BMS_IC[0].ic_reg.cell_channels; i++)
       {
-
         Serial.print(" C");
         Serial.print(i+1,DEC);
-        Serial.print(":");
-        Serial.print(bms_ic[current_ic].cells.c_codes[i]*0.0001,4);
+        Serial.print(":");        
+        Serial.print(BMS_IC[current_ic].cells.c_codes[i]*0.0001,4);
         Serial.print(",");
       }
       Serial.println();
     }
     else
     {
-      Serial.print("Cells, ");
-      for (int i=0; i<bms_ic[0].ic_reg.cell_channels; i++)
+      Serial.print(" Cells :");
+      for (int i=0; i<BMS_IC[0].ic_reg.cell_channels; i++)
       {
-        Serial.print(bms_ic[current_ic].cells.c_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].cells.c_codes[i]*0.0001,4);
         Serial.print(",");
       }
-
     }
   }
-  Serial.println();
+  Serial.println("\n");
+}
+
+/*!****************************************************************************
+  \brief Prints GPIO voltage codes and Vref2 voltage code onto the serial port
+   @return void
+ *****************************************************************************/
+void print_aux(uint8_t datalog_en)
+{
+  for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
+  {
+    if (datalog_en == 0)
+    {
+       Serial.print(" IC ");
+       Serial.print(current_ic+1,DEC);
+       Serial.print(F(": S0_V :"));
+       Serial.print(BMS_IC[current_ic].aux.a_codes[0]*0.0001,4);
+       Serial.print(",");
+      for (int i = 1; i < 5; i++)
+      {
+        Serial.print(F(" GPIO-"));
+        Serial.print(i,DEC);
+        Serial.print(":");
+        Serial.print(BMS_IC[current_ic].aux.a_codes[i]*0.0001,4);
+        Serial.print(",");
+      }
+      Serial.print(F(" Vref2 :"));
+      Serial.print(BMS_IC[current_ic].aux.a_codes[5]*0.0001,4);
+      Serial.println();
+    }
+    else
+    {
+      Serial.print("AUX :");
+
+      for (int i=0; i < 6; i++)
+      {
+        Serial.print(BMS_IC[current_ic].aux.a_codes[i]*0.0001,4);
+        Serial.print(",");
+      }
+    }
+  }
+  Serial.println("\n");
+}
+
+/*!*****************************************************************************
+  \brief Prints Status voltage codes and Vref2 voltage code onto the serial port
+   @return void
+ ******************************************************************************/
+void print_stat(void)
+{
+  double itmp;
+  for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
+  {
+    Serial.print(F(" IC "));
+    Serial.print(current_ic+1,DEC);
+    Serial.print(F(" SOC:"));
+    Serial.print(BMS_IC[current_ic].stat.stat_codes[0]*0.0001*10,4);
+    Serial.print(F(", Itemp:"));
+    itmp = (double)((BMS_IC[current_ic].stat.stat_codes[1] * (0.0001 / 0.0075)) - 273);   //Internal Die Temperature(°C) = ITMP • (100 µV / 7.5mV)°C - 273°C
+    Serial.print(itmp,4);
+    Serial.print(F(", VregA:"));
+    Serial.print(BMS_IC[current_ic].stat.stat_codes[2]*0.0001,4);
+    Serial.print(F(", VregD:"));
+    Serial.println(BMS_IC[current_ic].stat.stat_codes[3]*0.0001,4);
+    Serial.print(F(" Flag bits: 0x"));
+    serial_print_hex(BMS_IC[current_ic].stat.flags[0]);
+    Serial.print(F(",\t Flag bits and Mute bit:"));
+    Serial.print(F(" 0x"));
+    serial_print_hex((BMS_IC[current_ic].stat.flags[1])&(0x1F));
+    Serial.print(F(",\t Mux fail flag:"));
+    Serial.print(F(" 0x"));
+    serial_print_hex(BMS_IC[current_ic].stat.mux_fail[0]);
+    Serial.print(F(",\t THSD:"));
+    Serial.print(F(" 0x"));
+    serial_print_hex(BMS_IC[current_ic].stat.thsd[0]);
+    Serial.println("\n");
+  }
+}
+
+/*!****************************************************************************
+  \brief Prints Status voltage codes for SOC onto the serial port
+   @return void
+ *****************************************************************************/
+void print_sumofcells(void)
+{
+ for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
+  {
+    Serial.print(F(" IC "));
+    Serial.print(current_ic+1,DEC);
+    Serial.print(F(": SOC:"));
+    Serial.print(BMS_IC[current_ic].stat.stat_codes[0]*0.0001*10,4);
+    Serial.print(F(","));
+  }
+  Serial.println("\n");
 }
 
 /*!************************************************************
   \brief Prints S voltage codes to the serial port
    @return void
- *************************************************************/
-void print_Svolt(uint8_t datalog_en)
+*************************************************************/
+void print_svolt(uint8_t datalog_en)
 {
   for (int current_ic = 0 ; current_ic < TOTAL_IC; current_ic++)
   {
@@ -822,7 +917,7 @@ void print_Svolt(uint8_t datalog_en)
           Serial.print(" S");
           Serial.print(j,DEC);
           Serial.print(":");
-          Serial.print(bms_ic[current_ic].cells.c_codes[i]*0.0001,4);
+          Serial.print(BMS_IC[current_ic].cells.c_codes[i]*0.0001,4);
           Serial.print(",");
           j++;
         }
@@ -833,258 +928,153 @@ void print_Svolt(uint8_t datalog_en)
       Serial.print("S pin:, ");
       for (int i=6; i<12; i++)
       {
-        Serial.print(bms_ic[current_ic].cells.c_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].cells.c_codes[i]*0.0001,4);
         Serial.print(",");
       }
-
     }
   }
-  Serial.println();
+  Serial.println("\n");
 }
+
+/*!****************************************************************
+  \brief Function to check the MUX fail bit in the Status Register
+   @return void
+*******************************************************************/
+void check_mux_fail(void)
+{ 
+  int8_t error = 0;
+  for (int ic = 0; ic<TOTAL_IC; ic++)
+    { 
+      Serial.print(" IC ");
+      Serial.println(ic+1,DEC);
+      if (BMS_IC[ic].stat.mux_fail[0] != 0) error++;
+    
+      if (error==0) Serial.println(F("Mux Test: PASS \n"));
+      else Serial.println(F("Mux Test: FAIL \n"));
+    }
+}
+
+/*!************************************************************
+  \brief Prints Errors Detected during self test
+   @return void
+*************************************************************/
+void print_selftest_errors(uint8_t adc_reg ,int8_t error)
+{
+  if(adc_reg==1)
+  {
+    Serial.println("Cell ");
+    }
+  else if(adc_reg==2)
+  {
+    Serial.println("Aux ");
+    }
+  else if(adc_reg==3)
+  {
+    Serial.println("Stat ");
+    }
+  Serial.print(error, DEC);
+  Serial.println(F(" : errors detected in Digital Filter and Memory \n"));
+}
+
+/*!************************************************************
+  \brief Prints Errors Detected during Digital Redundancy test
+   @return void
+*************************************************************/
+void print_digital_redundancy_errors(uint8_t adc_reg ,int8_t error)
+{
+  if(adc_reg==2)
+  {
+    Serial.println("Aux ");
+    }
+  else if(adc_reg==3)
+  {
+    Serial.println("Stat ");
+    }
+
+  Serial.print(error, DEC);
+  Serial.println(F(" : errors detected in Measurement \n"));
+ }
 
 /*!****************************************************************************
   \brief Prints Open wire test results to the serial port
    @return void
  *****************************************************************************/
-void print_open()
+void print_open_wires(void)
 {
   for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
   {
-    if (bms_ic[current_ic].system_open_wire == 65535)
+    if (BMS_IC[current_ic].system_open_wire == 65535)
     {
       Serial.print("No Opens Detected on IC ");
       Serial.print(current_ic+1, DEC);
-      Serial.println();
     }
     else
     {
       Serial.print(F("There is an open wire on IC "));
       Serial.print(current_ic + 1,DEC);
       Serial.print(F(" Channel: "));
-      Serial.println(bms_ic[current_ic].system_open_wire);
+      Serial.println(BMS_IC[current_ic].system_open_wire);
     }
+    Serial.println("\n");
   }
-   Serial.println();
 }
 
 /*!****************************************************************************
-  \brief Prints GPIO voltage codes and Vref2 voltage code onto the serial port
-   @return void
- *****************************************************************************/
-void print_aux(uint8_t datalog_en)
-{
-
-  for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
-  {
-    if (datalog_en == 0)
-    {
-      Serial.print(" IC ");
-      Serial.print(current_ic+1,DEC);
-       Serial.print(F(" S0_V"));
-       Serial.print(":");
-       Serial.print(bms_ic[current_ic].aux.a_codes[0]*0.0001,4);
-       Serial.print(",");
-      for (int i=1; i < 5; i++)
-      {
-        Serial.print(F(" GPIO-"));
-        Serial.print(i,DEC);
-        Serial.print(":");
-        Serial.print(bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
-        Serial.print(",");
-      }
-      Serial.print(F(" Vref2"));
-      Serial.print(":");
-      Serial.print(bms_ic[current_ic].aux.a_codes[5]*0.0001,4);
-      Serial.println();
-    }
-    else
-    {
-      Serial.print("AUX, ");
-
-      for (int i=0; i < 6; i++)
-      {
-        Serial.print(bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
-        Serial.print(",");
-      }
-    }
-  }
-  Serial.println();
-}
-
-/*!****************************************************************************
-  \brief Prints GPIO voltage codes (SV0 and GPIO2)
-   @return void
- *****************************************************************************/
-void print_aux1()
-{
-  for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
-  {
-      Serial.print(" IC ");
-      Serial.print(current_ic+1,DEC);
-      Serial.print(F(": "));
-      
-      Serial.print(F(" S0_V"));
-      Serial.print(":");
-      Serial.print(bms_ic[current_ic].aux.a_codes[0]*0.0001,4);
-      Serial.print(",");
-      Serial.print(F(" GPIO- 1 "));
-      Serial.print(":");
-      Serial.print(bms_ic[current_ic].aux.a_codes[1]*0.0001,4);
-      Serial.print(",");
-  }
-  Serial.println();
-}
-
-/*!*****************************************************************************
-  \brief Prints Status voltage codes and Vref2 voltage code onto the serial port
-   @return void
- ******************************************************************************/
-void print_stat()
-{
-    double ITMP;
-  for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC "));
-    Serial.print(current_ic+1,DEC);
-    Serial.print(F(" SOC:"));
-    Serial.print(bms_ic[current_ic].stat.stat_codes[0]*0.0001*10,4);
-    Serial.print(F(","));
-     Serial.print(F(" Itemp:"));
-    ITMP = (double)((bms_ic[current_ic].stat.stat_codes[1] * (0.0001 / 0.0075)) - 273);   //Internal Die Temperature(°C) = ITMP • (100 µV / 7.5mV)°C - 273°C
-    Serial.print(ITMP,4);
-    Serial.print(F(","));
-    Serial.print(F(" VregA:"));
-    Serial.print(bms_ic[current_ic].stat.stat_codes[2]*0.0001,4);
-    Serial.print(F(","));
-    Serial.print(F(" VregD:"));
-    Serial.println(bms_ic[current_ic].stat.stat_codes[3]*0.0001,4);
-    Serial.print(F(" Flag bits:"));
-    Serial.print(F(" 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.flags[0]);
-    Serial.print(F(",\t Flag bits and Mute bit:"));
-    Serial.print(F(" 0x"));
-    serial_print_hex((bms_ic[current_ic].stat.flags[1])&(0x1F));
-    Serial.print(F(",\t Mux fail flag:"));
-    Serial.print(F(" 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.mux_fail[0]);
-    Serial.print(F(",\t THSD:"));
-    Serial.print(F(" 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.thsd[0]);
-    Serial.println();
-  }
-
-  Serial.println();
-}
-
-/*!****************************************************************************
-  \brief Prints Status voltage codes for SOC onto the serial port
-   @return void
- *****************************************************************************/
-void print_statsoc()
-{
- for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC "));
-    Serial.print(current_ic+1,DEC);
-    Serial.print(F(": "));
-    Serial.print(F(" SOC:"));
-    Serial.print(bms_ic[current_ic].stat.stat_codes[0]*0.0001*10,4);
-    Serial.print(F(","));
-  }
-
-  Serial.println();
-}
-
-/*!******************************************************************************
- \brief Prints the configuration data that is going to be written to the LTC6810
- to the serial port.
+  \brief Function to print the number of PEC Errors
   @return void
- ********************************************************************************/
-void print_config()
+ *****************************************************************************/
+void print_pec_error_count(void)
 {
-  int cfg_pec;
-
-  Serial.println(F("Written Configuration: "));
-  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F("CFGA IC "));
-    Serial.print(current_ic+1,DEC);
-    for(int i = 0;i<6;i++)
-    {
-      Serial.print(F(", 0x"));
-      serial_print_hex(bms_ic[current_ic].config.tx_data[i]);
-    }
-    Serial.print(F(", Calculated PEC: 0x"));
-    cfg_pec = pec15_calc(6,&bms_ic[current_ic].config.tx_data[0]);
-    serial_print_hex((uint8_t)(cfg_pec>>8));
-    Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(cfg_pec));
-    Serial.println();
-  }
-  Serial.println();
-}
-
-/*!*****************************************************************
- \brief Prints the configuration data that was read back from the
- LTC6810 to the serial port.
-  @return void
- *******************************************************************/
-void print_rxconfig()
-{
-  Serial.println(F("Received Configuration "));
   for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
   {
-    Serial.print(F("CFGA IC "));
-    Serial.print(current_ic+1,DEC);
-    for(int i = 0;i<6;i++)
-    {
-      Serial.print(F(", 0x"));
-      serial_print_hex(bms_ic[current_ic].config.rx_data[i]);
-    };
-    Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].config.rx_data[6]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].config.rx_data[7]);
-    Serial.println();
+      Serial.println("");
+      Serial.print(BMS_IC[current_ic].crc_count.pec_count,DEC);
+      Serial.print(F(" : PEC Errors Detected on IC"));
+      Serial.println(current_ic+1,DEC);
   }
-  Serial.println();
+  Serial.println("\n");
 }
 
-/*!******************************************************************************
+/*!****************************************************
+  \brief Function to select the S pin for discharge
+  @return void
+ ******************************************************/
+int8_t select_s_pin(void)
+{
+  int8_t read_s_pin=0;
+  
+  Serial.print(F("Please enter the Spin number: "));
+  read_s_pin = (int8_t)read_int();
+  Serial.println(read_s_pin);
+  return(read_s_pin);
+}
+
+/*!***********************************************************************************
  \brief Prints  PWM the configuration data that is going to be written to the LTC6810
  to the serial port.
   @return void
- ********************************************************************************/
-void print_pwmconfig()
+ ************************************************************************************/
+void print_wrpwm(void)
 {
-  int cfg_pec;
+  int pwm_pec;
 
-  Serial.println(F("Written pwm Configuration: "));
+  Serial.println(F("Written PWM Configuration: "));
   for (uint8_t current_ic = 0; current_ic<TOTAL_IC; current_ic++)
   {
     Serial.print(F("IC "));
     Serial.print(current_ic+1,DEC);
-    Serial.print(F(": "));
-    Serial.print(F("0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[5]);
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+     serial_print_hex(BMS_IC[current_ic].pwm.tx_data[i]);
+    }
     Serial.print(F(", Calculated PEC: 0x"));
-    cfg_pec = pec15_calc(6,&bms_ic[current_ic].pwm.tx_data[0]);
-    serial_print_hex((uint8_t)(cfg_pec>>8));
+    pwm_pec = pec15_calc(6,&BMS_IC[current_ic].pwm.tx_data[0]);
+    serial_print_hex((uint8_t)(pwm_pec>>8));
     Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(cfg_pec));
-    Serial.println();
-  }
-  Serial.println();
+    serial_print_hex((uint8_t)(pwm_pec));
+    Serial.println("\n");
+  } 
 }
 
 /*!*****************************************************************
@@ -1092,39 +1082,31 @@ void print_pwmconfig()
  LTC6810 to the serial port.
   @return void
  *******************************************************************/
-void print_rxpwmconfig()
+void print_rxpwm(void)
 {
   Serial.println(F("Received pwm Configuration:"));
   for (uint8_t current_ic=0; current_ic<TOTAL_IC; current_ic++)
   {
     Serial.print(F("IC "));
     Serial.print(current_ic+1,DEC);
-    Serial.print(F(": 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[5]);
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+     serial_print_hex(BMS_IC[current_ic].pwm.rx_data[i]);
+    }
     Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[6]);
+    serial_print_hex(BMS_IC[current_ic].pwm.rx_data[6]);
     Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[7]);
-    Serial.println();
+    serial_print_hex(BMS_IC[current_ic].pwm.rx_data[7]);
+    Serial.println("\n");
   }
-  Serial.println();
 }
 
 /*!****************************************************************************
   /prints data which is written on COMM register onto the serial port
    @return void
  *****************************************************************************/
-void print_comm()
+void print_wrcomm(void)
 {
   int comm_pec;
 
@@ -1133,66 +1115,51 @@ void print_comm()
   {
     Serial.print(F(" IC- "));
     Serial.print(current_ic+1,DEC);
-    Serial.print(F(": "));
-    Serial.print(F("0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[5]);
+    
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].com.tx_data[i]);
+    }
     Serial.print(F(", Calculated PEC: 0x"));
-    comm_pec = pec15_calc(6,&bms_ic[current_ic].com.tx_data[0]);
+    comm_pec = pec15_calc(6,&BMS_IC[current_ic].com.tx_data[0]);
     serial_print_hex((uint8_t)(comm_pec>>8));
     Serial.print(F(", 0x"));
     serial_print_hex((uint8_t)(comm_pec));
-    Serial.println();
+    Serial.println("\n");
   }
-  Serial.println();
 }
 
 /*!****************************************************************************
   \brief Prints received data from COMM register onto the serial port
    @return void
  *****************************************************************************/
-void print_rxcomm()
+void print_rxcomm(void)
 {
   Serial.println(F("Received Data in COMM register:"));
   for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
   {
-    Serial.print(F(" IC "));
+    Serial.print(F(" IC- "));
     Serial.print(current_ic+1,DEC);
-    Serial.print(F(": 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[5]);
+    
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].com.rx_data[i]);
+    }
     Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[6]);
+    serial_print_hex(BMS_IC[current_ic].com.rx_data[6]);
     Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[7]);
-    Serial.println();
+    serial_print_hex(BMS_IC[current_ic].com.rx_data[7]);
+    Serial.println("\n");
   }
-  Serial.println();
 }
 
 /*!******************************************************************************
  \brief Prints Serial ID to the serial port.
   @return void
  ********************************************************************************/
-void print_sid()
+void print_sid(void)
 {
   int sid_pec;
 
@@ -1201,58 +1168,62 @@ void print_sid()
   {
     Serial.print(F("IC "));
     Serial.print(current_ic+1,DEC);
-    Serial.print(F(": "));
-    Serial.print(F("0x"));
-    serial_print_hex(bms_ic[current_ic].sid[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sid[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sid[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sid[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sid[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sid[5]);
+    
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].sid[i]);
+    }
     Serial.print(F(", Calculated PEC: 0x"));
-    sid_pec = pec15_calc(6,&bms_ic[current_ic].sid[0]);
+    sid_pec = pec15_calc(6,&BMS_IC[current_ic].sid[0]);
     serial_print_hex((uint8_t)(sid_pec>>8));
     Serial.print(F(", 0x"));
     serial_print_hex((uint8_t)(sid_pec));
-    Serial.println();
+    Serial.println("\n");
   }
-  Serial.println();
+}
+
+/*!****************************************************************
+  \brief Function to reverse the direction of ISOSPI communication
+  when the ICs are connected in daisy chain
+   @return void
+*******************************************************************/
+void reverse_isospi_direction(void)
+{ 
+  Serial.print(F("ISOSPI: "));
+  Serial.println(ISOSPI_DIR);
+  BMS_IC[0].isospi_reverse =(bool)(!( ISOSPI_DIR));
+  ISOSPI_DIR=BMS_IC[0].isospi_reverse;
+  Serial.print(F("Current ISOSPI Direction: "));
+  Serial.println(BMS_IC[0].isospi_reverse);
+  Serial.println("\n");
+}
+
+/*!****************************************************************
+  \brief Function to check the Mute bit in the Status Register
+   @return void
+*******************************************************************/
+void check_mute_bit(void)
+{ 
+  for (int current_ic = 0 ; current_ic < TOTAL_IC; current_ic++)
+  {
+    Serial.print(F(" Mute bit in Status Register B: 0x"));
+    serial_print_hex((BMS_IC[current_ic].stat.flags[1])&(0x10));
+    Serial.println("\n");
+  }
 }
 
 /*!****************************************************************************
-  \brief Function to print the number of PEC Errors
+  \brief Function to print the Conversion Time
   @return void
  *****************************************************************************/
-void print_pec()
+void print_conv_time(uint32_t conv_time)
 {
-  for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
-  {
-      Serial.println("");
-      Serial.print(bms_ic[current_ic].crc_count.pec_count,DEC);
-      Serial.print(F(" : PEC Errors Detected on IC"));
-      Serial.println(current_ic+1,DEC);
-  }
-  Serial.println();
-}
+  uint16_t m_factor=1000; // to print in ms
 
- /*!************************************************************
-  \brief Function to print in HEX form
-  @return void
- *************************************************************/ 
-void serial_print_hex(uint8_t data)
-{
-  if (data< 16)
-  {
-    Serial.print("0");
-    Serial.print((byte)data,HEX);
-  }
-  else
-    Serial.print((byte)data,HEX);
+  Serial.print(F("Conversion completed in:"));
+  Serial.print(((float)conv_time/m_factor), 1);
+  Serial.println(F("ms \n"));
 }
 
 /*!****************************************************************************
@@ -1265,6 +1236,30 @@ void check_error(int error)
   {
     Serial.println(F("A PEC error was detected in the received data"));
   }
+}
+
+/*!************************************************************
+  \brief Function to print text on serial monitor
+  @return void
+*************************************************************/ 
+void serial_print_text(char data[])
+{       
+  Serial.println(data);
+}
+
+/*!************************************************************
+  \brief Function to print in HEX form
+  @return void
+*************************************************************/ 
+void serial_print_hex(uint8_t data)
+{
+  if (data< 16)
+  {
+    Serial.print("0");
+    Serial.print((byte)data,HEX);
+  }
+  else
+    Serial.print((byte)data,HEX);
 }
 
 /*!************************************************************
@@ -1295,7 +1290,7 @@ char byte_to_hex_buffer[3]=
  \brief Read 2 hex characters from the serial buffer and convert them to a byte
  @return char data Read Data
  *****************************************************************************/
-char read_hex()
+char read_hex(void)
 {
   byte data;
   hex_to_byte_buffer[2]=get_char();
@@ -1310,8 +1305,9 @@ char read_hex()
  \brief Read a command from the serial port
  @return char 
  *************************************************************/
-char get_char()
+char get_char(void)
 {
+  // read a command from the serial port
   while (Serial.available() <= 0);
   return(Serial.read());
 }

--- a/LTSketchbook/Part Number/6000/6810/DC2515/DC2515.ino
+++ b/LTSketchbook/Part Number/6000/6810/DC2515/DC2515.ino
@@ -18,7 +18,7 @@
 *
 * https://www.analog.com/en/products/ltc6810-1.html
 *
-********************************************************************************
+*********************************************************************************
 * Copyright 2019(c) Analog Devices, Inc.
 *
 * All rights reserved.
@@ -51,7 +51,7 @@
 * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*******************************************************************************/
+********************************************************************************/
 
 /*! @file
     @ingroup LTC6810-1

--- a/LTSketchbook/Part Number/6000/6811/DC2259/DC2259.ino
+++ b/LTSketchbook/Part Number/6000/6811/DC2259/DC2259.ino
@@ -58,63 +58,67 @@
     @ingroup LTC6811-1
 */
 
-/*
-NOTES
- Setup:
-   Set the terminal baud rate to 115200 and select the newline terminator.
-   Ensure all jumpers on the demo board are installed in their default positions from the factory.
-   Refer to Demo Manual DC2259.
+/************************************* Read me *******************************************
+In this sketch book:
+  -All Global Variables are in Upper casing
+  -All Local Variables are in lower casing
+  -The Function wakeup_sleep(TOTAL_IC) : is used to wake the LTC681x from sleep state.
+   It is defined in LTC681x.cpp
+  -The Function wakeup_idle(TOTAL_IC) : is used to wake the ICs connected in daisy chain 
+   via the LTC6820 by initiating a dummy SPI communication. It is defined in LTC681x.cpp  
+*******************************************************************************************/
 
-USER INPUT DATA FORMAT:
- decimal : 1024
- hex     : 0x400
- octal   : 02000  (leading 0)
- binary  : B10000000000
- float   : 1024.0
- */
-
+/************************* Includes ***************************/
 #include <Arduino.h>
 #include <stdint.h>
+#include <SPI.h>
 #include "Linduino.h"
 #include "LT_SPI.h"
-#include "LT_I2C.h"           // Hardware I2C driver
+#include "LT_I2C.h"          
 #include "QuikEval_EEPROM.h"
-#include "UserInterface.h"   // serial interface routines to communicate with the user
+#include "UserInterface.h"   
 #include "LTC681x.h"
 #include "LTC6811.h"
-#include <SPI.h>
 
+/************************* Defines *****************************/
 #define ENABLED 1
 #define DISABLED 0
-
 #define DATALOG_ENABLED 1
 #define DATALOG_DISABLED 0
 
-void print_menu();
+/**************** Local Function Declaration *******************/
+void measurement_loop(uint8_t datalog_en);
+void print_menu(void);
+void print_wrconfig(void);
+void print_rxconfig(void);
 void print_cells(uint8_t datalog_en);
 void print_aux(uint8_t datalog_en);
-void print_stat();
-void print_open();
-void print_config();
-void print_rxconfig();
-void print_comm();
-void print_rxcomm();
-void print_pwmconfig();
-void print_rxpwmconfig();
-void print_sctrl();
-void print_rxsctrl(); 
-void print_statsoc();
-void print_aux1();
+void print_stat(void);
+void print_sumofcells(void);
+void check_mux_fail(void);
+void print_selftest_errors(uint8_t adc_reg ,int8_t error);
+void print_overlap_results(int8_t error);
+void print_digital_redundancy_errors(uint8_t adc_reg ,int8_t error);
+void print_open_wires(void);
+void print_pec_error_count(void);
+int8_t select_s_pin(void);
+void print_wrpwm(void);
+void print_rxpwm(void);
+void print_wrsctrl(void);
+void print_rxsctrl(void); 
+void print_wrcomm(void);
+void print_rxcomm(void);
+void print_conv_time(uint32_t conv_time);
 void check_error(int error);
-void print_pec();
+void serial_print_text(char data[]);
 void serial_print_hex(uint8_t data);
-char get_char();
+char read_hex(void);   
+char get_char(void);
 
-/**********************************************************
+/*******************************************************************
   Setup Variables
-  The following variables can be modified to
-  configure the software.
-***********************************************************/
+  The following variables can be modified to configure the software.
+********************************************************************/
 const uint8_t TOTAL_IC = 2;//!< Number of ICs in the daisy chain
 
 //ADC Command Configurations. See LTC681x.h for options.
@@ -124,7 +128,10 @@ const uint8_t ADC_DCP = DCP_ENABLED; //!< Discharge Permitted
 const uint8_t CELL_CH_TO_CONVERT = CELL_CH_ALL; //!< Channel Selection for ADC conversion
 const uint8_t AUX_CH_TO_CONVERT = AUX_CH_ALL; //!< Channel Selection for ADC conversion
 const uint8_t STAT_CH_TO_CONVERT = STAT_CH_ALL; //!< Channel Selection for ADC conversion
-const uint8_t NO_OF_REG = REG_ALL; //!< Register Selection
+const uint8_t SEL_ALL_REG = REG_ALL; //!< Register Selection 
+const uint8_t SEL_REG_A = REG_1; //!< Register Selection 
+const uint8_t SEL_REG_B = REG_2; //!< Register Selection 
+
 const uint16_t MEASUREMENT_LOOP_TIME = 500; //!< Loop Time in milliseconds(ms)
 
 //Under Voltage and Over Voltage Thresholds
@@ -132,12 +139,12 @@ const uint16_t OV_THRESHOLD = 41000; //!< Over voltage threshold ADC Code. LSB =
 const uint16_t UV_THRESHOLD = 30000; //!< Under voltage threshold ADC Code. LSB = 0.0001 ---(3V)
 
 //Loop Measurement Setup. These Variables are ENABLED or DISABLED. Remember ALL CAPS
-const uint8_t WRITE_CONFIG = DISABLED; //!< Loop Measurement Setup
-const uint8_t READ_CONFIG = DISABLED; //!< Loop Measurement Setup
-const uint8_t MEASURE_CELL = ENABLED; //!< Loop Measurement Setup
-const uint8_t MEASURE_AUX = DISABLED; //!< Loop Measurement Setup
-const uint8_t MEASURE_STAT = DISABLED; //!< Loop Measurement Setup
-const uint8_t PRINT_PEC = DISABLED; //!< Loop Measurement Setup
+const uint8_t WRITE_CONFIG = DISABLED;  //!< This is to ENABLED or DISABLED writing into to configuration registers in a continuous loop
+const uint8_t READ_CONFIG = DISABLED; //!< This is to ENABLED or DISABLED reading the configuration registers in a continuous loop
+const uint8_t MEASURE_CELL = ENABLED; //!< This is to ENABLED or DISABLED measuring the cell voltages in a continuous loop
+const uint8_t MEASURE_AUX = DISABLED; //!< This is to ENABLED or DISABLED reading the auxiliary registers in a continuous loop
+const uint8_t MEASURE_STAT = DISABLED; //!< This is to ENABLED or DISABLED reading the status registers in a continuous loop
+const uint8_t PRINT_PEC = DISABLED; //!< This is to ENABLED or DISABLED printing the PEC Error Count in a continuous loop
 /************************************
   END SETUP
 *************************************/
@@ -148,7 +155,7 @@ const uint8_t PRINT_PEC = DISABLED; //!< Loop Measurement Setup
  register reads and the array lengths must be based
  on the number of ICs on the stack
  ******************************************************/
-cell_asic bms_ic[TOTAL_IC]; //!< Global Battery Variable
+cell_asic BMS_IC[TOTAL_IC]; //!< Global Battery Variable
 
 /*********************************************************
  Set the configuration bits. 
@@ -156,11 +163,11 @@ cell_asic bms_ic[TOTAL_IC]; //!< Global Battery Variable
 **********************************************************/
 bool REFON = true; //!< Reference Powered Up Bit
 bool ADCOPT = false; //!< ADC Mode option bit
-bool gpioBits_a[5] = {false,false,false,false,false}; //!< GPIO Pin Control // Gpio 1,2,3,4,5
+bool GPIOBITS_A[5] = {false,false,true,true,true}; //!< GPIO Pin Control // Gpio 1,2,3,4,5
 uint16_t UV=UV_THRESHOLD; //!< Under-voltage Comparison Voltage
 uint16_t OV=OV_THRESHOLD; //!< Over-voltage Comparison Voltage
-bool dccBits_a[12] = {false,false,false,false,false,false,false,false,false,false,false,false}; //!< Discharge cell switch //Dcc 1,2,3,4,5,6,7,8,9,10,11,12
-bool dctoBits[4] = {true, false, true, false}; //!< Discharge time value // Dcto 0,1,2,3 // Programed for 4 min 
+bool DCCBITS_A[12] = {false,false,false,false,false,false,false,false,false,false,false,false}; //!< Discharge cell switch //Dcc 1,2,3,4,5,6,7,8,9,10,11,12
+bool DCTOBITS[4] = {true, false, true, false}; //!< Discharge time value // Dcto 0,1,2,3 // Programed for 4 min 
 /*Ensure that Dcto bits are set according to the required discharge time. Refer to the data sheet */
 
 /*!**********************************************************************
@@ -172,13 +179,13 @@ void setup()
   Serial.begin(115200);
   quikeval_SPI_connect();
   spi_enable(SPI_CLOCK_DIV16); // This will set the Linduino to have a 1MHz Clock
-  LTC6811_init_cfg(TOTAL_IC, bms_ic);
+  LTC6811_init_cfg(TOTAL_IC, BMS_IC);
   for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
   {
-    LTC6811_set_cfgr(current_ic,bms_ic,REFON,ADCOPT,gpioBits_a,dccBits_a, dctoBits, UV, OV);
+    LTC6811_set_cfgr(current_ic,BMS_IC,REFON,ADCOPT,GPIOBITS_A,DCCBITS_A, DCTOBITS, UV, OV);
   }
-  LTC6811_reset_crc_count(TOTAL_IC,bms_ic);
-  LTC6811_init_reg_limits(TOTAL_IC,bms_ic);
+  LTC6811_reset_crc_count(TOTAL_IC,BMS_IC);
+  LTC6811_init_reg_limits(TOTAL_IC,BMS_IC);
   print_menu();
 }
 
@@ -204,35 +211,32 @@ void loop()
   }
 }
 
-
 /*!*****************************************
  \brief Executes the user command
  @return void
 *******************************************/
 void run_command(uint32_t cmd)
 {
-  const uint8_t STREG=0;
+  uint8_t streg=0;
   int8_t error = 0;
   uint32_t conv_time = 0;
-  uint32_t user_command;
-  int8_t readIC=0;
-  char input = 0;
+  int8_t s_pin_read=0;
   
   switch (cmd)
   {
     case 1: // Write and Read Configuration Register
       wakeup_sleep(TOTAL_IC);
-      LTC6811_wrcfg(TOTAL_IC,bms_ic);
-      print_config();
+      LTC6811_wrcfg(TOTAL_IC,BMS_IC); // Write into Configuration Register
+      print_wrconfig();
       wakeup_idle(TOTAL_IC);
-      error = LTC6811_rdcfg(TOTAL_IC,bms_ic);
+      error = LTC6811_rdcfg(TOTAL_IC,BMS_IC); // Read Configuration Register
       check_error(error);
       print_rxconfig();
       break;
 
     case 2: // Read Configuration Register
       wakeup_sleep(TOTAL_IC);
-      error = LTC6811_rdcfg(TOTAL_IC,bms_ic);
+      error = LTC6811_rdcfg(TOTAL_IC,BMS_IC);
       check_error(error);
       print_rxconfig();
       break;
@@ -241,15 +245,12 @@ void run_command(uint32_t cmd)
       wakeup_sleep(TOTAL_IC);
       LTC6811_adcv(ADC_CONVERSION_MODE,ADC_DCP,CELL_CH_TO_CONVERT);
       conv_time = LTC6811_pollAdc();
-      Serial.print(F("Cell conversion completed in:"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       break;
 
     case 4: // Read Cell Voltage Registers
       wakeup_sleep(TOTAL_IC);
-      error = LTC6811_rdcv(NO_OF_REG, TOTAL_IC,bms_ic); // Set to read back all cell voltage registers
+      error = LTC6811_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC); // Set to read back all cell voltage registers
       check_error(error);
       print_cells(DATALOG_DISABLED);
       break;
@@ -258,15 +259,12 @@ void run_command(uint32_t cmd)
       wakeup_sleep(TOTAL_IC);
       LTC6811_adax(ADC_CONVERSION_MODE, AUX_CH_TO_CONVERT);
       conv_time = LTC6811_pollAdc();
-      Serial.print(F("Aux conversion completed in: "));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F(" ms"));    
-      Serial.println(); 
+      print_conv_time(conv_time); 
       break;
 
     case 6: // Read AUX Voltage Registers
       wakeup_sleep(TOTAL_IC);
-      error = LTC6811_rdaux(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all aux registers
+      error = LTC6811_rdaux(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all aux registers
       check_error(error);
       print_aux(DATALOG_DISABLED);
       break;
@@ -275,15 +273,12 @@ void run_command(uint32_t cmd)
       wakeup_sleep(TOTAL_IC);
       LTC6811_adstat(ADC_CONVERSION_MODE, STAT_CH_TO_CONVERT);
       conv_time=LTC6811_pollAdc();
-      Serial.print(F("Stat conversion completed in "));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F(" ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       break;
 
     case 8: // Read Status registers
       wakeup_sleep(TOTAL_IC);
-      error = LTC6811_rdstat(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all aux registers
+      error = LTC6811_rdstat(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all stat registers
       check_error(error);
       print_stat();
       break;
@@ -292,187 +287,182 @@ void run_command(uint32_t cmd)
       wakeup_sleep(TOTAL_IC);
       LTC6811_adcvax(ADC_CONVERSION_MODE,ADC_DCP);
       conv_time = LTC6811_pollAdc();
-      Serial.println(F("Start Combined Cell Voltage and GPIO1, GPIO2 conversion completed"));
-      Serial.print(F("conversion completed in:"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       wakeup_idle(TOTAL_IC);
-      error =LTC6811_rdcv(NO_OF_REG, TOTAL_IC,bms_ic); // Set to read back all cell voltage registers
+      error =LTC6811_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC); // Set to read back all cell voltage registers
       check_error(error);
       print_cells(DATALOG_DISABLED);     
       wakeup_idle(TOTAL_IC);
-      error = LTC6811_rdaux(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all aux registers
+      error = LTC6811_rdaux(SEL_REG_A,TOTAL_IC,BMS_IC); // Set to read back aux registers A
       check_error(error);
-      print_aux1(DATALOG_DISABLED);
-      Serial.println();
+      print_aux(DATALOG_DISABLED);
       break;
       
     case 10: //Start Combined Cell Voltage and Sum of cells
       wakeup_sleep(TOTAL_IC);
       LTC6811_adcvsc(ADC_CONVERSION_MODE,ADC_DCP);
       conv_time = LTC6811_pollAdc();
-      Serial.print(F("Combined Cell Voltage conversion completed in:"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       wakeup_idle(TOTAL_IC);
-      error = LTC6811_rdcv(NO_OF_REG, TOTAL_IC,bms_ic); // Set to read back all cell voltage registers
+      error = LTC6811_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC); // Set to read back all cell voltage registers
       check_error(error);
       print_cells(DATALOG_DISABLED);
       wakeup_idle(TOTAL_IC);
-      error = LTC6811_rdstat(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all stat registers
+      error = LTC6811_rdstat(SEL_REG_A,TOTAL_IC,BMS_IC); // Set to read stat registers A
       check_error(error);
-      print_statsoc();
-      Serial.println();
+      print_sumofcells();
       break;
       
-    case 11: // Loop Measurements without data-log output
-      Serial.println(F("transmit 'm' to quit"));
+    case 11: // Loop Measurements of configuration register or cell voltages or auxiliary register or status register without data-log output
       wakeup_sleep(TOTAL_IC);
-      LTC6811_wrcfg(TOTAL_IC,bms_ic);
-      while (input != 'm')
-      {
-        if (Serial.available() > 0)
-        {
-          input = read_char();
-        }
-
-        measurement_loop(DATALOG_DISABLED);
-
-        delay(MEASUREMENT_LOOP_TIME);
-      }
+      LTC6811_wrcfg(TOTAL_IC,BMS_IC);
+      measurement_loop(DATALOG_DISABLED);
       print_menu();
       break;
 
-    case 12: //Data-log print option Loop Measurements
-      Serial.println(F("transmit 'm' to quit"));
+    case 12: //Data-log print option Loop Measurements of configuration register or cell voltages or auxiliary register or status register
       wakeup_sleep(TOTAL_IC);
-      LTC6811_wrcfg(TOTAL_IC,bms_ic);
-      while (input != 'm')
-      {
-        if (Serial.available() > 0)
-        {
-          input = read_char();
-        }
-
-        measurement_loop(DATALOG_ENABLED);
-
-        delay(MEASUREMENT_LOOP_TIME);
-      }
+      LTC6811_wrcfg(TOTAL_IC,BMS_IC);
+      measurement_loop(DATALOG_ENABLED);
       print_menu();
       break;
 
-    case 13: // Run the Mux Decoder Self Test
+    case 13: // Clear all ADC measurement registers
+      wakeup_sleep(TOTAL_IC);
+      LTC6811_clrcell();
+      LTC6811_clraux();
+      LTC6811_clrstat();
+      wakeup_idle(TOTAL_IC);    
+      LTC6811_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC); // Read back all cell voltage registers
+      print_cells(DATALOG_DISABLED);
+
+      LTC6811_rdaux(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Read back all aux registers
+      print_aux(DATALOG_DISABLED);
+
+      LTC6811_rdstat(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Read back all stat 
+      print_stat();           
+      break;
+        
+    case 14: //Read CV,AUX and ADSTAT Voltages 
+      wakeup_sleep(TOTAL_IC);
+      LTC6811_adcv(ADC_CONVERSION_MODE,ADC_DCP,CELL_CH_TO_CONVERT);
+      conv_time = LTC6811_pollAdc();
+      print_conv_time(conv_time);
+      wakeup_idle(TOTAL_IC);      
+      error = LTC6811_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC); // Set to read back all cell voltage registers
+      check_error(error);
+      print_cells(DATALOG_DISABLED);
+
+      wakeup_sleep(TOTAL_IC);
+      LTC6811_adax(ADC_CONVERSION_MODE , AUX_CH_TO_CONVERT);
+      conv_time = LTC6811_pollAdc();
+      print_conv_time(conv_time);
+      wakeup_idle(TOTAL_IC); 
+      error = LTC6811_rdaux(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all aux registers
+      check_error(error);
+      print_aux(DATALOG_DISABLED);   
+
+      wakeup_sleep(TOTAL_IC);
+      LTC6811_adstat(ADC_CONVERSION_MODE, STAT_CH_TO_CONVERT);
+      conv_time = LTC6811_pollAdc();
+      print_conv_time(conv_time);
+      wakeup_idle(TOTAL_IC);
+      error = LTC6811_rdstat(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all status registers 
+      check_error(error);
+      print_stat();    
+      break;
+
+    case 15: // Run the Mux Decoder Self Test
       wakeup_sleep(TOTAL_IC);
       LTC6811_diagn();
       conv_time = LTC6811_pollAdc();
-      Serial.print(F("DIAGN  conversion completed in: "));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F(" ms"));    
-      Serial.println(); 
-      error = LTC6811_rdstat(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all aux registers
+      print_conv_time(conv_time); 
+      error = LTC6811_rdstat(SEL_REG_B,TOTAL_IC,BMS_IC); // Set to read back status register B
       check_error(error);
-      for (int ic = 0; ic<TOTAL_IC; ic++)
-        { error = 0;
-          Serial.print(" IC ");
-          Serial.println(ic+1,DEC);
-          if (bms_ic[ic].stat.mux_fail[0] != 0) error++;
-        
-          if (error==0) Serial.println(F("Mux Test: PASS "));
-          else Serial.println(F("Mux Test: FAIL "));
-        }
-      Serial.println("");  
+      check_mux_fail();
       break;
 
-    case 14:  // Run the ADC/Memory Self Test
+    case 16:  // Run the ADC/Memory Self Test
+      error =0;
       wakeup_sleep(TOTAL_IC);
-      error = LTC6811_run_cell_adc_st(CELL,TOTAL_IC,bms_ic, ADC_CONVERSION_MODE, ADCOPT);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in Digital Filter and CELL Memory \n"));
+      error = LTC6811_run_cell_adc_st(CELL,TOTAL_IC,BMS_IC, ADC_CONVERSION_MODE, ADCOPT);
+      print_selftest_errors(CELL, error);
+      
+      error =0;
+      wakeup_sleep(TOTAL_IC);
+      error = LTC6811_run_cell_adc_st(AUX,TOTAL_IC, BMS_IC, ADC_CONVERSION_MODE, ADCOPT);
+      print_selftest_errors(AUX, error);
 
+      error =0;
       wakeup_sleep(TOTAL_IC);
-      error = LTC6811_run_cell_adc_st(AUX,TOTAL_IC, bms_ic, ADC_CONVERSION_MODE, ADCOPT);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in Digital Filter and AUX Memory \n"));
-
-      wakeup_sleep(TOTAL_IC);
-      error = LTC6811_run_cell_adc_st(STAT,TOTAL_IC, bms_ic, ADC_CONVERSION_MODE, ADCOPT);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in Digital Filter and STAT Memory \n"));
+      error = LTC6811_run_cell_adc_st(STAT,TOTAL_IC, BMS_IC, ADC_CONVERSION_MODE, ADCOPT);
+      print_selftest_errors(STAT, error);
       print_menu();
       break;
       
-    case 15: // Run ADC Overlap self test
+    case 17: // Run ADC Overlap self test
+      error =0;
       wakeup_sleep(TOTAL_IC);
-      error = (int8_t)LTC6811_run_adc_overlap(TOTAL_IC,bms_ic);
-      if (error==0) Serial.println(F("Overlap Test: PASS "));
-      else Serial.println(F("Overlap Test: FAIL"));
-      Serial.println(); 
+      error = (int8_t)LTC6811_run_adc_overlap(TOTAL_IC,BMS_IC);
+      print_overlap_results(error);
       break;
 
-    case 16: // Run ADC Redundancy self test
+    case 18: // Run ADC Digital Redundancy self test
+      error =0;
       wakeup_sleep(TOTAL_IC);
-      error = LTC6811_run_adc_redundancy_st(ADC_CONVERSION_MODE,AUX,TOTAL_IC, bms_ic);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in AUX Measurement \n"));
+      error = LTC6811_run_adc_redundancy_st(ADC_CONVERSION_MODE,AUX,TOTAL_IC, BMS_IC);
+      print_digital_redundancy_errors(AUX, error);
 
+      error =0;
       wakeup_sleep(TOTAL_IC);
-      error = LTC6811_run_adc_redundancy_st(ADC_CONVERSION_MODE,STAT,TOTAL_IC, bms_ic);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in STAT Measurement \n"));
+      error = LTC6811_run_adc_redundancy_st(ADC_CONVERSION_MODE,STAT,TOTAL_IC, BMS_IC);
+      print_digital_redundancy_errors(STAT, error);
       break;
 
-    case 17: // Open Wire test for single cell detection
+    case 19: // Open Wire test for single cell detection
       wakeup_sleep(TOTAL_IC);         
-      LTC6811_run_openwire_single(TOTAL_IC, bms_ic);
-      print_open();
-      Serial.println();    
+      LTC6811_run_openwire_single(TOTAL_IC, BMS_IC);
+      print_open_wires();  
       break;
 
-    case 18: // Open Wire test for multiple cell and two consecutive cells detection
+    case 20: // Open Wire test for multiple cell and two consecutive cells detection
       wakeup_sleep(TOTAL_IC);         
-      LTC6811_run_openwire_multi(TOTAL_IC, bms_ic);
-      Serial.println();    
+      LTC6811_run_openwire_multi(TOTAL_IC, BMS_IC);  
       break;
 
-    case 19:// PEC Errors Detected
-      print_pec(); 
-      Serial.println();     
+    case 21:// PEC Errors Detected
+      print_pec_error_count();    
       break;
 
-    case 20: //Reset PEC Counter
-      LTC6811_reset_crc_count(TOTAL_IC,bms_ic);
-      Serial.println(F("PEC counter reset"));
-      Serial.println();
+    case 22: // Reset PEC Counter
+      LTC6811_reset_crc_count(TOTAL_IC,BMS_IC);
+      print_pec_error_count();
       break;
       
-    case 21: // Enable a discharge transistor
-      Serial.println(F("Please enter the Spin number:"));
-      readIC = (int8_t)read_int();
-      Serial.println(readIC);
+    case 23: // Enable a discharge transistor
+      s_pin_read = select_s_pin();
       wakeup_sleep(TOTAL_IC);
-      LTC6811_set_discharge(readIC,TOTAL_IC,bms_ic);
-      LTC6811_wrcfg(TOTAL_IC,bms_ic);   
-      print_config();
+      LTC6811_set_discharge(s_pin_read,TOTAL_IC,BMS_IC);
+      LTC6811_wrcfg(TOTAL_IC,BMS_IC);   
+      print_wrconfig();
       wakeup_idle(TOTAL_IC);
-      error = LTC6811_rdcfg(TOTAL_IC,bms_ic);
+      error = LTC6811_rdcfg(TOTAL_IC,BMS_IC);
       check_error(error);
       print_rxconfig();
       break;
       
-    case 22: // Clear all discharge transistors
+    case 24: // Clear all discharge transistors
       wakeup_sleep(TOTAL_IC);
-      LTC6811_clear_discharge(TOTAL_IC,bms_ic);
-      LTC6811_wrcfg(TOTAL_IC,bms_ic);    
-      print_config();
+      LTC6811_clear_discharge(TOTAL_IC,BMS_IC);
+      LTC6811_wrcfg(TOTAL_IC,BMS_IC);    
+      print_wrconfig();
       wakeup_idle(TOTAL_IC);
-      error = LTC6811_rdcfg(TOTAL_IC,bms_ic);
+      error = LTC6811_rdcfg(TOTAL_IC,BMS_IC);
       check_error(error);
       print_rxconfig();
       break;
 
-    case 23://Write read pwm configuration     
+    case 25:// Write read pwm configuration     
       /*****************************************************
          PWM configuration data.
          1)Set the corresponding DCC bit to one for pwm operation. 
@@ -484,22 +474,22 @@ void run_command(uint32_t cmd)
       wakeup_sleep(TOTAL_IC);
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        bms_ic[current_ic].pwm.tx_data[0]= 0x88; // Duty cycle for S pin 2 and 1
-        bms_ic[current_ic].pwm.tx_data[1]= 0x88; // Duty cycle for S pin 4 and 3
-        bms_ic[current_ic].pwm.tx_data[2]= 0x88; // Duty cycle for S pin 6 and 5
-        bms_ic[current_ic].pwm.tx_data[3]= 0x88; // Duty cycle for S pin 8 and 7
-        bms_ic[current_ic].pwm.tx_data[4]= 0x88; // Duty cycle for S pin 10 and 9
-        bms_ic[current_ic].pwm.tx_data[5]= 0x88; // Duty cycle for S pin 12 and 11
+        BMS_IC[current_ic].pwm.tx_data[0]= 0x88; // Duty cycle for S pin 2 and 1
+        BMS_IC[current_ic].pwm.tx_data[1]= 0x88; // Duty cycle for S pin 4 and 3
+        BMS_IC[current_ic].pwm.tx_data[2]= 0x88; // Duty cycle for S pin 6 and 5
+        BMS_IC[current_ic].pwm.tx_data[3]= 0x88; // Duty cycle for S pin 8 and 7
+        BMS_IC[current_ic].pwm.tx_data[4]= 0x88; // Duty cycle for S pin 10 and 9
+        BMS_IC[current_ic].pwm.tx_data[5]= 0x88; // Duty cycle for S pin 12 and 11
       }          
-      LTC6811_wrpwm(TOTAL_IC,0,bms_ic);
-      print_pwmconfig(); 
+      LTC6811_wrpwm(TOTAL_IC,0,BMS_IC);
+      print_wrpwm(); 
 
       wakeup_idle(TOTAL_IC);
-      LTC6811_rdpwm(TOTAL_IC,0,bms_ic);       
-      print_rxpwmconfig();                              
+      LTC6811_rdpwm(TOTAL_IC,0,BMS_IC);       
+      print_rxpwm();                              
       break;
 
-    case 24: // Write and read S Control Register Group
+    case 26: // Write and read S Control Register Group
       wakeup_sleep(TOTAL_IC);
       /**************************************************************************************
          S pin control. 
@@ -509,300 +499,255 @@ void run_command(uint32_t cmd)
       ***************************************************************************************/
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        bms_ic[current_ic].sctrl.tx_data[0]=0xFF; // No. of high pulses on S pin 2 and 1
-        bms_ic[current_ic].sctrl.tx_data[1]=0xFF; // No. of high pulses on S pin 4 and 3
-        bms_ic[current_ic].sctrl.tx_data[2]=0xFF; // No. of high pulses on S pin 6 and 5
-        bms_ic[current_ic].sctrl.tx_data[3]=0xFF; // No. of high pulses on S pin 8 and 7
-        bms_ic[current_ic].sctrl.tx_data[4]=0xFF; // No. of high pulses on S pin 10 and 9
-        bms_ic[current_ic].sctrl.tx_data[5]=0xFF; // No. of high pulses on S pin 12 and 11
+        BMS_IC[current_ic].sctrl.tx_data[0]=0xFF; // No. of high pulses on S pin 2 and 1
+        BMS_IC[current_ic].sctrl.tx_data[1]=0xFF; // No. of high pulses on S pin 4 and 3
+        BMS_IC[current_ic].sctrl.tx_data[2]=0xFF; // No. of high pulses on S pin 6 and 5
+        BMS_IC[current_ic].sctrl.tx_data[3]=0xFF; // No. of high pulses on S pin 8 and 7
+        BMS_IC[current_ic].sctrl.tx_data[4]=0xFF; // No. of high pulses on S pin 10 and 9
+        BMS_IC[current_ic].sctrl.tx_data[5]=0xFF; // No. of high pulses on S pin 12 and 11
       }
-      LTC6811_wrsctrl(TOTAL_IC,STREG,bms_ic);
-      print_sctrl();
+      LTC6811_wrsctrl(TOTAL_IC,streg,BMS_IC);
+      print_wrsctrl();
 
       // Start S Control pulsing
       wakeup_idle(TOTAL_IC);
       LTC6811_stsctrl();
-      LTC6811_pollAdc();
-      Serial.println(F("Start S Control Pulsing"));
-      Serial.println();
 
       // Read S Control Register Group 
       wakeup_idle(TOTAL_IC);
-      error=LTC6811_rdsctrl(TOTAL_IC,STREG,bms_ic);
+      error=LTC6811_rdsctrl(TOTAL_IC,streg,BMS_IC);
       check_error(error);
       print_rxsctrl();
       break;
 
-    case 25: // Clear S Control Register Group
+    case 27: // Clear S Control Register Group
       wakeup_sleep(TOTAL_IC);
       LTC6811_clrsctrl();
-      Serial.println(F("S Control Register Cleared"));
-      Serial.println(); 
       
-      // Read S Control Register Group
       wakeup_idle(TOTAL_IC);
-      error=LTC6811_rdsctrl(TOTAL_IC,STREG,bms_ic);
+      error=LTC6811_rdsctrl(TOTAL_IC,streg,BMS_IC); // Read S Control Register Group
       check_error(error);
       print_rxsctrl();
       break;
-
-    case 26://Start SPI Communication on the GPIO Ports
-      wakeup_sleep(TOTAL_IC);
-      /************************************************************
-         Communication control bits and communication data bytes. 
-         Refer to the data sheet. 
+      
+    case 28://SPI Communication 
+      /*************************************************************
+         Ensure to set the GPIO bits to 1 in the CFG register group. 
       *************************************************************/  
-       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
-      {                        
-        bms_ic[current_ic].com.tx_data[0]= 0x80;
-        bms_ic[current_ic].com.tx_data[1]= 0x00;
-        bms_ic[current_ic].com.tx_data[2]= 0xA2;
-        bms_ic[current_ic].com.tx_data[3]= 0x20;
-        bms_ic[current_ic].com.tx_data[4]= 0xA3;
-        bms_ic[current_ic].com.tx_data[5]= 0x39;
-      }    
-      LTC6811_wrcomm(TOTAL_IC,bms_ic);               
-      print_comm();   
-
-      wakeup_idle(TOTAL_IC);
-      LTC6811_stcomm(); 
-      LTC6811_pollAdc();           
-      Serial.println(F("Stcomm SPI Communication completed"));
-      Serial.println();  
-
-      wakeup_idle(TOTAL_IC);
-      error = LTC6811_rdcomm(TOTAL_IC,bms_ic);                       
-      check_error(error);
-      print_rxcomm();        
-      break;
-
-    case 27: // write byte I2C Communication on the GPIO Ports(using eeprom 24AA01)
-      wakeup_sleep(TOTAL_IC);
-      /************************************************************
-         Communication control bits and communication data bytes. 
-         Refer to the data sheet. 
-      *************************************************************/ 
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        bms_ic[current_ic].com.tx_data[0]= 0x6A; // Icom(6)Start + I2C_address D0 (1010 0000)
-        bms_ic[current_ic].com.tx_data[1]= 0x00; // Fcom master ack  
-        bms_ic[current_ic].com.tx_data[2]= 0x00; // eeprom address D1 (0000 0000)
-        bms_ic[current_ic].com.tx_data[3]= 0x00; // Fcom master ack 
-        bms_ic[current_ic].com.tx_data[4]= 0x01; // Icom BLANCK D2 (0Xxx)
-        bms_ic[current_ic].com.tx_data[5]= 0x29; // Fcom master nack+stop 
-      }             
-             
-      LTC6811_wrcomm(TOTAL_IC,bms_ic);// write comm register    
-      print_comm();
+        //Communication control bits and communication data bytes. Refer to the data sheet.
+        BMS_IC[current_ic].com.tx_data[0]= 0x81; // Icom CSBM Low(8) + data D0 (0x11)
+        BMS_IC[current_ic].com.tx_data[1]= 0x10; // Fcom CSBM Low(0) 
+        BMS_IC[current_ic].com.tx_data[2]= 0xA2; // Icom CSBM Falling Edge (A) +  D1 (0x25)
+        BMS_IC[current_ic].com.tx_data[3]= 0x50; // Fcom CSBM Low(0)    
+        BMS_IC[current_ic].com.tx_data[4]= 0xA1; // Icom CSBM Falling Edge (A) +  D2 (0x17)
+        BMS_IC[current_ic].com.tx_data[5]= 0x79; // Fcom CSBM High(9)
+      }
+      wakeup_sleep(TOTAL_IC);   
+      LTC6811_wrcomm(TOTAL_IC,BMS_IC); // write to comm register                 
+      print_wrcomm(); // print data in the comm register
 
-      wakeup_idle(TOTAL_IC); 
-      LTC6811_stcomm();// start I2C to write data into slave device
-      LTC6811_pollAdc();
-      Serial.println(F("Stcomm I2C Communication completed"));
-      Serial.println(); 
-    
-      wakeup_idle(TOTAL_IC); 
-      error = LTC6811_rdcomm(TOTAL_IC,bms_ic); // Read comm register                       
-      check_error(error);
-      print_rxcomm(); // Print comm register  
-      break;
-      
-    case 28: // Read byte data I2C Communication on the GPIO Ports(using eeprom 24AA01)
-      wakeup_sleep(TOTAL_IC);
-      /************************************************************
-         Communication control bits and communication data bytes. 
-         Refer to the data sheet. 
-        *************************************************************/         
-      for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
-      {        
-        bms_ic[current_ic].com.tx_data[0]= 0x6A; // Icom(6)Start + I2C_address D0 (1010 0000)
-        bms_ic[current_ic].com.tx_data[1]= 0x10; // Fcom master ack 
-        bms_ic[current_ic].com.tx_data[2]= 0x60; // again start I2C with I2C_address (1010 0001)
-        bms_ic[current_ic].com.tx_data[3]= 0x19; // fcom master nack + stop  
-      }            
-      LTC6811_wrcomm(TOTAL_IC,bms_ic);
-
-      wakeup_idle(TOTAL_IC); 
-      LTC6811_stcomm();// I2C for write data in slave device 
-      LTC6811_pollAdc();   
-      Serial.println(F("I2C Communication completed"));
-      Serial.println(); 
-
-      wakeup_idle(TOTAL_IC); 
-      error = LTC6811_rdcomm(TOTAL_IC,bms_ic); // Read comm register                 
-      check_error(error);
-      print_rxcomm(); // Print comm register   
-      break;      
-
-    case 29: // Clear all ADC measurement registers
-      wakeup_sleep(TOTAL_IC);
-      LTC6811_clrcell();
-      LTC6811_clraux();
-      LTC6811_clrstat();
-      Serial.println(F("All Registers Cleared"));
-      wakeup_sleep(TOTAL_IC);
-      error = LTC6811_rdcv(NO_OF_REG, TOTAL_IC,bms_ic); // read back all cell voltage registers
-      check_error(error);
-      print_cells(DATALOG_DISABLED);
-
-      error = LTC6811_rdaux(NO_OF_REG,TOTAL_IC,bms_ic); // read back all aux registers
-      check_error(error);
-      print_aux(DATALOG_DISABLED);
-
-      error = LTC6811_rdstat(NO_OF_REG,TOTAL_IC,bms_ic); // read back all stat 
-      check_error(error);
-      print_stat();           
-      break;
-        
-    case 30: //Read CV,AUX and ADSTAT Voltages 
-      wakeup_sleep(TOTAL_IC);
-      LTC6811_adcv(ADC_CONVERSION_MODE,ADC_DCP,CELL_CH_TO_CONVERT);
-      conv_time = LTC6811_pollAdc();
-      Serial.print(F("cell conversion completed in: "));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F(" ms"));
-      Serial.println();
-      wakeup_idle(TOTAL_IC);      
-      error = LTC6811_rdcv(NO_OF_REG, TOTAL_IC,bms_ic); // Set to read back all cell voltage registers
-      check_error(error);
-      print_cells(DATALOG_DISABLED);
-
-      wakeup_sleep(TOTAL_IC);
-      LTC6811_adax(ADC_CONVERSION_MODE , AUX_CH_TO_CONVERT);
-      conv_time = LTC6811_pollAdc();
-      Serial.print(F("Aux conversion completed in: "));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F(" ms"));    
-      Serial.println();
-      wakeup_idle(TOTAL_IC); 
-      error = LTC6811_rdaux(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all aux registers
-      check_error(error);
-      print_aux(DATALOG_DISABLED);   
-
-      wakeup_sleep(TOTAL_IC);
-      LTC6811_adstat(ADC_CONVERSION_MODE, STAT_CH_TO_CONVERT);
-      conv_time = LTC6811_pollAdc();
-      Serial.print(F("Stat conversion completed in "));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F(" ms"));
-      Serial.println();
       wakeup_idle(TOTAL_IC);
-      error = LTC6811_rdstat(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all stat 
+      LTC6811_stcomm(3); // data length=3 // initiates communication between master and the I2C slave
+
+      wakeup_idle(TOTAL_IC);
+      error = LTC6811_rdcomm(TOTAL_IC,BMS_IC); // read from comm register                       
       check_error(error);
-      print_stat();    
+      print_rxcomm();  // print received data into the comm register
       break;
+
+  case 29: // write byte I2C Communication on the GPIO Ports(using I2C eeprom 24LC025)
+       /************************************************************
+         Ensure to set the GPIO bits to 1 in the CFG register group. 
+      *************************************************************/   
+      for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
+      {
+        //Communication control bits and communication data bytes. Refer to the data sheet.
+        BMS_IC[current_ic].com.tx_data[0]= 0x6A; // Icom Start(6) + I2C_address D0 (0xA0)
+        BMS_IC[current_ic].com.tx_data[1]= 0x08; // Fcom master NACK(8)  
+        BMS_IC[current_ic].com.tx_data[2]= 0x00; // Icom Blank (0) + eeprom address D1 (0x00)
+        BMS_IC[current_ic].com.tx_data[3]= 0x08; // Fcom master NACK(8)   
+        BMS_IC[current_ic].com.tx_data[4]= 0x01; // Icom Blank (0) + data D2 (0x11)
+        BMS_IC[current_ic].com.tx_data[5]= 0x19; // Fcom master NACK + Stop(9) 
+      }
+      wakeup_sleep(TOTAL_IC);       
+      LTC6811_wrcomm(TOTAL_IC,BMS_IC); // write to comm register    
+      print_wrcomm(); // print transmitted data from the comm register
+
+      wakeup_idle(TOTAL_IC);
+      LTC6811_stcomm(3); // data length=3 // initiates communication between master and the I2C slave
+
+      wakeup_idle(TOTAL_IC);
+      error = LTC6811_rdcomm(TOTAL_IC,BMS_IC); // read from comm register                       
+      check_error(error);
+      print_rxcomm(); // print received data into the comm register  
+      break; 
+
+    case 30: // Read byte data I2C Communication on the GPIO Ports(using I2C eeprom 24LC025)
+      /************************************************************
+         Ensure to set the GPIO bits to 1 in the CFG register group.  
+      *************************************************************/     
+      for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
+      {
+        //Communication control bits and communication data bytes. Refer to the data sheet.        
+        BMS_IC[current_ic].com.tx_data[0]= 0x6A; // Icom Start (6) + I2C_address D0 (A0) (Write operation to set the word address)
+        BMS_IC[current_ic].com.tx_data[1]= 0x08; // Fcom master NACK(8)  
+        BMS_IC[current_ic].com.tx_data[2]= 0x00; // Icom Blank (0) + eeprom address(word address) D1 (0x00)
+        BMS_IC[current_ic].com.tx_data[3]= 0x08; // Fcom master NACK(8)
+        BMS_IC[current_ic].com.tx_data[4]= 0x6A; // Icom Start (6) + I2C_address D2 (0xA1)(Read operation)
+        BMS_IC[current_ic].com.tx_data[5]= 0x18; // Fcom master NACK(8)  
+      }
+      wakeup_sleep(TOTAL_IC);         
+      LTC6811_wrcomm(TOTAL_IC,BMS_IC); // write to comm register 
+
+      wakeup_idle(TOTAL_IC);
+      LTC6811_stcomm(3); // data length=3 // initiates communication between master and the I2C slave 
+
+      for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
+      { 
+        //Communication control bits and communication data bytes. Refer to the data sheet.       
+        BMS_IC[current_ic].com.tx_data[0]= 0x0F; // Icom Blank (0) + data D0 (FF)
+        BMS_IC[current_ic].com.tx_data[1]= 0xF9; // Fcom master NACK + Stop(9) 
+        BMS_IC[current_ic].com.tx_data[2]= 0x7F; // Icom No Transmit (7) + data D1 (FF)
+        BMS_IC[current_ic].com.tx_data[3]= 0xF9; // Fcom master NACK + Stop(9)
+        BMS_IC[current_ic].com.tx_data[4]= 0x7F; // Icom No Transmit (7) + data D2 (FF)
+        BMS_IC[current_ic].com.tx_data[5]= 0xF9; // Fcom master NACK + Stop(9) 
+      }  
+
+      wakeup_idle(TOTAL_IC);
+      LTC6811_wrcomm(TOTAL_IC,BMS_IC); // write to comm register
+
+      wakeup_idle(TOTAL_IC);
+      LTC6811_stcomm(1); // data length=1 // initiates communication between master and the I2C slave  
+
+      wakeup_idle(TOTAL_IC);
+      error = LTC6811_rdcomm(TOTAL_IC,BMS_IC); // read from comm register                
+      check_error(error);
+      print_rxcomm(); // print received data from the comm register    
+      break;    
 
     case 31: // Set or reset the gpio pins(to drive output on gpio pins)
       /***********************************************************************
        Please ensure you have set the GPIO bits according to your requirement 
-       in the configuration register.( check the global variable gpioBits_a )
+       in the configuration register.( check the global variable GPIOBITS_A )
       ************************************************************************/   
       wakeup_sleep(TOTAL_IC);
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        LTC6811_set_cfgr(current_ic,bms_ic,REFON,ADCOPT,gpioBits_a,dccBits_a, dctoBits, UV, OV);
+        LTC6811_set_cfgr(current_ic,BMS_IC,REFON,ADCOPT,GPIOBITS_A,DCCBITS_A, DCTOBITS, UV, OV);
       } 
       wakeup_idle(TOTAL_IC);
-      LTC6811_wrcfg(TOTAL_IC,bms_ic);
-      print_config();
+      LTC6811_wrcfg(TOTAL_IC,BMS_IC);
+      print_wrconfig();
       break;
-	  
-	  case 'm': //prints menu
+    
+    case 'm': //prints menu
       print_menu();
       break;
 
     default:
-      Serial.println(F("Incorrect Option"));
-      Serial.println();
+      char str_error[]="Incorrect Option \n";
+      serial_print_text(str_error);
       break;
   }
 }
 
-/*!*********************************
-  \brief For Loop Measurement
+/*!**********************************************************************************************************************************************
+ \brief For writing/reading configuration data or measuring cell voltages or reading aux register or reading status register in a continuous loop  
  @return void
-***********************************/
+*************************************************************************************************************************************************/
 void measurement_loop(uint8_t datalog_en)
 {
   int8_t error = 0;
-  if (WRITE_CONFIG == ENABLED)
+  char input = 0;
+  
+  Serial.println(F("Transmit 'm' to quit"));
+  
+  while (input != 'm')
   {
-    wakeup_sleep(TOTAL_IC);
-    LTC6811_wrcfg(TOTAL_IC,bms_ic);
-    print_config();
+     if (Serial.available() > 0)
+      {
+        input = read_char();
+      } 
+    if (WRITE_CONFIG == ENABLED)
+    {
+      wakeup_sleep(TOTAL_IC);
+      LTC6811_wrcfg(TOTAL_IC,BMS_IC);
+      print_wrconfig();
+    }
+  
+    if (READ_CONFIG == ENABLED)
+    {
+      wakeup_sleep(TOTAL_IC);
+      error = LTC6811_rdcfg(TOTAL_IC,BMS_IC);
+      check_error(error);
+      print_rxconfig();
+    }
+  
+    if (MEASURE_CELL == ENABLED)
+    {
+      wakeup_idle(TOTAL_IC);
+      LTC6811_adcv(ADC_CONVERSION_MODE,ADC_DCP,CELL_CH_TO_CONVERT);
+      LTC6811_pollAdc();
+      wakeup_idle(TOTAL_IC);
+      error = LTC6811_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC);
+      check_error(error);
+      print_cells(datalog_en);
+    }
+  
+    if (MEASURE_AUX == ENABLED)
+    {
+      wakeup_idle(TOTAL_IC);
+      LTC6811_adax(ADC_CONVERSION_MODE , AUX_CH_ALL);
+      LTC6811_pollAdc();
+      wakeup_idle(TOTAL_IC);
+      error = LTC6811_rdaux(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all aux registers
+      check_error(error);
+      print_aux(datalog_en);
+    }
+  
+    if (MEASURE_STAT == ENABLED)
+    {
+      wakeup_idle(TOTAL_IC);
+      LTC6811_adstat(ADC_CONVERSION_MODE, STAT_CH_ALL);
+      LTC6811_pollAdc();
+      wakeup_idle(TOTAL_IC);
+      error = LTC6811_rdstat(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all aux registers
+      check_error(error);
+      print_stat();
+    }
+  
+    if (PRINT_PEC == ENABLED)
+    {
+      print_pec_error_count();
+    }
+
+    delay(MEASUREMENT_LOOP_TIME);
   }
-
-  if (READ_CONFIG == ENABLED)
-  {
-    wakeup_sleep(TOTAL_IC);
-    error = LTC6811_rdcfg(TOTAL_IC,bms_ic);
-    check_error(error);
-    print_rxconfig();
-  }
-
-  if (MEASURE_CELL == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    LTC6811_adcv(ADC_CONVERSION_MODE,ADC_DCP,CELL_CH_TO_CONVERT);
-    LTC6811_pollAdc();
-    wakeup_idle(TOTAL_IC);
-    error = LTC6811_rdcv(NO_OF_REG, TOTAL_IC,bms_ic);
-    check_error(error);
-    print_cells(datalog_en);
-
-  }
-
-  if (MEASURE_AUX == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    LTC6811_adax(ADC_CONVERSION_MODE , AUX_CH_ALL);
-    LTC6811_pollAdc();
-    wakeup_idle(TOTAL_IC);
-    error = LTC6811_rdaux(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all aux registers
-    check_error(error);
-    print_aux(datalog_en);
-  }
-
-  if (MEASURE_STAT == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    LTC6811_adstat(ADC_CONVERSION_MODE, STAT_CH_ALL);
-    LTC6811_pollAdc();
-    wakeup_idle(TOTAL_IC);
-    error = LTC6811_rdstat(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all aux registers
-    check_error(error);
-    print_stat();
-  }
-
-  if (PRINT_PEC == ENABLED)
-  {
-    print_pec();
-  }
-
 }
 
 /*!*********************************
   \brief Prints the main menu
  @return void
 ***********************************/
-void print_menu()
+void print_menu(void)
 {
-  Serial.println(F("List of Commands: "));
-  Serial.println(F("Write and Read Configuration: 1                             |Loop measurements with data-log output: 12                             |Write and Read of PWM: 23  "));
-  Serial.println(F("Read Configuration: 2                                       |Run Mux Self Test: 13                                                  |Write and  Read of S control: 24 "));
-  Serial.println(F("Start Cell Voltage Conversion: 3                            |Run ADC Self Test: 14                                                  |Clear S control register: 25 "));
-  Serial.println(F("Read Cell Voltages: 4                                       |ADC overlap Test : 15                                                  |SPI Communication: 26 "));
-  Serial.println(F("Start Aux Voltage Conversion: 5                             |Run Digital Redundancy Test: 16                                        |I2C Communication Write to Slave: 27"));
-  Serial.println(F("Read Aux Voltages: 6                                        |Open Wire Test for single cell detection: 17                           |I2C Communication Read from Slave:28"));
-  Serial.println(F("Start Stat Voltage Conversion: 7                            |Open Wire Test for multiple cell or two consecutive cells detection:18 |Clear Registers: 29"));
-  Serial.println(F("Read Stat Voltages: 8                                       |Print PEC Counter: 19                                                  |Read CV,AUX and ADSTAT Voltages:30"));
-  Serial.println(F("Start Combined Cell Voltage and GPIO1, GPIO2 Conversion: 9  |Reset PEC Counter: 20                                                  |Set or Reset the GPIO pins: 31 "));
-  Serial.println(F("Start  Cell Voltage and Sum of cells : 10                   |Set Discharge: 21                                                      |"));
-  Serial.println(F("loop Measurements: 11                                       |Clear Discharge: 22                                                    |"));
-  Serial.println();
+  Serial.println(F("List of 6811 Commands: "));
+  Serial.println(F("Write and Read Configuration: 1                            |Loop measurements with data-log output: 12     |Set Discharge: 23"));                         
+  Serial.println(F("Read Configuration: 2                                      |Clear Registers: 13                            |Clear Discharge: 24"));
+  Serial.println(F("Start Cell Voltage Conversion: 3                           |Read CV,AUX and ADSTAT Voltages: 14            |Write and Read of PWM: 25"));                 
+  Serial.println(F("Read Cell Voltages: 4                                      |Run Mux Self Test: 15                          |Write and Read of S control: 26"));    
+  Serial.println(F("Start Aux Voltage Conversion: 5                            |Run ADC Self Test: 16                          |Clear S control register: 27")); 
+  Serial.println(F("Read Aux Voltages: 6                                       |ADC overlap Test : 17                          |SPI Communication: 28"));    
+  Serial.println(F("Start Stat Voltage Conversion: 7                           |Run Digital Redundancy Test: 18                |I2C Communication Write to Slave: 29"));             
+  Serial.println(F("Read Stat Voltages: 8                                      |Open Wire Test for single cell detection: 19   |I2C Communication Read from Slave:30"));                        
+  Serial.println(F("Start Combined Cell Voltage and GPIO1, GPIO2 Conversion: 9 |Open Wire Test for multiple cell detection: 20 |Set or Reset the GPIO pins: 31 ")); 
+  Serial.println(F("Start  Cell Voltage and Sum of cells : 10                  |Print PEC Counter: 21                          |"));
+  Serial.println(F("Loop Measurements: 11                                      |Reset PEC Counter: 22                          | \n "));
+  
   Serial.println(F("Print 'm' for menu"));
-  Serial.println(F("Please enter command: "));
-  Serial.println();
+  Serial.println(F("Please enter command: \n"));
 }
 
 /*!******************************************************************************
@@ -810,36 +755,27 @@ void print_menu()
  to the serial port.
  @return void
  ********************************************************************************/
-void print_config()
+void print_wrconfig(void)
 {
   int cfg_pec;
 
   Serial.println(F("Written Configuration: "));
   for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
   {
-    Serial.print(F(" IC "));
+    Serial.print(F("CFGA IC "));
     Serial.print(current_ic+1,DEC);
-    Serial.print(F(": "));
-    Serial.print(F("0x"));
-    serial_print_hex(bms_ic[current_ic].config.tx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].config.tx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].config.tx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].config.tx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].config.tx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].config.tx_data[5]);
+    for(int i = 0;i<6;i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].config.tx_data[i]);
+    }
     Serial.print(F(", Calculated PEC: 0x"));
-    cfg_pec = pec15_calc(6,&bms_ic[current_ic].config.tx_data[0]);
+    cfg_pec = pec15_calc(6,&BMS_IC[current_ic].config.tx_data[0]);
     serial_print_hex((uint8_t)(cfg_pec>>8));
     Serial.print(F(", 0x"));
     serial_print_hex((uint8_t)(cfg_pec));
-    Serial.println();
+    Serial.println("\n");
   }
-  Serial.println();
 }
 
 /*!*****************************************************************
@@ -847,32 +783,24 @@ void print_config()
  LTC6811 to the serial port.
   @return void
  *******************************************************************/
-void print_rxconfig()
+void print_rxconfig(void)
 {
-  Serial.println(F("Received Configuration: "));
+  Serial.println(F("Received Configuration "));
   for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
   {
-    Serial.print(F(" IC "));
+    Serial.print(F("CFGA IC "));
     Serial.print(current_ic+1,DEC);
-    Serial.print(F(": 0x"));
-    serial_print_hex(bms_ic[current_ic].config.rx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].config.rx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].config.rx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].config.rx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].config.rx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].config.rx_data[5]);
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].config.rx_data[i]);
+    }
     Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].config.rx_data[6]);
+    serial_print_hex(BMS_IC[current_ic].config.rx_data[6]);
     Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].config.rx_data[7]);
-    Serial.println();
+    serial_print_hex(BMS_IC[current_ic].config.rx_data[7]);
+    Serial.println("\n");
   }
-  Serial.println();
 }
 
 /*!************************************************************
@@ -881,37 +809,33 @@ void print_rxconfig()
  *************************************************************/
 void print_cells(uint8_t datalog_en)
 {
-   for (int current_ic = 0 ; current_ic < TOTAL_IC; current_ic++)
+  for (int current_ic = 0 ; current_ic < TOTAL_IC; current_ic++)
   {
     if (datalog_en == 0)
     {
       Serial.print(" IC ");
       Serial.print(current_ic+1,DEC);
-      Serial.print(": ");
-      for (int i=0; i<bms_ic[0].ic_reg.cell_channels; i++)
+      Serial.print(": ");      for (int i=0; i< BMS_IC[0].ic_reg.cell_channels; i++)
       {
-
         Serial.print(" C");
         Serial.print(i+1,DEC);
-        Serial.print(":");
-        Serial.print(bms_ic[current_ic].cells.c_codes[i]*0.0001,4);
+        Serial.print(":");        
+        Serial.print(BMS_IC[current_ic].cells.c_codes[i]*0.0001,4);
         Serial.print(",");
       }
       Serial.println();
     }
     else
     {
-      Serial.print("Cells ");
-      
-      for (int i=0; i<bms_ic[0].ic_reg.cell_channels; i++)
+      Serial.print(" Cells :");
+      for (int i=0; i<BMS_IC[0].ic_reg.cell_channels; i++)
       {
-        Serial.print(bms_ic[current_ic].cells.c_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].cells.c_codes[i]*0.0001,4);
         Serial.print(",");
       }
-
     }
   }
-  Serial.println();
+  Serial.println("\n");
 }
 
 /*!****************************************************************************
@@ -934,112 +858,78 @@ void print_aux(uint8_t datalog_en)
         Serial.print(F(" GPIO-"));
         Serial.print(i+1,DEC);
         Serial.print(":");
-        Serial.print(bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].aux.a_codes[i]*0.0001,4);
         Serial.print(",");
       }
       Serial.print(F(" Vref2"));
       Serial.print(":");
-      Serial.print(bms_ic[current_ic].aux.a_codes[5]*0.0001,4);
+      Serial.print(BMS_IC[current_ic].aux.a_codes[5]*0.0001,4);
       Serial.println();
     }
     else
     {
       Serial.print("AUX ");
-
-      for (int i=0; i < 6; i++)
-      {
-        Serial.print(bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
-        Serial.print(",");
-      }
-    }
-  }
-  Serial.println();
-}
-
-/*!****************************************************************************
-  \brief Prints GPIO voltage codes (GPIO 1 & 2)
- @return void
- *****************************************************************************/
-void print_aux1(uint8_t datalog_en)
-{
-  for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
-  {
-    if (datalog_en == 0)
-    {
       Serial.print(" IC ");
       Serial.print(current_ic+1,DEC);
-      Serial.print(F(": "));
-      for (int i=0; i < 2; i++)
-      {
-        Serial.print(F(" GPIO-"));
-        Serial.print(i+1,DEC);
-        Serial.print(":");
-        Serial.print(bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
-        Serial.print(",");
-      }
-    }
-    else
-    {
-      Serial.print("AUX ");
+      Serial.print(": ");
 
       for (int i=0; i < 6; i++)
       {
-        Serial.print(bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].aux.a_codes[i]*0.0001,4);
         Serial.print(",");
       }
     }
   }
-  Serial.println();
+  Serial.println("\n");
 }
 
 /*!****************************************************************************
   \brief Prints Status voltage codes and Vref2 voltage code onto the serial port
  @return void
  *****************************************************************************/
-void print_stat()
+void print_stat(void)
 {
-   double ITMP;
+   double itmp;
   for (uint8_t current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
   {
     Serial.print(F(" IC "));
     Serial.print(current_ic+1,DEC);
     Serial.print(F(": "));
     Serial.print(F(" SOC:"));
-    Serial.print(bms_ic[current_ic].stat.stat_codes[0]*0.0001*20,4);
+    Serial.print(BMS_IC[current_ic].stat.stat_codes[0]*0.0001*20,4);
     Serial.print(F(","));
     Serial.print(F(" Itemp:"));
-    ITMP = (double)((bms_ic[current_ic].stat.stat_codes[1] * (0.0001 / 0.0075)) - 273);   //Internal Die Temperature(°C) = ITMP • (100 µV / 7.5mV)°C - 273°C
-    Serial.print(ITMP,4);
+    itmp = (double)((BMS_IC[current_ic].stat.stat_codes[1] * (0.0001 / 0.0075)) - 273);   //Internal Die Temperature(°C) = itmp • (100 µV / 7.5mV)°C - 273°C
+    Serial.print(itmp,4);
     Serial.print(F(","));
     Serial.print(F(" VregA:"));
-    Serial.print(bms_ic[current_ic].stat.stat_codes[2]*0.0001,4);
+    Serial.print(BMS_IC[current_ic].stat.stat_codes[2]*0.0001,4);
     Serial.print(F(","));
     Serial.print(F(" VregD:"));
-    Serial.print(bms_ic[current_ic].stat.stat_codes[3]*0.0001,4);
+    Serial.print(BMS_IC[current_ic].stat.stat_codes[3]*0.0001,4);
     Serial.println();
     Serial.print(F(" Flags:"));
     Serial.print(F(" 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.flags[0]);
+    serial_print_hex(BMS_IC[current_ic].stat.flags[0]);
     Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.flags[1]);
+    serial_print_hex(BMS_IC[current_ic].stat.flags[1]);
     Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.flags[2]);
+    serial_print_hex(BMS_IC[current_ic].stat.flags[2]);
     Serial.print(F("   Mux fail flag:"));
     Serial.print(F(" 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.mux_fail[0]);
+    serial_print_hex(BMS_IC[current_ic].stat.mux_fail[0]);
     Serial.print(F("   THSD:"));
     Serial.print(F(" 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.thsd[0]);
-    Serial.println();  
-}
-  Serial.println();
+    serial_print_hex(BMS_IC[current_ic].stat.thsd[0]);
+    Serial.println("\n");  
+  }
 }
 
 /*!****************************************************************************
   \brief Prints Status voltage codes for SOC onto the serial port
  @return void
  *****************************************************************************/
-void print_statsoc()
+void print_sumofcells(void)
 {
  for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
   {
@@ -1047,34 +937,133 @@ void print_statsoc()
     Serial.print(current_ic+1,DEC);
     Serial.print(F(": "));
     Serial.print(F(" SOC:"));
-    Serial.print(bms_ic[current_ic].stat.stat_codes[0]*0.0001*20,4);
+    Serial.print(BMS_IC[current_ic].stat.stat_codes[0]*0.0001*20,4);
     Serial.print(F(","));
   }
-  Serial.println();
+  Serial.println("\n");
+}
+
+/*!****************************************************************
+  \brief Function to check the MUX fail bit in the Status Register
+   @return void
+*******************************************************************/
+void check_mux_fail(void)
+{ 
+  int8_t error = 0;
+  for (int ic = 0; ic<TOTAL_IC; ic++)
+    { 
+      Serial.print(" IC ");
+      Serial.println(ic+1,DEC);
+      if (BMS_IC[ic].stat.mux_fail[0] != 0) error++;
+    
+      if (error==0) Serial.println(F("Mux Test: PASS \n"));
+      else Serial.println(F("Mux Test: FAIL \n"));
+    }
+}
+
+/*!************************************************************
+  \brief Prints Errors Detected during self test
+   @return void
+*************************************************************/
+void print_selftest_errors(uint8_t adc_reg ,int8_t error)
+{
+  if(adc_reg==1)
+  {
+    Serial.println("Cell ");
+    }
+  else if(adc_reg==2)
+  {
+    Serial.println("Aux ");
+    }
+  else if(adc_reg==3)
+  {
+    Serial.println("Stat ");
+    }
+  Serial.print(error, DEC);
+  Serial.println(F(" : errors detected in Digital Filter and Memory \n"));
+}
+
+/*!************************************************************
+  \brief Prints the output of  the ADC overlap test  
+   @return void
+*************************************************************/
+void print_overlap_results(int8_t error)
+{
+  if (error==0) Serial.println(F("Overlap Test: PASS \n"));
+  else Serial.println(F("Overlap Test: FAIL \n"));
+}
+
+/*!************************************************************
+  \brief Prints Errors Detected during Digital Redundancy test
+   @return void
+*************************************************************/
+void print_digital_redundancy_errors(uint8_t adc_reg ,int8_t error)
+{
+  if(adc_reg==2)
+  {
+    Serial.println("Aux ");
+    }
+  else if(adc_reg==3)
+  {
+    Serial.println("Stat ");
+    }
+
+  Serial.print(error, DEC);
+  Serial.println(F(" : errors detected in Measurement \n"));
 }
 
 /*****************************************************************************
   \brief Prints Open wire test results to the serial port
   @return void
  *****************************************************************************/
-void print_open()
+void print_open_wires(void)
 {
   for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
   {
-    if (bms_ic[current_ic].system_open_wire == 65535)
+    if (BMS_IC[current_ic].system_open_wire == 65535)
     {
       Serial.print("No Opens Detected on IC ");
-      Serial.print(current_ic+1, DEC);
-      Serial.println();
+      Serial.println(current_ic+1, DEC);
     }
     else
     {
       Serial.print(F("There is an open wire on IC "));
       Serial.print(current_ic + 1,DEC);
       Serial.print(F(" Channel: "));
-      Serial.println(bms_ic[current_ic].system_open_wire);
+      Serial.println(BMS_IC[current_ic].system_open_wire);
     }
+    Serial.println("\n");
   }
+}
+
+/*!************************************************************
+  \brief Prints the PEC errors detected to the serial port
+  @return void
+ *************************************************************/ 
+void print_pec_error_count(void)
+{
+  for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.println("");
+    Serial.print(BMS_IC[current_ic].crc_count.pec_count,DEC);
+    Serial.print(F(" : PEC Errors Detected on IC"));
+    Serial.println(current_ic+1,DEC);
+  }
+  Serial.println("\n");
+}
+
+/*!****************************************************
+  \brief Function to select the S pin for discharge
+  @return void
+ ******************************************************/
+int8_t select_s_pin(void)
+{
+  int8_t read_s_pin=0;
+  
+  Serial.print(F("Please enter the Spin number: "));
+  read_s_pin = (int8_t)read_int();
+  Serial.println(read_s_pin);
+  return(read_s_pin);
 }
 
 /*!******************************************************************************
@@ -1082,36 +1071,27 @@ void print_open()
  to the serial port.
   @return void
  ********************************************************************************/
-void print_pwmconfig()
+void print_wrpwm(void)
 {
-  int cfg_pec;
+  int pwm_pec;
 
   Serial.println(F("Written PWM Configuration: "));
   for (uint8_t current_ic = 0; current_ic<TOTAL_IC; current_ic++)
   {
     Serial.print(F("IC "));
     Serial.print(current_ic+1,DEC);
-    Serial.print(F(": "));
-    Serial.print(F("0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[5]);
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+     serial_print_hex(BMS_IC[current_ic].pwm.tx_data[i]);
+    }
     Serial.print(F(", Calculated PEC: 0x"));
-    cfg_pec = pec15_calc(6,&bms_ic[current_ic].pwm.tx_data[0]);
-    serial_print_hex((uint8_t)(cfg_pec>>8));
+    pwm_pec = pec15_calc(6,&BMS_IC[current_ic].pwm.tx_data[0]);
+    serial_print_hex((uint8_t)(pwm_pec>>8));
     Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(cfg_pec));
-    Serial.println();
-  }
-  Serial.println();
+    serial_print_hex((uint8_t)(pwm_pec));
+    Serial.println("\n");
+  } 
 }
 
 /*!*****************************************************************
@@ -1119,136 +1099,53 @@ void print_pwmconfig()
  LTC6811 to the serial port.
  @return void
  *******************************************************************/
-void print_rxpwmconfig()
+void print_rxpwm(void)
 {
-  Serial.println(F("Received PWM Configuration:"));
+  Serial.println(F("Received pwm Configuration:"));
   for (uint8_t current_ic=0; current_ic<TOTAL_IC; current_ic++)
   {
     Serial.print(F("IC "));
     Serial.print(current_ic+1,DEC);
-    Serial.print(F(": 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[5]);
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+     serial_print_hex(BMS_IC[current_ic].pwm.rx_data[i]);
+    }
     Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[6]);
+    serial_print_hex(BMS_IC[current_ic].pwm.rx_data[6]);
     Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[7]);
-    Serial.println();
+    serial_print_hex(BMS_IC[current_ic].pwm.rx_data[7]);
+    Serial.println("\n");
   }
-  Serial.println();
-}
-
-/*!************************************************************
-  \brief Prints comm register data to the serial port
-  @return void
- *************************************************************/ 
-void print_comm()
-{
-  uint8_t comm_pec;
-  Serial.println(F("Written Data in COMM Register: "));
-  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC "));
-    Serial.print(current_ic+1,DEC);
-    Serial.print(F(": "));
-    Serial.print(F("0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[5]);
-    Serial.print(F(", Calculated PEC: 0x"));
-    comm_pec = pec15_calc(6,&bms_ic[current_ic].com.tx_data[0]);
-    serial_print_hex((uint8_t)(comm_pec>>8));
-    Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(comm_pec));
-    Serial.println();
-  }
-  Serial.println();
-}
-
-/*!************************************************************
-  \brief Prints comm register data that was read back from the
- LTC6811 to the serial port. 
- @return void
- *************************************************************/
-void print_rxcomm()
-{
-  Serial.println(F("Received Data:"));
-  for (uint8_t current_ic=0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC "));
-    Serial.print(current_ic+1,DEC);
-    Serial.print(F(": 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[5]);
-    Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[6]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[7]);
-    Serial.println();
-  }
-  Serial.println();
 }
 
 /*!************************************************************
   \brief Prints S control register data to the serial port
   @return void
  *************************************************************/ 
-void print_sctrl()
+void print_wrsctrl(void)
 {
-  int sctrl_pec;
+   int sctrl_pec;
 
-  Serial.println(F("Written Data in sctrl register: "));
+  Serial.println(F("Written Data in Sctrl register: "));
   for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
   {
-    Serial.print(F(" IC "));
+    Serial.print(F(" IC: "));
     Serial.print(current_ic+1,DEC);
-    Serial.print(F(": "));
-    Serial.print(F("0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[5]);
+    Serial.print(F(" Sctrl register group:"));
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].sctrl.tx_data[i]);
+    }
+    
     Serial.print(F(", Calculated PEC: 0x"));
-    sctrl_pec = pec15_calc(6,&bms_ic[current_ic].sctrl.tx_data[0]);
+    sctrl_pec = pec15_calc(6,&BMS_IC[current_ic].sctrl.tx_data[0]);
     serial_print_hex((uint8_t)(sctrl_pec>>8));
     Serial.print(F(", 0x"));
     serial_print_hex((uint8_t)(sctrl_pec));
-    Serial.println();
+    Serial.println("\n");
   }
-  Serial.println();
 }
 
 /*!************************************************************
@@ -1256,47 +1153,93 @@ void print_sctrl()
  LTC6811 to the serial port.
 @return void
  *************************************************************/
-void print_rxsctrl()
+void print_rxsctrl(void)
 {
   Serial.println(F("Received Data:"));
   for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
   {
     Serial.print(F(" IC "));
     Serial.print(current_ic+1,DEC);
-    Serial.print(F(": 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[0]);
+    
+    for(int i = 0; i < 6; i++)
+    {
     Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[5]);
+    serial_print_hex(BMS_IC[current_ic].sctrl.rx_data[i]);
+    }
+    
     Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[6]);
+    serial_print_hex(BMS_IC[current_ic].sctrl.rx_data[6]);
     Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[7]);
-    Serial.println();
+    serial_print_hex(BMS_IC[current_ic].sctrl.rx_data[7]);
+    Serial.println("\n");
   }
-  Serial.println();
 }
 
 /*!************************************************************
-  \brief Prints the PEC errors detected to the serial port
+  \brief Prints comm register data to the serial port
   @return void
  *************************************************************/ 
-void print_pec()
+void print_wrcomm(void)
 {
+  int comm_pec;
+
+  Serial.println(F("Written Data in COMM Register: "));
+  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.print(F(" IC- "));
+    Serial.print(current_ic+1,DEC);
+    
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].com.tx_data[i]);
+    }
+    Serial.print(F(", Calculated PEC: 0x"));
+    comm_pec = pec15_calc(6,&BMS_IC[current_ic].com.tx_data[0]);
+    serial_print_hex((uint8_t)(comm_pec>>8));
+    Serial.print(F(", 0x"));
+    serial_print_hex((uint8_t)(comm_pec));
+    Serial.println("\n");
+  }
+}
+
+/*!************************************************************
+  \brief Prints comm register data that was read back from the
+ LTC6811 to the serial port. 
+ @return void
+ *************************************************************/
+void print_rxcomm(void)
+{
+  Serial.println(F("Received Data in COMM register:"));
   for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
   {
-    Serial.println("");
-    Serial.print(bms_ic[current_ic].crc_count.pec_count,DEC);
-    Serial.print(F(" : PEC Errors Detected on IC"));
-    Serial.println(current_ic+1,DEC);
+    Serial.print(F(" IC- "));
+    Serial.print(current_ic+1,DEC);
+    
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].com.rx_data[i]);
+    }
+    Serial.print(F(", Received PEC: 0x"));
+    serial_print_hex(BMS_IC[current_ic].com.rx_data[6]);
+    Serial.print(F(", 0x"));
+    serial_print_hex(BMS_IC[current_ic].com.rx_data[7]);
+    Serial.println("\n");
   }
+}
+
+/*!****************************************************************************
+  \brief Function to print the Conversion Time
+  @return void
+ *****************************************************************************/
+void print_conv_time(uint32_t conv_time)
+{
+  uint16_t m_factor=1000;  // to print in ms
+
+  Serial.print(F("Conversion completed in:"));
+  Serial.print(((float)conv_time/m_factor), 1);
+  Serial.println(F("ms \n"));
 }
 
 /*!************************************************************
@@ -1309,6 +1252,15 @@ void check_error(int error)
   {
     Serial.println(F("A PEC error was detected in the received data"));
   }
+}
+
+/*!************************************************************
+  \brief Function to print text on serial monitor
+  @return void
+*************************************************************/ 
+void serial_print_text(char data[])
+{       
+  Serial.println(data);
 }
 
 /*!************************************************************
@@ -1354,7 +1306,7 @@ char byte_to_hex_buffer[3]=
  \brief Read 2 hex characters from the serial buffer and convert them to a byte
  @return char data Read Data
  *************************************************************/
-char read_hex()    
+char read_hex(void)    
 {
   byte data;
   hex_to_byte_buffer[2]=get_char();
@@ -1369,9 +1321,8 @@ char read_hex()
  \brief Read a command from the serial port
  @return char 
  *************************************************************/
-char get_char()
+char get_char(void)
 {
-
   while (Serial.available() <= 0);
   return(Serial.read());
 }

--- a/LTSketchbook/Part Number/6000/6812/DC2350AA/DC2350AA.ino
+++ b/LTSketchbook/Part Number/6000/6812/DC2350AA/DC2350AA.ino
@@ -59,61 +59,73 @@
     @ingroup LTC6812-1
 */
 
-/*
-NOTES
- Setup:
-   Set the terminal baud rate to 115200 and select the newline terminator.
-   Ensure all jumpers on the demo board are installed in their default positions from the factory.
-   Refer to Demo Manual DC2259.
+/************************************* Read me *******************************************
+In this sketch book:
+  -All Global Variables are in Upper casing
+  -All Local Variables are in lower casing
+  -The Function wakeup_sleep(TOTAL_IC) : is used to wake the LTC681x from sleep state.
+   It is defined in LTC681x.cpp
+  -The Function wakeup_idle(TOTAL_IC) : is used to wake the ICs connected in daisy chain 
+   via the LTC6820 by initiating a dummy SPI communication. It is defined in LTC681x.cpp 
+*******************************************************************************************/
 
-USER INPUT DATA FORMAT:
- decimal : 1024
- hex     : 0x400
- octal   : 02000  (leading 0)
- binary  : B10000000000
- float   : 1024.0
- */
- 
+/************************* Includes ***************************/
 #include <Arduino.h>
 #include <stdint.h>
+#include <SPI.h>
 #include "Linduino.h"
 #include "LT_SPI.h"
 #include "UserInterface.h"
 #include "LTC681x.h"
 #include "LTC6812.h"
-#include <SPI.h>
 
+/************************* Defines *****************************/
 #define ENABLED 1
 #define DISABLED 0
-
 #define DATALOG_ENABLED 1
 #define DATALOG_DISABLED 0
+#define PWM 1
+#define SCTL 2
 
-void print_menu();
-void print_config();
-void print_rxconfig();
+/**************** Local Function Declaration *******************/
+void measurement_loop(uint8_t datalog_en);
+void print_menu(void);
+void print_wrconfig(void);
+void print_wrconfigb(void);
+void print_rxconfig(void);
+void print_rxconfigb(void);
 void print_cells(uint8_t datalog_en);
-void print_open();
 void print_aux(uint8_t datalog_en);
-void print_stat();
+void print_stat(void);
+void print_aux1(void);
+void print_sumofcells(void);
+void check_mux_fail(void);
+void print_selftest_errors(uint8_t adc_reg ,int8_t error);
+void print_overlap_results(int8_t error);
+void print_digital_redundancy_errors(uint8_t adc_reg ,int8_t error);
+void print_open_wires(void);
+void print_pec_error_count(void);
+int8_t select_s_pin(void);
+void print_wrpwm(void);
+void print_rxpwm(void);
+void print_wrsctrl(void);
+void print_rxsctrl(void);
+void print_wrpsb(uint8_t type);
+void print_rxpsb(uint8_t type);
+void print_wrcomm(void);
+void print_rxcomm(void);
+void check_mute_bit(void);
+void print_conv_time(uint32_t conv_time);
 void check_error(int error);
-void print_pec();
+void serial_print_text(char data[]);
 void serial_print_hex(uint8_t data);
-void print_statsoc();
-void print_aux1();
-void print_comm();
-void print_rxcomm();
-void print_pwm();
-void print_rxpwm();
-void print_sctrl();
-void print_rxsctrl();
-char get_char();
+char read_hex(void); 
+char get_char(void);
 
-/**********************************************************
+/*******************************************************************
   Setup Variables
-  The following variables can be modified to
-  configure the software.
-***********************************************************/
+  The following variables can be modified to configure the software.
+********************************************************************/
 const uint8_t TOTAL_IC = 2; //!< Number of ICs in the daisy chain
 
 //ADC Command Configurations. See LTC681x.h for options.
@@ -123,7 +135,9 @@ const uint8_t ADC_DCP = DCP_DISABLED; //!< Discharge Permitted
 const uint8_t CELL_CH_TO_CONVERT = CELL_CH_ALL; //!< Channel Selection for ADC conversion
 const uint8_t AUX_CH_TO_CONVERT = AUX_CH_ALL;  //!< Channel Selection for ADC conversion
 const uint8_t STAT_CH_TO_CONVERT = STAT_CH_ALL;  //!< Channel Selection for ADC conversion
-const uint8_t NO_OF_REG = REG_ALL; //!< Register Selection
+const uint8_t SEL_ALL_REG = REG_ALL; //!< Register Selection 
+const uint8_t SEL_REG_A = REG_1; //!< Register Selection 
+const uint8_t SEL_REG_B = REG_2; //!< Register Selection 
 
 const uint16_t MEASUREMENT_LOOP_TIME = 500; //!< Loop Time in milliseconds(ms)
 
@@ -132,12 +146,12 @@ const uint16_t OV_THRESHOLD = 41000; //!< Over voltage threshold ADC Code. LSB =
 const uint16_t UV_THRESHOLD = 30000; //!< Under voltage threshold ADC Code. LSB = 0.0001 ---(3V)
 
 //Loop Measurement Setup. These Variables are ENABLED or DISABLED. Remember ALL CAPS
-const uint8_t WRITE_CONFIG = DISABLED; //!< Loop Measurement Setup
-const uint8_t READ_CONFIG = DISABLED; //!< Loop Measurement Setup
-const uint8_t MEASURE_CELL = ENABLED; //!< Loop Measurement Setup
-const uint8_t MEASURE_AUX = DISABLED; //!< Loop Measurement Setup
-const uint8_t MEASURE_STAT = DISABLED; //!< Loop Measurement Setup
-const uint8_t PRINT_PEC = DISABLED; //!< Loop Measurement Setup
+const uint8_t WRITE_CONFIG = DISABLED;  //!< This is to ENABLED or DISABLED writing into to configuration registers in a continuous loop
+const uint8_t READ_CONFIG = DISABLED; //!< This is to ENABLED or DISABLED reading the configuration registers in a continuous loop
+const uint8_t MEASURE_CELL = ENABLED; //!< This is to ENABLED or DISABLED measuring the cell voltages in a continuous loop
+const uint8_t MEASURE_AUX = DISABLED; //!< This is to ENABLED or DISABLED reading the auxiliary registers in a continuous loop
+const uint8_t MEASURE_STAT = DISABLED; //!< This is to ENABLED or DISABLED reading the status registers in a continuous loop
+const uint8_t PRINT_PEC = DISABLED; //!< This is to ENABLED or DISABLED printing the PEC Error Count in a continuous loop
 /************************************
   END SETUP
 *************************************/
@@ -148,25 +162,24 @@ const uint8_t PRINT_PEC = DISABLED; //!< Loop Measurement Setup
  register reads and the array lengths must be based
  on the number of ICs on the stack
  ******************************************************/
-
-cell_asic bms_ic[TOTAL_IC]; //!< Global Battery Variable
+cell_asic BMS_IC[TOTAL_IC]; //!< Global Battery Variable
 
 /*************************************************************************
  Set configuration register. Refer to the data sheet
 **************************************************************************/
 bool REFON = true; //!< Reference Powered Up Bit
 bool ADCOPT = false; //!< ADC Mode option bit
-bool gpioBits_a[5] = {false,false,false,false,false}; //!< GPIO Pin Control // Gpio 1,2,3,4,5
-bool gpioBits_b[4] = {false,false,false,false}; //!< GPIO Pin Control // Gpio 6,7,8,9
+bool GPIOBITS_A[5] = {false,false,true,true,true}; //!< GPIO Pin Control // Gpio 1,2,3,4,5
+bool GPIOBITS_B[4] = {false,false,false,false}; //!< GPIO Pin Control // Gpio 6,7,8,9
 uint16_t UV=UV_THRESHOLD; //!< Under voltage Comparison Voltage
 uint16_t OV=OV_THRESHOLD; //!< Over voltage Comparison Voltage
-bool dccBits_a[12] = {false,false,false,false,false,false,false,false,false,false,false,false}; //!< Discharge cell switch //Dcc 1,2,3,4,5,6,7,8,9,10,11,12
-bool dccBits_b[7]= {false,false,false,false}; //!< Discharge cell switch //Dcc 0,13,14,15
-bool dctoBits[4] = {true,false,true,false}; //!< Discharge time value //Dcto 0,1,2,3  // Programed for 4 min 
+bool DCCBITS_A[12] = {false,false,false,false,false,false,false,false,false,false,false,false}; //!< Discharge cell switch //Dcc 1,2,3,4,5,6,7,8,9,10,11,12
+bool DCCBITS_B[7]= {false,false,false,false}; //!< Discharge cell switch //Dcc 0,13,14,15
+bool DCTOBITS[4] = {true,false,true,false}; //!< Discharge time value //Dcto 0,1,2,3  // Programed for 4 min 
 /*Ensure that Dcto bits are set according to the required discharge time. Refer to the data sheet */
 bool FDRF = false; //!< Force Digital Redundancy Failure Bit
 bool DTMEN = true; //!< Enable Discharge Timer Monitor
-bool psBits[2]= {false,false}; //!< Digital Redundancy Path Selection//ps-0,1
+bool PSBits[2]= {false,false}; //!< Digital Redundancy Path Selection//ps-0,1
 
 /*!**********************************************************************
  \brief  Initializes hardware and variables
@@ -177,15 +190,15 @@ void setup()
   Serial.begin(115200);
   quikeval_SPI_connect();
   spi_enable(SPI_CLOCK_DIV16); // This will set the Linduino to have a 1MHz Clock
-  LTC6812_init_cfg(TOTAL_IC, bms_ic);
-  LTC6812_init_cfgb(TOTAL_IC,bms_ic);
+  LTC6812_init_cfg(TOTAL_IC, BMS_IC);
+  LTC6812_init_cfgb(TOTAL_IC,BMS_IC);
   for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
   {
-    LTC6812_set_cfgr(current_ic,bms_ic,REFON,ADCOPT,gpioBits_a,dccBits_a, dctoBits, UV, OV);
-    LTC6812_set_cfgrb(current_ic,bms_ic,FDRF,DTMEN,psBits,gpioBits_b,dccBits_b);   
+    LTC6812_set_cfgr(current_ic,BMS_IC,REFON,ADCOPT,GPIOBITS_A,DCCBITS_A, DCTOBITS, UV, OV);
+    LTC6812_set_cfgrb(current_ic,BMS_IC,FDRF,DTMEN,PSBits,GPIOBITS_B,DCCBITS_B);   
   }   
-  LTC6812_reset_crc_count(TOTAL_IC,bms_ic);
-  LTC6812_init_reg_limits(TOTAL_IC,bms_ic);
+  LTC6812_reset_crc_count(TOTAL_IC,BMS_IC);
+  LTC6812_init_reg_limits(TOTAL_IC,BMS_IC);
   print_menu();
 }
 
@@ -217,68 +230,63 @@ void loop()
 *******************************************/
 void run_command(uint32_t cmd)
 {
-  const uint8_t STREG=0;
+  uint8_t streg=0;
   int8_t error = 0;
   uint32_t conv_time = 0;
-  uint32_t user_command;
-  int8_t readIC=0;
-  char input = 0;
+  int8_t s_pin_read=0;
 
   switch (cmd)
   {
     case 1: // Write and read Configuration Register
       wakeup_sleep(TOTAL_IC);
-      LTC6812_wrcfg(TOTAL_IC,bms_ic); // Write into Configuration Register
-      LTC6812_wrcfgb(TOTAL_IC,bms_ic); // Write into Configuration Register B
-      print_config();
+      LTC6812_wrcfg(TOTAL_IC,BMS_IC); // Write into Configuration Register
+      LTC6812_wrcfgb(TOTAL_IC,BMS_IC); // Write into Configuration Register B
+      print_wrconfig();
+      print_wrconfigb();
 
       wakeup_idle(TOTAL_IC);
-      error = LTC6812_rdcfg(TOTAL_IC,bms_ic); // Read Configuration Register
+      error = LTC6812_rdcfg(TOTAL_IC,BMS_IC); // Read Configuration Register
       check_error(error);
-      error = LTC6812_rdcfgb(TOTAL_IC,bms_ic); // Read Configuration Register B
+      error = LTC6812_rdcfgb(TOTAL_IC,BMS_IC); // Read Configuration Register B
       check_error(error);
       print_rxconfig();
+      print_rxconfigb();
       break;
 
     case 2: // Read Configuration Register
       wakeup_sleep(TOTAL_IC);
-      error = LTC6812_rdcfg(TOTAL_IC,bms_ic);
+      error = LTC6812_rdcfg(TOTAL_IC,BMS_IC);
       check_error(error);
-      error = LTC6812_rdcfgb(TOTAL_IC,bms_ic);
+      error = LTC6812_rdcfgb(TOTAL_IC,BMS_IC);
       check_error(error);
       print_rxconfig();
+      print_rxconfigb();
       break;
 
     case 3: // Start Cell ADC Measurement
       wakeup_sleep(TOTAL_IC);
       LTC6812_adcv(ADC_CONVERSION_MODE,ADC_DCP,CELL_CH_TO_CONVERT);
       conv_time = LTC6812_pollAdc();
-      Serial.print(F("cell conversion completed in:"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       break;
 
     case 4: // Read Cell Voltage Registers
       wakeup_sleep(TOTAL_IC);
-      error = LTC6812_rdcv(NO_OF_REG, TOTAL_IC,bms_ic); // Set to read back all cell voltage registers
+      error = LTC6812_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC); // Set to read back all cell voltage registers
       check_error(error);
       print_cells(DATALOG_DISABLED);
       break;
 
     case 5: // Start GPIO ADC Measurement
       wakeup_sleep(TOTAL_IC);
-      LTC6812_adax(ADC_CONVERSION_MODE , AUX_CH_TO_CONVERT);
+      LTC6812_adax(ADC_CONVERSION_MODE, AUX_CH_TO_CONVERT);
       conv_time= LTC6812_pollAdc();
-      Serial.print(F("aux conversion completed in :"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       break;
 
     case 6: // Read AUX Voltage Registers
       wakeup_sleep(TOTAL_IC);
-      error = LTC6812_rdaux(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all aux registers
+      error = LTC6812_rdaux(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all aux registers
       check_error(error);
       print_aux(DATALOG_DISABLED);
       break;
@@ -287,15 +295,12 @@ void run_command(uint32_t cmd)
       wakeup_sleep(TOTAL_IC);
       LTC6812_adstat(ADC_CONVERSION_MODE, STAT_CH_TO_CONVERT);
       conv_time=LTC6812_pollAdc();
-      Serial.print(F("stat conversion completed in :"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       break;
 
     case 8: // Read Status registers
       wakeup_sleep(TOTAL_IC);
-      error = LTC6812_rdstat(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all aux registers
+      error = LTC6812_rdstat(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all stat registers
       check_error(error);
       print_stat();
       break;
@@ -304,190 +309,164 @@ void run_command(uint32_t cmd)
       wakeup_sleep(TOTAL_IC);
       LTC6812_adcvax(ADC_CONVERSION_MODE,ADC_DCP);
       conv_time = LTC6812_pollAdc();
-      Serial.println(F("Start Combined Cell Voltage and GPIO1, GPIO2 conversion completed"));
-      Serial.print(F("conversion completed in:"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       wakeup_idle(TOTAL_IC);
-      error = LTC6812_rdcv(NO_OF_REG, TOTAL_IC,bms_ic); // Set to read back all cell voltage registers
+      error = LTC6812_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC); // Set to read back all cell voltage registers
       check_error(error);
       print_cells(DATALOG_DISABLED);
       wakeup_idle(TOTAL_IC);
-      error = LTC6812_rdaux(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all aux registers
+      error = LTC6812_rdaux(SEL_REG_A, TOTAL_IC,BMS_IC); // Set to read back aux register A
       check_error(error);
       print_aux1(DATALOG_DISABLED);
-      Serial.println();
       break;
 
-    case 10 : //Start Combined Cell Voltage and Sum of cells
+    case 10 : // Start Combined Cell Voltage and Sum of cells
       wakeup_sleep(TOTAL_IC);
       LTC6812_adcvsc(ADC_CONVERSION_MODE,ADC_DCP);
       conv_time = LTC6812_pollAdc();
-      Serial.print(F("Combined Cell Voltage conversion completed in:"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       wakeup_idle(TOTAL_IC);
-      error = LTC6812_rdcv(NO_OF_REG, TOTAL_IC,bms_ic); // Set to read back all cell voltage registers
+      error = LTC6812_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC); // Set to read back all cell voltage registers
       check_error(error);
       print_cells(DATALOG_DISABLED);
       wakeup_idle(TOTAL_IC);
-      error = LTC6812_rdstat(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all stat registers
+      error = LTC6812_rdstat(SEL_REG_A,TOTAL_IC,BMS_IC); // Set to read back stat register A
       check_error(error);
-      print_statsoc();
-      Serial.println();
+      print_sumofcells();
       break;
 
-    case 11: // Loop Measurements with out data-log output
-      Serial.println(F("transmit 'm' to quit"));
+    case 11: // Loop Measurements of configuration register or cell voltages or auxiliary register or status register without data-log output
       wakeup_sleep(TOTAL_IC);
-      LTC6812_wrcfg(TOTAL_IC,bms_ic);
-      LTC6812_wrcfgb(TOTAL_IC,bms_ic);
-      while (input != 'm')
-      {
-        if (Serial.available() > 0)
-        {
-          input = read_char();
-        }
-
-        measurement_loop(DATALOG_DISABLED);
-
-        delay(MEASUREMENT_LOOP_TIME);
-      }
+      LTC6812_wrcfg(TOTAL_IC,BMS_IC);
+      LTC6812_wrcfgb(TOTAL_IC,BMS_IC);
+      measurement_loop(DATALOG_DISABLED);
       print_menu();
       break;
 
-    case 12: //Data-log print option Loop Measurements
-      Serial.println(F("transmit 'm' to quit"));
+    case 12: // Data-log print option Loop Measurements of configuration register or cell voltages or auxiliary register or status register
       wakeup_sleep(TOTAL_IC);
-      LTC6812_wrcfg(TOTAL_IC,bms_ic);
-      LTC6812_wrcfgb(TOTAL_IC,bms_ic);
-      while (input != 'm')
-      {
-        if (Serial.available() > 0)
-        {
-          input = read_char();
-        }
-
-        measurement_loop(DATALOG_ENABLED);
-
-        delay(MEASUREMENT_LOOP_TIME);
-      }
+      LTC6812_wrcfg(TOTAL_IC,BMS_IC);
+      LTC6812_wrcfgb(TOTAL_IC,BMS_IC);
+      measurement_loop(DATALOG_ENABLED);
       print_menu();
       break;
 
-    case 13: // Run the Mux Decoder Self Test
+    case 13: // Clear all ADC measurement registers
+      wakeup_sleep(TOTAL_IC);
+      LTC6812_clrcell();
+      LTC6812_clraux();
+      LTC6812_clrstat();
+      wakeup_idle(TOTAL_IC);
+      LTC6812_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC); // read back all cell voltage registers
+      print_cells(DATALOG_DISABLED);
+      LTC6812_rdaux(SEL_ALL_REG,TOTAL_IC,BMS_IC); // read back all auxiliary registers
+      print_aux(DATALOG_DISABLED);
+      LTC6812_rdstat(SEL_ALL_REG,TOTAL_IC,BMS_IC); // read back all status registers
+      print_stat();
+      break;
+
+    case 14: // Run the Mux Decoder Self Test
       wakeup_sleep(TOTAL_IC);
       LTC6812_diagn();
       LTC6812_pollAdc();
-      error = LTC6812_rdstat(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all aux registers
+      error = LTC6812_rdstat(SEL_REG_B,TOTAL_IC,BMS_IC); // Set to read back stat register B
       check_error(error);
-      for (int ic = 0; ic<TOTAL_IC; ic++)
-        { error = 0;
-          Serial.print(" IC ");
-          Serial.println(ic+1,DEC);
-          if (bms_ic[ic].stat.mux_fail[0] != 0) error++;
-        
-          if (error==0) Serial.println(F("Mux Test: PASS "));
-          else Serial.println(F("Mux Test: FAIL "));
-        }
-      Serial.println("");
+      check_mux_fail();
       break;
 
-    case 14:  // Run the ADC/Memory Self Test
+    case 15:  // Run the ADC/Memory Self Test
+      error = 0;
       wakeup_sleep(TOTAL_IC);
-      error = LTC6812_run_cell_adc_st(CELL,TOTAL_IC,bms_ic, ADC_CONVERSION_MODE,ADCOPT);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in Digital Filter and CELL Memory \n"));
-     
-      wakeup_sleep(TOTAL_IC);
-      error = LTC6812_run_cell_adc_st(AUX,TOTAL_IC, bms_ic, ADC_CONVERSION_MODE,ADCOPT);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in Digital Filter and AUX Memory \n"));
+      error = LTC6812_run_cell_adc_st(CELL,TOTAL_IC,BMS_IC, ADC_CONVERSION_MODE,ADCOPT);
+      print_selftest_errors(CELL, error);
 
+      error = 0;
       wakeup_sleep(TOTAL_IC);
-      error = LTC6812_run_cell_adc_st(STAT,TOTAL_IC, bms_ic, ADC_CONVERSION_MODE,ADCOPT);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in Digital Filter and STAT Memory \n"));
+      error = LTC6812_run_cell_adc_st(AUX,TOTAL_IC, BMS_IC, ADC_CONVERSION_MODE,ADCOPT);
+      print_selftest_errors(AUX, error);
+
+      error = 0;
+      wakeup_sleep(TOTAL_IC);
+      error = LTC6812_run_cell_adc_st(STAT,TOTAL_IC, BMS_IC, ADC_CONVERSION_MODE,ADCOPT);
+      print_selftest_errors(STAT, error);
       break;
 
-    case 15: // Run ADC Overlap self test
+    case 16: // Run ADC Overlap self test
       wakeup_sleep(TOTAL_IC);
-      error = (int8_t)LTC6812_run_adc_overlap(TOTAL_IC,bms_ic);
-      if (error==0) Serial.println(F("Overlap Test: PASS "));
-      else Serial.println(F("Overlap Test: FAIL"));
-      Serial.println();
+      error = (int8_t)LTC6812_run_adc_overlap(TOTAL_IC,BMS_IC);
+       print_overlap_results(error);
       break;
 
-    case 16: // Run ADC Digital Redundancy self test
+    case 17: // Run ADC Digital Redundancy self test
       wakeup_sleep(TOTAL_IC);
-      error = LTC6812_run_adc_redundancy_st(ADC_CONVERSION_MODE,AUX,TOTAL_IC, bms_ic);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in AUX Measurement \n"));
+      error = LTC6812_run_adc_redundancy_st(ADC_CONVERSION_MODE,AUX,TOTAL_IC, BMS_IC);
+      print_digital_redundancy_errors(AUX, error);
       
       wakeup_sleep(TOTAL_IC);
-      error = LTC6812_run_adc_redundancy_st(ADC_CONVERSION_MODE,STAT,TOTAL_IC, bms_ic);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in STAT Measurement \n"));
+      error = LTC6812_run_adc_redundancy_st(ADC_CONVERSION_MODE,STAT,TOTAL_IC, BMS_IC);
+      print_digital_redundancy_errors(STAT, error);
       break;
 
-    case 17: // Run open wire self test for single cell detection
+    case 18: // Run open wire self test for single cell detection
       wakeup_sleep(TOTAL_IC);
-      LTC6812_run_openwire_single(TOTAL_IC, bms_ic);
-      print_open();
-      Serial.println();   
+      LTC6812_run_openwire_single(TOTAL_IC, BMS_IC);
+      print_open_wires();  
       break;
 
-    case 18: // Run open wire self test for multiple cell and two consecutive cells detection
+    case 19: // Run open wire self test for multiple cell and two consecutive cells detection
       wakeup_sleep(TOTAL_IC);
-      LTC6812_run_openwire_multi(TOTAL_IC, bms_ic);
-      Serial.println();   
+      LTC6812_run_openwire_multi(TOTAL_IC, BMS_IC);  
       break;
+
+    case 20: // Open wire Diagnostic for Auxiliary Measurements
+      wakeup_sleep(TOTAL_IC);
+      LTC6812_run_gpio_openwire(TOTAL_IC, BMS_IC);
+      print_open_wires();
+      break;   
   
-    case 19: //print pec counter
-      print_pec();
-      Serial.println();
+    case 21: //print pec counter
+      print_pec_error_count();
       break;
     
-    case 20: // Reset pec counter
-      LTC6812_reset_crc_count(TOTAL_IC,bms_ic);
-      Serial.println("PEC Counters is Reset");
-      Serial.println();
+    case 22: // Reset pec counter
+      LTC6812_reset_crc_count(TOTAL_IC,BMS_IC);
+      print_pec_error_count();
       break;
 
-    case 21: // Enable a discharge transistor
-      Serial.println(F("Please enter the Spin number"));
-      readIC = (int8_t)read_int();
-      Serial.print(readIC);
+    case 23: // Enable a discharge transistor
+      s_pin_read = select_s_pin();
       wakeup_sleep(TOTAL_IC);
-      LTC6812_set_discharge(readIC,TOTAL_IC,bms_ic);
-      LTC6812_wrcfg(TOTAL_IC,bms_ic);
-      LTC6812_wrcfgb(TOTAL_IC,bms_ic);
-      print_config();
+      LTC6812_set_discharge(s_pin_read,TOTAL_IC,BMS_IC);
+      LTC6812_wrcfg(TOTAL_IC,BMS_IC);
+      LTC6812_wrcfgb(TOTAL_IC,BMS_IC);
+      print_wrconfig();
+      print_wrconfigb();
       wakeup_idle(TOTAL_IC);
-      error = LTC6812_rdcfg(TOTAL_IC,bms_ic);
+      error = LTC6812_rdcfg(TOTAL_IC,BMS_IC);
       check_error(error);
-      error = LTC6812_rdcfgb(TOTAL_IC,bms_ic);
+      error = LTC6812_rdcfgb(TOTAL_IC,BMS_IC);
       check_error(error);
       print_rxconfig();
+      print_rxconfigb();
       break;
 
-    case 22: // Clear all discharge transistors
+    case 24: // Clear all discharge transistors
       wakeup_sleep(TOTAL_IC);
-      LTC6812_clear_discharge(TOTAL_IC,bms_ic);
-      LTC6812_wrcfg(TOTAL_IC,bms_ic);
-      LTC6812_wrcfgb(TOTAL_IC,bms_ic);
-      print_config();
+      LTC6812_clear_discharge(TOTAL_IC,BMS_IC);
+      LTC6812_wrcfg(TOTAL_IC,BMS_IC);
+      LTC6812_wrcfgb(TOTAL_IC,BMS_IC);
+      print_wrconfig();
+      print_wrconfigb();
       wakeup_idle(TOTAL_IC);
-      error = LTC6812_rdcfg(TOTAL_IC,bms_ic);
+      error = LTC6812_rdcfg(TOTAL_IC,BMS_IC);
       check_error(error);
-      error = LTC6812_rdcfgb(TOTAL_IC,bms_ic);
+      error = LTC6812_rdcfgb(TOTAL_IC,BMS_IC);
       check_error(error);
       print_rxconfig();
+      print_rxconfigb();
       break;
 
-    case 23://Write read pwm configuration             
+    case 25:// Write read pwm configuration             
       /*****************************************************
          PWM configuration data.
          1)Set the corresponding DCC bit to one for pwm operation. 
@@ -500,36 +479,41 @@ void run_command(uint32_t cmd)
 
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        bms_ic[current_ic].pwm.tx_data[0]= 0x88; //Duty cycle for S pin 2 and 1
-        bms_ic[current_ic].pwm.tx_data[1]= 0x88; //Duty cycle for S pin 4 and 3
-        bms_ic[current_ic].pwm.tx_data[2]= 0x88; //Duty cycle for S pin 6 and 5
-        bms_ic[current_ic].pwm.tx_data[3]= 0x88; //Duty cycle for S pin 8 and 7
-        bms_ic[current_ic].pwm.tx_data[4]= 0x88; //Duty cycle for S pin 10 and 9
-        bms_ic[current_ic].pwm.tx_data[5]= 0x88; //Duty cycle for S pin 12 and 11
+        BMS_IC[current_ic].pwm.tx_data[0]= 0x88; //Duty cycle for S pin 2 and 1
+        BMS_IC[current_ic].pwm.tx_data[1]= 0x88; //Duty cycle for S pin 4 and 3
+        BMS_IC[current_ic].pwm.tx_data[2]= 0x88; //Duty cycle for S pin 6 and 5
+        BMS_IC[current_ic].pwm.tx_data[3]= 0x88; //Duty cycle for S pin 8 and 7
+        BMS_IC[current_ic].pwm.tx_data[4]= 0x88; //Duty cycle for S pin 10 and 9
+        BMS_IC[current_ic].pwm.tx_data[5]= 0x88; //Duty cycle for S pin 12 and 11
       }
                 
-      LTC6812_wrpwm(TOTAL_IC,0,bms_ic); //Write pwm configuration  
+      LTC6812_wrpwm(TOTAL_IC,0,BMS_IC); //Write pwm configuration  
 
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        bms_ic[current_ic].pwmb.tx_data[0]= 0x88; //Duty cycle for S pin 14 and 13
-        bms_ic[current_ic].pwmb.tx_data[1]= 0x08; //Duty cycle for S pin 15
-        bms_ic[current_ic].pwmb.tx_data[2]= 0x00;
+        BMS_IC[current_ic].pwmb.tx_data[0]= 0x88; //Duty cycle for S pin 14 and 13
+        BMS_IC[current_ic].pwmb.tx_data[1]= 0x08; //Duty cycle for S pin 15
+        BMS_IC[current_ic].pwmb.tx_data[2]= 0x00;
+        BMS_IC[current_ic].pwmb.tx_data[3]= 0x00;
+        BMS_IC[current_ic].pwmb.tx_data[4]= 0x00;
+        BMS_IC[current_ic].pwmb.tx_data[5]= 0x00;
       }
-   
-      LTC6812_wrpsb(TOTAL_IC,bms_ic); //  Write PWM/S control register  group B
-      print_pwm();
+      wakeup_idle(TOTAL_IC);
+      LTC6812_wrpsb(TOTAL_IC,BMS_IC); //  Write PWM/S control register  group B
+      print_wrpwm();
+      print_wrpsb(PWM);
 
       wakeup_idle(TOTAL_IC);
-      error=LTC6812_rdpwm(TOTAL_IC,0,bms_ic); // Read pwm configuration  
+      error=LTC6812_rdpwm(TOTAL_IC,0,BMS_IC); // Read pwm configuration  
       check_error(error);
       
-      error=LTC6812_rdpsb(TOTAL_IC,bms_ic); // Read PWM/S Control Register Group
+      error=LTC6812_rdpsb(TOTAL_IC,BMS_IC); // Read PWM/S Control Register Group
       check_error(error);        
-      print_rxpwm();                                
+      print_rxpwm(); 
+      print_rxpsb(PWM);                               
       break;
 
-    case 24: // Write and read S Control Register Group
+    case 26: // Write and read S Control Register Group
      /**************************************************************************************
          S pin control. 
          1)Ensure that the pwm is set according to the requirement using the previous case.
@@ -539,316 +523,308 @@ void run_command(uint32_t cmd)
       wakeup_sleep(TOTAL_IC);
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        bms_ic[current_ic].sctrl.tx_data[0]= 0xFF; // No. of high pulses on S pin 2 and 1
-        bms_ic[current_ic].sctrl.tx_data[1]= 0xFF; // No. of high pulses on S pin 4 and 3
-        bms_ic[current_ic].sctrl.tx_data[2]= 0xFF; // No. of high pulses on S pin 6 and 5
-        bms_ic[current_ic].sctrl.tx_data[3]= 0xFF; // No. of high pulses on S pin 8 and 7
-        bms_ic[current_ic].sctrl.tx_data[4]= 0xFF; // No. of high pulses on S pin 10 and 9
-        bms_ic[current_ic].sctrl.tx_data[5]= 0xFF; // No. of high pulses on S pin 12 and 11
+        BMS_IC[current_ic].sctrl.tx_data[0]= 0xFF; // No. of high pulses on S pin 2 and 1
+        BMS_IC[current_ic].sctrl.tx_data[1]= 0xFF; // No. of high pulses on S pin 4 and 3
+        BMS_IC[current_ic].sctrl.tx_data[2]= 0xFF; // No. of high pulses on S pin 6 and 5
+        BMS_IC[current_ic].sctrl.tx_data[3]= 0xFF; // No. of high pulses on S pin 8 and 7
+        BMS_IC[current_ic].sctrl.tx_data[4]= 0xFF; // No. of high pulses on S pin 10 and 9
+        BMS_IC[current_ic].sctrl.tx_data[5]= 0xFF; // No. of high pulses on S pin 12 and 11
       }
         
-      LTC6812_wrsctrl(TOTAL_IC,STREG,bms_ic);// Write S Control Register Group
+      LTC6812_wrsctrl(TOTAL_IC,streg,BMS_IC);// Write S Control Register Group
   
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        bms_ic[current_ic].sctrlb.tx_data[3]= 0xFF; // No. of high pulses on S pin 14 and 13
-        bms_ic[current_ic].sctrlb.tx_data[4]= 0x0F; // No. of high pulses on S pin 15
-        bms_ic[current_ic].sctrlb.tx_data[5]= 0x00;
+        BMS_IC[current_ic].sctrlb.tx_data[0]= 0x00;
+        BMS_IC[current_ic].sctrlb.tx_data[1]= 0x00;
+        BMS_IC[current_ic].sctrlb.tx_data[2]= 0x00;
+        BMS_IC[current_ic].sctrlb.tx_data[3]= 0xFF; // No. of high pulses on S pin 14 and 13
+        BMS_IC[current_ic].sctrlb.tx_data[4]= 0x0F; // No. of high pulses on S pin 15
+        BMS_IC[current_ic].sctrlb.tx_data[5]= 0x00;
       }
-  
-        LTC6812_wrpsb(TOTAL_IC,bms_ic); //  Write PWM/S contol register group B
-        print_sctrl();
-  
-        wakeup_idle(TOTAL_IC);
-        LTC6812_stsctrl(); // start S Control pulsing
-        LTC6812_pollAdc();
-        Serial.println(F("Start S Control Pulsing"));
-        Serial.println();
-  
-        wakeup_idle(TOTAL_IC);
-        error=LTC6812_rdsctrl(TOTAL_IC,STREG,bms_ic); // Read S Control Register Group
-        check_error(error);
-  
-        error=LTC6812_rdpsb(TOTAL_IC,bms_ic); // Read PWM/S Control Register Group
-        check_error(error); 
-        print_rxsctrl();
-        break;
+      wakeup_idle(TOTAL_IC);
+      LTC6812_wrpsb(TOTAL_IC,BMS_IC); //  Write PWM/S control register group B
+      print_wrsctrl();
+      print_wrpsb(SCTL);
 
-    case 25: // Clear S Control Register Group
-      wakeup_sleep(TOTAL_IC);
-      LTC6812_clrsctrl();
-      Serial.println(F("S Control Register Cleared"));
-      error=LTC6812_rdsctrl(TOTAL_IC,STREG,bms_ic);
-      check_error(error);  
-      LTC6812_rdpsb(TOTAL_IC,bms_ic);        
+      wakeup_idle(TOTAL_IC);
+      LTC6812_stsctrl(); // start S Control pulsing
+
+      wakeup_idle(TOTAL_IC);
+      error=LTC6812_rdsctrl(TOTAL_IC,streg,BMS_IC); // Read S Control Register Group
+      check_error(error);
+
+      error=LTC6812_rdpsb(TOTAL_IC,BMS_IC); // Read PWM/S Control Register Group
+      check_error(error); 
       print_rxsctrl();
+      print_rxpsb(SCTL);
       break;
 
-    case 26://SPI Communication 
+    case 27: // Clear S Control Register Group
       wakeup_sleep(TOTAL_IC);
+      LTC6812_clrsctrl();
+      wakeup_idle(TOTAL_IC);
+      error=LTC6812_rdsctrl(TOTAL_IC,streg,BMS_IC);
+      check_error(error);  
+      LTC6812_rdpsb(TOTAL_IC,BMS_IC);        
+      print_rxsctrl();
+      print_rxpsb(SCTL);
+      break;
+
+    case 28:// SPI Communication 
       /************************************************************
-         Communication control bits and communication data bytes. 
-         Refer to the data sheet. 
+         Ensure to set the GPIO bits to 1 in the CFG register group.   
       *************************************************************/  
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        bms_ic[current_ic].com.tx_data[0]= 0x81; //comm data to be transmitted
-        bms_ic[current_ic].com.tx_data[1]= 0x10;
-        bms_ic[current_ic].com.tx_data[2]= 0xA2;
-        bms_ic[current_ic].com.tx_data[3]= 0x50;
-        bms_ic[current_ic].com.tx_data[4]= 0xA1;
-        bms_ic[current_ic].com.tx_data[5]= 0x79;
-      }   
-      LTC6812_wrcomm(TOTAL_IC,bms_ic);               
-      print_comm();
+        //Communication control bits and communication data bytes. Refer to the data sheet.
+        BMS_IC[current_ic].com.tx_data[0]= 0x81; // Icom CSBM Low(8) + data D0 (0x11)
+        BMS_IC[current_ic].com.tx_data[1]= 0x10; // Fcom CSBM Low(0) 
+        BMS_IC[current_ic].com.tx_data[2]= 0xA2; // Icom CSBM Falling Edge (A) + data D1 (0x25)
+        BMS_IC[current_ic].com.tx_data[3]= 0x50; // Fcom CSBM Low(0)    
+        BMS_IC[current_ic].com.tx_data[4]= 0xA1; // Icom CSBM Falling Edge (A) + data D2 (0x17)
+        BMS_IC[current_ic].com.tx_data[5]= 0x79; // Fcom CSBM High(9)
+      }
+      wakeup_sleep(TOTAL_IC);   
+      LTC6812_wrcomm(TOTAL_IC,BMS_IC);               
+      print_wrcomm();
 
       wakeup_idle(TOTAL_IC);
-      LTC6812_stcomm(); 
-      LTC6812_pollAdc();      
-      Serial.println(F("SPI Communication completed"));
-      Serial.println();
-
+      LTC6812_stcomm(3); 
+      
       wakeup_idle(TOTAL_IC);
-      error = LTC6812_rdcomm(TOTAL_IC,bms_ic);                       
+      error = LTC6812_rdcomm(TOTAL_IC,BMS_IC);                       
       check_error(error);
       print_rxcomm();  
       break;
 
-    case 27: // write byte I2C Communication on the GPIO Ports(using eeprom 24AA01)
-      wakeup_sleep(TOTAL_IC);
+    case 29: // Write byte I2C Communication on the GPIO Ports(using I2C eeprom 24LC025)
        /************************************************************
-         Communication control bits and communication data bytes. 
-         Refer to the data sheet. 
+         Ensure to set the GPIO bits to 1 in the CFG register group.   
       *************************************************************/   
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        bms_ic[current_ic].com.tx_data[0]= 0x6A; // Icom(6)Start + I2C_address D0 (1010 0000)
-        bms_ic[current_ic].com.tx_data[1]= 0x00; // Fcom master ack  
-        bms_ic[current_ic].com.tx_data[2]= 0x00; // eeprom address D1 (0000 0000)
-        bms_ic[current_ic].com.tx_data[3]= 0x00; // Fcom master ack 
-        bms_ic[current_ic].com.tx_data[4]= 0x01; // Icom BLANCK D2 (0Xxx)
-        bms_ic[current_ic].com.tx_data[5]= 0x29; // Fcom master nack+stop 
-      }       
-      LTC6812_wrcomm(TOTAL_IC,bms_ic);// write comm register    
-      print_comm();
-       
-      wakeup_idle(TOTAL_IC);                  
-      LTC6812_stcomm();
-      LTC6812_pollAdc();
-      Serial.println(F("I2C Communication completed"));
-      Serial.println();
-      
-      wakeup_idle(TOTAL_IC);              
-      error = LTC6812_rdcomm(TOTAL_IC,bms_ic); // Read comm register                       
+        //Communication control bits and communication data bytes. Refer to the data sheet.
+        BMS_IC[current_ic].com.tx_data[0]= 0x6A; // Icom Start(6) + I2C_address D0 (0xA0)
+        BMS_IC[current_ic].com.tx_data[1]= 0x08; // Fcom master NACK(8)  
+        BMS_IC[current_ic].com.tx_data[2]= 0x00; // Icom Blank (0) + eeprom address D1 (0x00)
+        BMS_IC[current_ic].com.tx_data[3]= 0x08; // Fcom master NACK(8)   
+        BMS_IC[current_ic].com.tx_data[4]= 0x01; // Icom Blank (0) + data D2 (0x12)
+        BMS_IC[current_ic].com.tx_data[5]= 0x29; // Fcom master NACK + Stop(9) 
+      }
+      wakeup_sleep(TOTAL_IC);       
+      LTC6812_wrcomm(TOTAL_IC,BMS_IC); // write to comm register    
+      print_wrcomm(); // print transmitted data from the comm register
+
+      wakeup_idle(TOTAL_IC);
+      LTC6812_stcomm(3); // data length=3 // initiates communication between master and the I2C slave
+
+      wakeup_idle(TOTAL_IC);
+      error = LTC6812_rdcomm(TOTAL_IC,BMS_IC); // read from comm register                        
       check_error(error);
-      print_rxcomm(); // Print comm register  
+      print_rxcomm(); // print received data into the comm register    
       break; 
 
-    case 28: // Read byte data I2C Communication on the GPIO Ports(using eeprom 24AA01)
-      wakeup_sleep(TOTAL_IC);
+    case 30: // Read byte data I2C Communication on the GPIO Ports(using I2C eeprom 24LC025)
       /************************************************************
-         Communication control bits and communication data bytes. 
-         Refer to the data sheet. 
+         Ensure to set the GPIO bits to 1 in the CFG register group.   
       *************************************************************/     
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
-      {        
-        bms_ic[0].com.tx_data[0]= 0x6A; // Icom(6)Start + I2C_address D0 (1010 0000)
-        bms_ic[0].com.tx_data[1]= 0x10; // Fcom master ack 
-        bms_ic[0].com.tx_data[2]= 0x60; // again start I2C with I2C_address (1010 0001)
-        bms_ic[0].com.tx_data[3]= 0x19; // fcom master nack + stop  
-      }         
-      LTC6812_wrcomm(TOTAL_IC,bms_ic); 
-      
-      wakeup_idle(TOTAL_IC);              
-      LTC6812_stcomm();// I2C for write data in slave device    
-      LTC6812_pollAdc();
-      
-      wakeup_idle(TOTAL_IC); 
-      error = LTC6812_rdcomm(TOTAL_IC,bms_ic); // Read comm register                 
+      { 
+        //Communication control bits and communication data bytes. Refer to the data sheet.       
+        BMS_IC[current_ic].com.tx_data[0]= 0x6A; // Icom Start (6) + I2C_address D0 (A0) (Write operation to set the word address)
+        BMS_IC[current_ic].com.tx_data[1]= 0x08; // Fcom master NACK(8)  
+        BMS_IC[current_ic].com.tx_data[2]= 0x00; // Icom Blank (0) + eeprom address(word address) D1 (0x00)
+        BMS_IC[current_ic].com.tx_data[3]= 0x08; // Fcom master NACK(8)
+        BMS_IC[current_ic].com.tx_data[4]= 0x6A; // Icom Start (6) + I2C_address D2 (0xA1)(Read operation)
+        BMS_IC[current_ic].com.tx_data[5]= 0x18; // Fcom master NACK(8)  
+      }
+      wakeup_sleep(TOTAL_IC);         
+      LTC6812_wrcomm(TOTAL_IC,BMS_IC); // write to comm register
+
+      wakeup_idle(TOTAL_IC);
+      LTC6812_stcomm(3); // data length=3 // initiates communication between master and the I2C slave
+
+      for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
+      { 
+        //Communication control bits and communication data bytes. Refer to the data sheet.       
+        BMS_IC[current_ic].com.tx_data[0]= 0x0F; // Icom Blank (0) + data D0 (FF)
+        BMS_IC[current_ic].com.tx_data[1]= 0xF9; // Fcom master NACK + Stop(9)  
+        BMS_IC[current_ic].com.tx_data[2]= 0x7F; // Icom No Transmit (7) + data D1 (FF)
+        BMS_IC[current_ic].com.tx_data[3]= 0xF9; // Fcom master NACK + Stop(9)
+        BMS_IC[current_ic].com.tx_data[4]= 0x7F; // Icom No Transmit (7) + data D2 (FF)
+        BMS_IC[current_ic].com.tx_data[5]= 0xF9; // Fcom master NACK + Stop(9)   
+      }  
+      wakeup_idle(TOTAL_IC);
+      LTC6812_wrcomm(TOTAL_IC,BMS_IC); // write to comm register
+
+      wakeup_idle(TOTAL_IC);
+      LTC6812_stcomm(1); // data length=1 // initiates communication between master and the I2C slave
+
+      wakeup_idle(TOTAL_IC);
+      error = LTC6812_rdcomm(TOTAL_IC,BMS_IC); // read from comm register                
       check_error(error);
-      print_rxcomm(); // Print comm register   
+      print_rxcomm(); // print received data from the comm register   
       break;
       
-    case 29: //  Enable MUTE
+    case 31: //  Enable MUTE
       wakeup_sleep(TOTAL_IC);
-      LTC6812_wrcfg(TOTAL_IC,bms_ic);
-      LTC6812_wrcfgb(TOTAL_IC,bms_ic);
       LTC6812_mute();  
-      Serial.println("Received Configuration register after enabling MUTE");
       wakeup_idle(TOTAL_IC);
-      error = LTC6812_rdcfg(TOTAL_IC,bms_ic);
+      error = LTC6812_rdcfgb(TOTAL_IC,BMS_IC);
       check_error(error);
-      error = LTC6812_rdcfgb(TOTAL_IC,bms_ic);
-      check_error(error);
-      print_rxconfig();
+      check_mute_bit();
       break;
 
-    case 30: // To enable UNMUTE
+    case 32: // To enable UNMUTE
       wakeup_sleep(TOTAL_IC);
-      LTC6812_wrcfg(TOTAL_IC,bms_ic);
-      LTC6812_wrcfgb(TOTAL_IC,bms_ic);
       LTC6812_unmute();
-      Serial.println("Received Configuration register after disabling MUTE");
       wakeup_idle(TOTAL_IC);
-      error = LTC6812_rdcfg(TOTAL_IC,bms_ic);
+      error = LTC6812_rdcfgb(TOTAL_IC,BMS_IC);
       check_error(error);
-      error = LTC6812_rdcfgb(TOTAL_IC,bms_ic);
-      check_error(error);
-      print_rxconfig();
+      check_mute_bit();
       break;  
 
-    case 31: // Clear all ADC measurement registers
-      wakeup_sleep(TOTAL_IC);
-      LTC6812_clrcell();
-      LTC6812_clraux();
-      LTC6812_clrstat();
-      Serial.println(F("All Registers Cleared"));
-      wakeup_idle(TOTAL_IC);
-      error = LTC6812_rdcv(NO_OF_REG, TOTAL_IC,bms_ic); // read back all cell voltage registers
-      check_error(error);
-      print_cells(DATALOG_DISABLED);
-      error = LTC6812_rdaux(NO_OF_REG,TOTAL_IC,bms_ic); // read back all auxiliary registers
-      check_error(error);
-      print_aux(DATALOG_DISABLED);
-      error = LTC6812_rdstat(NO_OF_REG,TOTAL_IC,bms_ic); // read back all status registers
-      check_error(error);
-      print_stat();
-      break;
-
-    case 32: // Set and reset the gpio pins(to drive output on gpio pins)
+    case 33: // Set and reset the gpio pins(to drive output on gpio pins)
       /***********************************************************************
        Please ensure you have set the GPIO bits according to your requirement 
-       in the configuration register.( check the global variable gpioBits_a )
+       in the configuration register.( check the global variable GPIOBITS_A )
       ************************************************************************/  
       wakeup_sleep(TOTAL_IC);
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        LTC6812_set_cfgr(current_ic,bms_ic,REFON,ADCOPT,gpioBits_a,dccBits_a, dctoBits, UV, OV);
-        LTC6812_set_cfgrb(current_ic,bms_ic,FDRF,DTMEN,psBits,gpioBits_b,dccBits_b);   
+        LTC6812_set_cfgr(current_ic,BMS_IC,REFON,ADCOPT,GPIOBITS_A,DCCBITS_A, DCTOBITS, UV, OV);
+        LTC6812_set_cfgrb(current_ic,BMS_IC,FDRF,DTMEN,PSBits,GPIOBITS_B,DCCBITS_B);   
       } 
-
-      LTC6812_wrcfg(TOTAL_IC,bms_ic);
-      LTC6812_wrcfgb(TOTAL_IC,bms_ic);
-      print_config();       
+      wakeup_idle(TOTAL_IC);
+      LTC6812_wrcfg(TOTAL_IC,BMS_IC);
+      LTC6812_wrcfgb(TOTAL_IC,BMS_IC);
+      print_wrconfig();
+      print_wrconfigb();       
       break; 
-
-    case 33: // Open wire Diagnostic for Auxiliary Measurements
-      wakeup_sleep(TOTAL_IC);
-      LTC6812_run_gpio_openwire(TOTAL_IC, bms_ic);
-      print_open();
-      Serial.println();
-      break;   
       
     case 'm': //prints menu
       print_menu();
       break;
 
     default:
-      Serial.println(F("Incorrect Option"));
-      Serial.println();
+      char str_error[]="Incorrect Option \n";
+      serial_print_text(str_error);
       break;
   }
 }
 
-/*!*********************************
-  \brief For Loop Measurement
+/*!**********************************************************************************************************************************************
+ \brief For writing/reading configuration data or measuring cell voltages or reading aux register or reading status register in a continuous loop  
  @return void
-***********************************/
+*************************************************************************************************************************************************/
 void measurement_loop(uint8_t datalog_en)
 {
   int8_t error = 0;
-  if (WRITE_CONFIG == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    LTC6812_wrcfg(TOTAL_IC,bms_ic);
-    LTC6812_wrcfgb(TOTAL_IC,bms_ic);
-    print_config();
-  }
-
-  if (READ_CONFIG == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    error = LTC6812_rdcfg(TOTAL_IC,bms_ic);
-    check_error(error);
-    error = LTC6812_rdcfgb(TOTAL_IC,bms_ic);
-    check_error(error);
-    print_rxconfig();
-  }
-
-  if (MEASURE_CELL == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    LTC6812_adcv(ADC_CONVERSION_MODE,ADC_DCP,CELL_CH_TO_CONVERT);
-    LTC6812_pollAdc();
-    wakeup_idle(TOTAL_IC);
-    error = LTC6812_rdcv(0, TOTAL_IC,bms_ic);
-    check_error(error);
-    print_cells(datalog_en);
-
-  }
-
-  if (MEASURE_AUX == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    LTC6812_adax(ADC_CONVERSION_MODE , AUX_CH_ALL);
-    LTC6812_pollAdc();
-    wakeup_idle(TOTAL_IC);
-    error = LTC6812_rdaux(0,TOTAL_IC,bms_ic); // Set to read back all aux registers
-    check_error(error);
-    print_aux(datalog_en);
-  }
-
-  if (MEASURE_STAT == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    LTC6812_adstat(ADC_CONVERSION_MODE, STAT_CH_ALL);
-    LTC6812_pollAdc();
-    wakeup_idle(TOTAL_IC);
-    error = LTC6812_rdstat(0,TOTAL_IC,bms_ic); // Set to read back all aux registers
-    check_error(error);
-    print_stat();
-  }
-
-  if(PRINT_PEC == ENABLED)
-  {
-    print_pec();
-  }
+  char input = 0;
   
+  Serial.println(F("Transmit 'm' to quit"));
+  
+  while (input != 'm')
+  {
+     if (Serial.available() > 0)
+      {
+        input = read_char();
+      } 
+  
+    if (WRITE_CONFIG == ENABLED)
+    {
+      wakeup_idle(TOTAL_IC);
+      LTC6812_wrcfg(TOTAL_IC,BMS_IC);
+      LTC6812_wrcfgb(TOTAL_IC,BMS_IC);
+      print_wrconfig();
+      print_wrconfigb();
+    }
+  
+    if (READ_CONFIG == ENABLED)
+    {
+      wakeup_idle(TOTAL_IC);
+      error = LTC6812_rdcfg(TOTAL_IC,BMS_IC);
+      check_error(error);
+      error = LTC6812_rdcfgb(TOTAL_IC,BMS_IC);
+      check_error(error);
+      print_rxconfig();
+      print_rxconfigb();
+    }
+  
+    if (MEASURE_CELL == ENABLED)
+    {
+      wakeup_idle(TOTAL_IC);
+      LTC6812_adcv(ADC_CONVERSION_MODE,ADC_DCP,CELL_CH_TO_CONVERT);
+      LTC6812_pollAdc();
+      wakeup_idle(TOTAL_IC);
+      error = LTC6812_rdcv(0, TOTAL_IC,BMS_IC);
+      check_error(error);
+      print_cells(datalog_en);
+    }
+  
+    if (MEASURE_AUX == ENABLED)
+    {
+      wakeup_idle(TOTAL_IC);
+      LTC6812_adax(ADC_CONVERSION_MODE , AUX_CH_ALL);
+      LTC6812_pollAdc();
+      wakeup_idle(TOTAL_IC);
+      error = LTC6812_rdaux(0,TOTAL_IC,BMS_IC); // Set to read back all aux registers
+      check_error(error);
+      print_aux(datalog_en);
+    }
+  
+    if (MEASURE_STAT == ENABLED)
+    {
+      wakeup_idle(TOTAL_IC);
+      LTC6812_adstat(ADC_CONVERSION_MODE, STAT_CH_ALL);
+      LTC6812_pollAdc();
+      wakeup_idle(TOTAL_IC);
+      error = LTC6812_rdstat(0,TOTAL_IC,BMS_IC); // Set to read back all aux registers
+      check_error(error);
+      print_stat();
+    }
+  
+    if(PRINT_PEC == ENABLED)
+    {
+      print_pec_error_count();
+    }
+
+    delay(MEASUREMENT_LOOP_TIME);
+  }
 }
 
 /*!*********************************
   \brief Prints the main menu
    @return void
 ***********************************/
-void print_menu()
+void print_menu(void)
 {
   Serial.println(F("List of LTC6812 Command:"));
-  Serial.println(F("Write and Read Configuration: 1                            |Loop measurements with data-log output : 12                            |Write and Read of PWM : 23"));
-  Serial.println(F("Read Configuration: 2                                      |Run Mux Self Test: 13                                                  |Write and  Read of S control : 24"));
-  Serial.println(F("Start Cell Voltage Conversion: 3                           |Run ADC Self Test: 14                                                  |Clear S control register : 25"));
-  Serial.println(F("Read Cell Voltages: 4                                      |ADC overlap Test : 15                                                  |SPI Communication  : 26"));
-  Serial.println(F("Start Aux Voltage Conversion: 5                            |Run Digital Redundancy Test: 16                                        |I2C Communication Write to Slave :27"));
-  Serial.println(F("Read Aux Voltages: 6                                       |Open Wire Test for single cell detection: 17                           |I2C Communication Read from Slave :28"));
-  Serial.println(F("Start Stat Voltage Conversion: 7                           |Open Wire Test for multiple cell or two consecutive cells detection:18 |Enable MUTE : 29"));
-  Serial.println(F("Read Stat Voltages: 8                                      |Print PEC Counter: 19                                                  |Disable MUTE : 30"));
-  Serial.println(F("Start Combined Cell Voltage and GPIO1, GPIO2 Conversion: 9 |Reset PEC Counter: 20                                                  |Clear Registers: 31"));
-  Serial.println(F("Start  Cell Voltage and Sum of cells : 10                  |Set Discharge: 21                                                      |Set or reset the gpio pins: 32"));
-  Serial.println(F("Loop Measurements: 11                                      |Clear Discharge: 22                                                    |Open wire for Auxiliary Measurement: 33"));
-  Serial.println();
+  Serial.println(F("Write and Read Configuration: 1                            |Loop measurements with data-log output : 12                            |Set Discharge: 23   "));  
+  Serial.println(F("Read Configuration: 2                                      |Clear Registers: 13                                                    |Clear Discharge: 24   "));
+  Serial.println(F("Start Cell Voltage Conversion: 3                           |Run Mux Self Test: 14                                                  |Write and Read of PWM : 25"));
+  Serial.println(F("Read Cell Voltages: 4                                      |Run ADC Self Test: 15                                                  |Write and  Read of S control : 26"));
+  Serial.println(F("Start Aux Voltage Conversion: 5                            |ADC overlap Test : 16                                                  |Clear S control register : 27"));
+  Serial.println(F("Read Aux Voltages: 6                                       |Run Digital Redundancy Test: 17                                        |SPI Communication  : 28"));
+  Serial.println(F("Start Stat Voltage Conversion: 7                           |Open Wire Test for single cell detection: 18                           |I2C Communication Write to Slave :29"));
+  Serial.println(F("Read Stat Voltages: 8                                      |Open Wire Test for multiple cell or two consecutive cells detection:19 |I2C Communication Read from Slave :30"));
+  Serial.println(F("Start Combined Cell Voltage and GPIO1, GPIO2 Conversion: 9 |Open wire for Auxiliary Measurement: 20                                |Enable MUTE : 31"));
+  Serial.println(F("Start  Cell Voltage and Sum of cells : 10                  |Print PEC Counter: 21                                                  |Disable MUTE : 32")); 
+  Serial.println(F("Loop Measurements: 11                                      |Reset PEC Counter: 22                                                  |Set or reset the gpio pins: 33 \n "));
   Serial.println(F("Print 'm' for menu"));
-  Serial.println(F("Please enter command: "));
-  Serial.println();
+  Serial.println(F("Please enter command: \n "));
 }
 
 /*!******************************************************************************
- \brief Prints the configuration data that is going to be written to the LTC6812
- to the serial port.
+ \brief Prints the Configuration Register A data that is going to be written to 
+ the LTC6812 to the serial port.
   @return void
  ********************************************************************************/
-void print_config()
+void print_wrconfig(void)
 {
     int cfg_pec;
-    Serial.println(F("Written Configuration: "));
+    Serial.println(F("Written Configuration A Register: "));
     for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
     {
       Serial.print(F("CFGA IC "));
@@ -856,69 +832,92 @@ void print_config()
       for(int i = 0;i<6;i++)
       {
         Serial.print(F(", 0x"));
-        serial_print_hex(bms_ic[current_ic].config.tx_data[i]);
+        serial_print_hex(BMS_IC[current_ic].config.tx_data[i]);
       }
       Serial.print(F(", Calculated PEC: 0x"));
-      cfg_pec = pec15_calc(6,&bms_ic[current_ic].config.tx_data[0]);
+      cfg_pec = pec15_calc(6,&BMS_IC[current_ic].config.tx_data[0]);
       serial_print_hex((uint8_t)(cfg_pec>>8));
       Serial.print(F(", 0x"));
       serial_print_hex((uint8_t)(cfg_pec));
-      Serial.println();
-      
+      Serial.println("\n");
+    }
+}
+
+/*!******************************************************************************
+ \brief Prints the Configuration Register B data that is going to be written to 
+ the LTC6812 to the serial port.
+  @return void
+ ********************************************************************************/
+void print_wrconfigb(void)
+{
+    int cfg_pec;
+    Serial.println(F("Written Configuration B Register: "));
+    for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
+    { 
       Serial.print(F("CFGB IC "));
       Serial.print(current_ic+1,DEC);
       for(int i = 0;i<6;i++)
       {
         Serial.print(F(", 0x"));
-        serial_print_hex(bms_ic[current_ic].configb.tx_data[i]);
+        serial_print_hex(BMS_IC[current_ic].configb.tx_data[i]);
       }
       Serial.print(F(", Calculated PEC: 0x"));
-      cfg_pec = pec15_calc(6,&bms_ic[current_ic].configb.tx_data[0]);
+      cfg_pec = pec15_calc(6,&BMS_IC[current_ic].configb.tx_data[0]);
       serial_print_hex((uint8_t)(cfg_pec>>8));
       Serial.print(F(", 0x"));
       serial_print_hex((uint8_t)(cfg_pec));
-      Serial.println();
+      Serial.println("\n");
     }
-    Serial.println();
 }
 
 /*!*****************************************************************
- \brief Prints the configuration data that was read back from the
- LTC6812 to the serial port.
+ \brief Prints the Configuration Register A data that was read back 
+ from the LTC6812 to the serial port.
   @return void
  *******************************************************************/
-void print_rxconfig()
+void print_rxconfig(void)
 {
-  Serial.println(F("Received Configuration: "));
+  Serial.println(F("Received Configuration A Register: "));
   for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
   {
     Serial.print(F("CFGA IC "));
     Serial.print(current_ic+1,DEC);
-    for(int i = 0;i<6;i++)
+    for(int i = 0; i < 6; i++)
     {
       Serial.print(F(", 0x"));
-      serial_print_hex(bms_ic[current_ic].config.rx_data[i]);
+      serial_print_hex(BMS_IC[current_ic].config.rx_data[i]);
     }
     Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].config.rx_data[6]);
+    serial_print_hex(BMS_IC[current_ic].config.rx_data[6]);
     Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].config.rx_data[7]);
-    Serial.println();
+    serial_print_hex(BMS_IC[current_ic].config.rx_data[7]);
+    Serial.println("\n");
+  }
+}
 
+/*!*****************************************************************
+ \brief Prints the Configuration Register B that was read back from 
+ the LTC6812 to the serial port.
+  @return void
+ *******************************************************************/
+void print_rxconfigb(void)
+{
+  Serial.println(F("Received Configuration B Register: "));
+  for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
+  {
     Serial.print(F("CFGB IC "));
     Serial.print(current_ic+1,DEC);
-    for(int i = 0;i<6;i++)
+    for(int i = 0; i < 6; i++)
     {
       Serial.print(F(", 0x"));
-      serial_print_hex(bms_ic[current_ic].configb.rx_data[i]);
-    };
+      serial_print_hex(BMS_IC[current_ic].configb.rx_data[i]);
+    }
     Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].configb.rx_data[6]);
+    serial_print_hex(BMS_IC[current_ic].configb.rx_data[6]);
     Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].configb.rx_data[7]);
-    Serial.println();
+    serial_print_hex(BMS_IC[current_ic].configb.rx_data[7]);
+    Serial.println("\n");
   }
-  Serial.println();
 }
 
 /*!************************************************************
@@ -934,28 +933,27 @@ void print_cells(uint8_t datalog_en)
       Serial.print(" IC ");
       Serial.print(current_ic+1,DEC);
       Serial.print(", ");
-      for (int i=0; i<bms_ic[0].ic_reg.cell_channels; i++)
+      for (int i=0; i<BMS_IC[0].ic_reg.cell_channels; i++)
       {
-
         Serial.print(" C");
         Serial.print(i+1,DEC);
         Serial.print(":");
-        Serial.print(bms_ic[current_ic].cells.c_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].cells.c_codes[i]*0.0001,4);
         Serial.print(",");
       }
       Serial.println();
     }
     else
     {
-      Serial.print("Cells, ");
-      for (int i=0; i<bms_ic[0].ic_reg.cell_channels; i++)
+      Serial.print(" Cells, ");
+      for (int i=0; i<BMS_IC[0].ic_reg.cell_channels; i++)
       {
-        Serial.print(bms_ic[current_ic].cells.c_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].cells.c_codes[i]*0.0001,4);
         Serial.print(",");
       }
     }
   }
-  Serial.println();
+  Serial.println("\n");
 }
 
 /*!****************************************************************************
@@ -972,12 +970,12 @@ void print_aux(uint8_t datalog_en)
       Serial.print(current_ic+1,DEC);
       
         
-      for (int i=0; i < 5; i++)
+      for (int i = 0; i < 5; i++)
       {
         Serial.print(F(" GPIO-"));
         Serial.print(i+1,DEC);
         Serial.print(":");
-        Serial.print(bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].aux.a_codes[i]*0.0001,4);
         Serial.print(",");
       }
       
@@ -986,73 +984,70 @@ void print_aux(uint8_t datalog_en)
         Serial.print(F(" GPIO-"));
         Serial.print(i,DEC);
         Serial.print(":");
-        Serial.print(bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].aux.a_codes[i]*0.0001,4);
         Serial.print(",");
       }
 
-      Serial.print(F(" Vref2"));
-      Serial.print(":");
-      Serial.print(bms_ic[current_ic].aux.a_codes[5]*0.0001,4);
+      Serial.print(F(" Vref2 :"));
+      Serial.print(BMS_IC[current_ic].aux.a_codes[5]*0.0001,4);
       Serial.println();
 
-      Serial.print(" Flags : 0x");
-      Serial.print((uint8_t)bms_ic[current_ic].aux.a_codes[11],HEX);
+      Serial.print(" OV/UV Flags : 0x");
+      Serial.print((uint8_t)BMS_IC[current_ic].aux.a_codes[11],HEX);
       Serial.println();
     }
     else
     {
-      Serial.print("AUX, ");
+      Serial.print(" AUX : ");
 
       for (int i=0; i < 12; i++)
       {
-        Serial.print(bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].aux.a_codes[i]*0.0001,4);
         Serial.print(",");
       }
     }
   }
-  Serial.println();
+  Serial.println("\n");
 }
 
 /*!****************************************************************************
   \brief Prints Status voltage codes and Vref2 voltage code onto the serial port
    @return void
  *****************************************************************************/
-void print_stat()
+void print_stat(void)
 {
+  double itmp;
 
   for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
   {
-    double ITMP;
     Serial.print(F(" IC "));
     Serial.print(current_ic+1,DEC);
     Serial.print(F(" SOC:"));
-    Serial.print(bms_ic[current_ic].stat.stat_codes[0]*0.0001*30,4);
+    Serial.print(BMS_IC[current_ic].stat.stat_codes[0]*0.0001*30,4);
     Serial.print(F(","));
     Serial.print(F(" Itemp:"));
-    ITMP = (double)((bms_ic[current_ic].stat.stat_codes[1] * (0.0001 / 0.0076)) - 276);   //Internal Die Temperature(°C) = ITMP • (100 µV / 7.5mV)°C - 273°C
-    Serial.print(ITMP,4);
+    itmp = (double)((BMS_IC[current_ic].stat.stat_codes[1] * (0.0001 / 0.0076)) - 276);   //Internal Die Temperature(°C) = ITMP • (100 µV / 7.6mV)°C - 276°C
+    Serial.print(itmp,4);
     Serial.print(F(","));
     Serial.print(F(" VregA:"));
-    Serial.print(bms_ic[current_ic].stat.stat_codes[2]*0.0001,4);
+    Serial.print(BMS_IC[current_ic].stat.stat_codes[2]*0.0001,4);
     Serial.print(F(","));
     Serial.print(F(" VregD:"));
-    Serial.println(bms_ic[current_ic].stat.stat_codes[3]*0.0001,4);
-    Serial.print(F(" Flags:"));
-    Serial.print(F("0x"));
-    serial_print_hex(bms_ic[current_ic].stat.flags[0]);
+    Serial.println(BMS_IC[current_ic].stat.stat_codes[3]*0.0001,4);
+    Serial.print(F(" OV/UV Flags: 0x"));
+    serial_print_hex(BMS_IC[current_ic].stat.flags[0]);
     Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.flags[1]);
+    serial_print_hex(BMS_IC[current_ic].stat.flags[1]);
     Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.flags[2]);
+    serial_print_hex(BMS_IC[current_ic].stat.flags[2]);
     Serial.print(F(",\t Mux fail flag:"));
     Serial.print(F(" 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.mux_fail[0]);
+    serial_print_hex(BMS_IC[current_ic].stat.mux_fail[0]);
     Serial.print(F(",\t THSD:"));
     Serial.print(F(" 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.thsd[0]);
-    Serial.println();
-  }
-  Serial.println();
+    serial_print_hex(BMS_IC[current_ic].stat.thsd[0]);
+    Serial.println("\n");
+  }  
 }
 
 /*!****************************************************************************
@@ -1073,7 +1068,7 @@ void print_aux1(uint8_t datalog_en)
         Serial.print(F(" GPIO-"));
         Serial.print(i+1,DEC);
         Serial.print(":");
-        Serial.print(bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].aux.a_codes[i]*0.0001,4);
         Serial.print(",");
       }
     }
@@ -1083,40 +1078,109 @@ void print_aux1(uint8_t datalog_en)
 
       for (int i=0; i < 6; i++)
       {
-        Serial.print(bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].aux.a_codes[i]*0.0001,4);
         Serial.print(",");
       }
     }
   }
-  Serial.println();
+  Serial.println("\n");
 }
 
 /*!****************************************************************************
   \brief Prints Status voltage codes for SOC onto the serial port
    @return void
  *****************************************************************************/
-void print_statsoc()
+void print_sumofcells(void)
 {
   for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
   {
     Serial.print(F(" IC "));
     Serial.print(current_ic+1,DEC);
-    Serial.print(F(" SOC:"));
-    Serial.print(bms_ic[current_ic].stat.stat_codes[0]*0.0001*30,4);
+    Serial.print(F(": SOC:"));
+    Serial.print(BMS_IC[current_ic].stat.stat_codes[0]*0.0001*30,4);
     Serial.print(F(","));
   }
-  Serial.println();
+  Serial.println("\n");
+}
+
+/*!****************************************************************
+  \brief Function to check the MUX fail bit in the Status Register
+   @return void
+*******************************************************************/
+void check_mux_fail(void)
+{ 
+  int8_t error = 0;
+  for (int ic = 0; ic<TOTAL_IC; ic++)
+    { 
+      Serial.print(" IC ");
+      Serial.println(ic+1,DEC);
+      if (BMS_IC[ic].stat.mux_fail[0] != 0) error++;
+    
+      if (error==0) Serial.println(F("Mux Test: PASS \n"));
+      else Serial.println(F("Mux Test: FAIL \n"));
+    }
+}
+
+/*!************************************************************
+  \brief Prints Errors Detected during self test
+   @return void
+*************************************************************/
+void print_selftest_errors(uint8_t adc_reg ,int8_t error)
+{
+  if(adc_reg==1)
+  {
+    Serial.println("Cell ");
+    }
+  else if(adc_reg==2)
+  {
+    Serial.println("Aux ");
+    }
+  else if(adc_reg==3)
+  {
+    Serial.println("Stat ");
+    }
+  Serial.print(error, DEC);
+  Serial.println(F(" : errors detected in Digital Filter and Memory \n"));
+}
+
+/*!************************************************************
+  \brief Prints the output of  the ADC overlap test  
+   @return void
+*************************************************************/
+void print_overlap_results(int8_t error)
+{
+  if (error==0) Serial.println(F("Overlap Test: PASS \n"));
+  else Serial.println(F("Overlap Test: FAIL \n"));
+}
+
+/*!************************************************************
+  \brief Prints Errors Detected during Digital Redundancy test
+   @return void
+*************************************************************/
+void print_digital_redundancy_errors(uint8_t adc_reg ,int8_t error)
+{
+  if(adc_reg==2)
+  {
+    Serial.println("Aux ");
+    }
+  else if(adc_reg==3)
+  {
+    Serial.println("Stat ");
+    }
+
+  Serial.print(error, DEC);
+  Serial.println(F(" : errors detected in Measurement \n"));
 }
 
 /*!****************************************************************************
   \brief Prints Open wire test results to the serial port
    @return void
  *****************************************************************************/
-void print_open()
+void print_open_wires(void)
 {
  for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
   {
-    if (bms_ic[current_ic].system_open_wire == 65535)
+    if (BMS_IC[current_ic].system_open_wire == 65535)
     {
       Serial.print("No Opens Detected on IC ");
       Serial.print(current_ic+1, DEC);
@@ -1127,286 +1191,353 @@ void print_open()
       Serial.print(F("There is an open wire on IC "));
       Serial.print(current_ic + 1,DEC);
       Serial.print(F(" Channel: "));
-      Serial.println(bms_ic[current_ic].system_open_wire);
+      Serial.println(BMS_IC[current_ic].system_open_wire);
     }
   }
-}
-
-
-/*!****************************************************************************
-  \brief Prints data which is written on PWM register onto the serial port
-   @return void
- *****************************************************************************/
-void print_pwm()
-{
-  int pwm_pec;
-  int psb_pec;
-
-  Serial.println(F("Written Data in PWM Registers: "));
-  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC: "));
-    Serial.println(current_ic+1,DEC);
-    Serial.print(F(" PWM register group:0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[5]);
-
-    Serial.print(F(", Calculated PEC:0x"));
-    pwm_pec = pec15_calc(6,&bms_ic[current_ic].pwm.tx_data[0]);
-    serial_print_hex((uint8_t)(pwm_pec>>8));
-    Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(pwm_pec));
-    Serial.println();
-
-    Serial.print(F(" PWM/S control register group B:0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.tx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.tx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.tx_data[2]);
-
-    Serial.print(F(", Calculated PEC: 0x"));
-    psb_pec = pec15_calc(6,&bms_ic[current_ic].pwmb.tx_data[0]);
-    serial_print_hex((uint8_t)(psb_pec>>8));
-    Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(psb_pec));
-    Serial.println();
-  }
-  Serial.println();
-}
-
-/*!****************************************************************************
-  \brief Prints received data from PWM register onto the serial port
-   @return void
- *****************************************************************************/
-void print_rxpwm()
-{
-  Serial.println(F("Received Data in PWM register:"));
-  for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC: "));
-    Serial.println(current_ic+1,DEC);
-    Serial.print(F(" PWM register group:0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[5]);
-    Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[6]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[7]);
-    Serial.println();
-
-    Serial.print(F(" PWM/S control register group B:0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.rx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.rx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.rx_data[2]);
-    
-    Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.rx_data[6]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.rx_data[7]);
-    Serial.println();    
-  }
-  Serial.println();
-}
-
-/*!****************************************************************************
- \brief prints data which is written on S Control register 
-   @return void
- *****************************************************************************/
-void print_sctrl()
-{
-  int sctrl_pec;
-  int psb_pec; 
-
-  Serial.println(F("Written Data in Sctrl register: "));
-  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC: "));
-    Serial.print(current_ic+1,DEC);
-    Serial.print(F(" Sctrl register group:0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[5]);
-    
-    Serial.print(F(", Calculated PEC: 0x"));
-    sctrl_pec = pec15_calc(6,&bms_ic[current_ic].sctrl.tx_data[0]);
-    serial_print_hex((uint8_t)(sctrl_pec>>8));
-    Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(sctrl_pec));
-    Serial.println();
-
-    Serial.print(F(" PWM/S control register group B:0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.tx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.tx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.tx_data[5]);
-    
-    Serial.print(F(", Calculated PEC: 0x"));
-    psb_pec = pec15_calc(6,&bms_ic[current_ic].sctrlb.tx_data[0]);
-    serial_print_hex((uint8_t)(psb_pec>>8));
-    Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(psb_pec));
-    Serial.println();
-  }
-  Serial.println();
-}
-
-/*!****************************************************************************
-  \brief prints data which is read back from S Control register 
-   @return void
- *****************************************************************************/
-void print_rxsctrl()
-{
-  Serial.println(F("Received Data in S control register:"));
-  for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC: "));
-    Serial.print(current_ic+1,DEC);
-    Serial.print(F(" Sctrl register group:0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[5]);
-    
-    Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[6]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[7]);
-    Serial.println();
-
-    Serial.print(F(" PWM/S control register group B:0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.rx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.rx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.rx_data[5]);
-    
-    Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.rx_data[6]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.rx_data[7]);
-    Serial.println();  
-  }
-  Serial.println();
-}
-
-/*!****************************************************************************
-  \brief  prints data which is written on COMM register onto the serial port
-  @return void
- *****************************************************************************/
-void print_comm()
-{
-  int comm_pec;
-
-  Serial.println(F("Written Data in COMM Register: "));
-  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC- "));
-    Serial.print(current_ic+1,DEC);
-    Serial.print(F(": "));
-    Serial.print(F("0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[5]);
-    Serial.print(F(", Calculated PEC: 0x"));
-    comm_pec = pec15_calc(6,&bms_ic[current_ic].com.tx_data[0]);
-    serial_print_hex((uint8_t)(comm_pec>>8));
-    Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(comm_pec));
-    Serial.println();
-  }
-  Serial.println();
-}
-
-/*!****************************************************************************
-  \brief Prints received data from COMM register onto the serial port
-  @return void
- *****************************************************************************/
-void print_rxcomm()
-{
-  Serial.println(F("Received Data in COMM register:"));
-  for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC "));
-    Serial.print(current_ic+1,DEC);
-    Serial.print(F(": 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[5]);
-    Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[6]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[7]);
-    Serial.println();
-  }
-  Serial.println();
+  Serial.println("\n");
 }
 
 /*!****************************************************************************
   \brief Function to print the number of PEC Errors
   @return void
  *****************************************************************************/
-void print_pec()
+void print_pec_error_count(void)
 {
   for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
   {
       Serial.println("");
-      Serial.print(bms_ic[current_ic].crc_count.pec_count,DEC);
+      Serial.print(BMS_IC[current_ic].crc_count.pec_count,DEC);
       Serial.print(F(" : PEC Errors Detected on IC"));
       Serial.println(current_ic+1,DEC);
   }
+  Serial.println("\n");
+}
+
+/*!****************************************************
+  \brief Function to select the S pin for discharge
+  @return void
+ ******************************************************/
+int8_t select_s_pin(void)
+{
+  int8_t read_s_pin=0;
+  
+  Serial.print(F("Please enter the Spin number: "));
+  read_s_pin = (int8_t)read_int();
+  Serial.println(read_s_pin);
+  return(read_s_pin);
+}
+
+/*!****************************************************************************
+  \brief Prints data which is written on PWM register onto the serial port
+   @return void
+ *****************************************************************************/
+void print_wrpwm(void)
+{
+  int pwm_pec;
+
+  Serial.println(F("Write PWM Register A: "));
+  for (uint8_t current_ic = 0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.print(F("IC "));
+    Serial.print(current_ic+1,DEC);
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+     serial_print_hex(BMS_IC[current_ic].pwm.tx_data[i]);
+    }
+    Serial.print(F(", Calculated PEC: 0x"));
+    pwm_pec = pec15_calc(6,&BMS_IC[current_ic].pwm.tx_data[0]);
+    serial_print_hex((uint8_t)(pwm_pec>>8));
+    Serial.print(F(", 0x"));
+    serial_print_hex((uint8_t)(pwm_pec));
+    Serial.println("\n");
+  } 
+}
+
+/*!****************************************************************************
+  \brief Prints received data from PWM register onto the serial port
+   @return void
+ *****************************************************************************/
+void print_rxpwm(void)
+{
+  Serial.println(F("Receive PWM Register A data:"));
+  for (uint8_t current_ic=0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.print(F("IC "));
+    Serial.print(current_ic+1,DEC);
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+     serial_print_hex(BMS_IC[current_ic].pwm.rx_data[i]);
+    }
+    Serial.print(F(", Received PEC: 0x"));
+    serial_print_hex(BMS_IC[current_ic].pwm.rx_data[6]);
+    Serial.print(F(", 0x"));
+    serial_print_hex(BMS_IC[current_ic].pwm.rx_data[7]);
+    Serial.println("\n");
+  }
+}
+
+/*!****************************************************************************
+ \brief prints data which is written on S Control register 
+   @return void
+ *****************************************************************************/
+void print_wrsctrl(void)
+{
+  int sctrl_pec;
+
+  Serial.println(F("Written Data in Sctrl register A: "));
+  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.print(F(" IC "));
+    Serial.print(current_ic+1,DEC);
+    
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].sctrl.tx_data[i]);
+    }
+    
+    Serial.print(F(", Calculated PEC: 0x"));
+    sctrl_pec = pec15_calc(6,&BMS_IC[current_ic].sctrl.tx_data[0]);
+    serial_print_hex((uint8_t)(sctrl_pec>>8));
+    Serial.print(F(", 0x"));
+    serial_print_hex((uint8_t)(sctrl_pec));
+    Serial.println("\n");
+  }
+}
+
+/*!****************************************************************************
+  \brief Prints data which is read back from S Control register 
+   @return void
+ *****************************************************************************/
+void print_rxsctrl(void)
+{
+  Serial.println(F("Received Data from Sctrl register A:"));
+  for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.print(F(" IC "));
+    Serial.print(current_ic+1,DEC);
+    
+    for(int i = 0; i < 6; i++)
+    {
+    Serial.print(F(", 0x"));
+    serial_print_hex(BMS_IC[current_ic].sctrl.rx_data[i]);
+    }
+    
+    Serial.print(F(", Received PEC: 0x"));
+    serial_print_hex(BMS_IC[current_ic].sctrl.rx_data[6]);
+    Serial.print(F(", 0x"));
+    serial_print_hex(BMS_IC[current_ic].sctrl.rx_data[7]);
+    Serial.println("\n");
+  }
+}
+
+/*!****************************************************************************
+  \brief Prints data which is written on PWM/S control register group B onto 
+  the serial port
+   @return void
+ *****************************************************************************/
+void print_wrpsb(uint8_t type)
+{
+  int psb_pec=0;
+
+  Serial.println(F("PWM/S control register group B: "));
+  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
+  {
+      if(type == 1)
+      {
+        Serial.print(F("IC "));
+        Serial.print(current_ic+1,DEC);
+        Serial.print(F(": 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.tx_data[0]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.tx_data[1]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.tx_data[2]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.tx_data[3]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.tx_data[4]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.tx_data[5]);
+    
+        Serial.print(F(", Calculated PEC: 0x"));
+        psb_pec = pec15_calc(6,&BMS_IC[current_ic].pwmb.tx_data[0]);
+        serial_print_hex((uint8_t)(psb_pec>>8));
+        Serial.print(F(", 0x"));
+        serial_print_hex((uint8_t)(psb_pec));
+        Serial.println("\n");
+      } 
+      else if(type == 2)
+      {
+        Serial.print(F("IC "));
+        Serial.print(current_ic+1,DEC);
+        Serial.print(F(": 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.tx_data[0]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.tx_data[1]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.tx_data[2]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.tx_data[3]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.tx_data[4]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.tx_data[5]);
+        
+        
+        Serial.print(F(", Calculated PEC: 0x"));
+        psb_pec = pec15_calc(6,&BMS_IC[current_ic].sctrlb.tx_data[0]);
+        serial_print_hex((uint8_t)(psb_pec>>8));
+        Serial.print(F(", 0x"));
+        serial_print_hex((uint8_t)(psb_pec));
+        Serial.println("\n");       
+      }
+  }  
+}
+
+
+/*!****************************************************************************
+  \brief Prints received data from PWM/S control register group B
+   onto the serial port
+   @return void
+ *****************************************************************************/
+void print_rxpsb(uint8_t type)
+{
+  Serial.println(F("PWM/S control register group B:"));
+  if(type == 1)
+  {
+      for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
+      {
+        Serial.print(F("IC "));
+        Serial.print(current_ic+1,DEC);
+        Serial.print(F(": 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.rx_data[0]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.rx_data[1]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.rx_data[2]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.rx_data[3]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.rx_data[4]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.rx_data[5]);
+        
+        Serial.print(F(", Received PEC: 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.rx_data[6]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.rx_data[7]);
+       Serial.println("\n");
+      }
+  }
+   else if(type == 2)
+  {
+      for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
+      {
+        Serial.print(F(" IC "));
+        Serial.print(current_ic+1,DEC);
+        Serial.print(F(": 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.rx_data[0]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.rx_data[1]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.rx_data[2]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.rx_data[3]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.rx_data[4]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.rx_data[5]);
+        
+        Serial.print(F(", Received PEC: 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.rx_data[6]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.rx_data[7]);
+        Serial.println("\n");  
+      }
+  }  
+}
+
+/*!****************************************************************************
+  \brief  prints data which is written on COMM register onto the serial port
+  @return void
+ *****************************************************************************/
+void print_wrcomm(void)
+{
+ int comm_pec;
+
+  Serial.println(F("Written Data in COMM Register: "));
+  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.print(F(" IC- "));
+    Serial.print(current_ic+1,DEC);
+    
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].com.tx_data[i]);
+    }
+    Serial.print(F(", Calculated PEC: 0x"));
+    comm_pec = pec15_calc(6,&BMS_IC[current_ic].com.tx_data[0]);
+    serial_print_hex((uint8_t)(comm_pec>>8));
+    Serial.print(F(", 0x"));
+    serial_print_hex((uint8_t)(comm_pec));
+    Serial.println("\n");
+  }
+}
+
+/*!****************************************************************************
+  \brief Prints received data from COMM register onto the serial port
+  @return void
+ *****************************************************************************/
+void print_rxcomm(void)
+{
+   Serial.println(F("Received Data in COMM register:"));
+  for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.print(F(" IC- "));
+    Serial.print(current_ic+1,DEC);
+    
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].com.rx_data[i]);
+    }
+    Serial.print(F(", Received PEC: 0x"));
+    serial_print_hex(BMS_IC[current_ic].com.rx_data[6]);
+    Serial.print(F(", 0x"));
+    serial_print_hex(BMS_IC[current_ic].com.rx_data[7]);
+    Serial.println("\n");
+  }
+}
+
+/*!********************************************************************
+  \brief Function to check the Mute bit in the Configuration Register
+   @return void
+**********************************************************************/
+void check_mute_bit(void)
+{ 
+  for (int current_ic = 0 ; current_ic < TOTAL_IC; current_ic++)
+  {
+    Serial.print(F(" Mute bit in Configuration Register B: 0x"));
+    serial_print_hex((BMS_IC[current_ic].configb.rx_data[1])&(0x80));
+    Serial.println("\n");
+  }
+}
+
+/*!****************************************************************************
+  \brief Function to print the Conversion Time
+  @return void
+ *****************************************************************************/
+void print_conv_time(uint32_t conv_time)
+{
+  uint16_t m_factor=1000;  // to print in ms
+
+  Serial.print(F("Conversion completed in:"));
+  Serial.print(((float)conv_time/m_factor), 1);
+  Serial.println(F("ms \n"));
 }
 
 /*!****************************************************************************
@@ -1419,6 +1550,15 @@ void check_error(int error)
   {
     Serial.println(F("A PEC error was detected in the received data"));
   }
+}
+
+/*!************************************************************
+  \brief Function to print text on serial monitor
+  @return void
+*************************************************************/ 
+void serial_print_text(char data[])
+{       
+  Serial.println(data);
 }
 
  /*!************************************************************
@@ -1436,7 +1576,6 @@ void serial_print_hex(uint8_t data)
     Serial.print((byte)data,HEX);
 }
  
-/*-------------------------------------------------------------------------------------------------------------------*/
 /*!************************************************************
  \brief Hex conversion constants
  *************************************************************/
@@ -1465,7 +1604,7 @@ char byte_to_hex_buffer[3]=
  \brief Read 2 hex characters from the serial buffer and convert them to a byte
  @return char data Read Data
  *************************************************************/
-char read_hex()
+char read_hex(void)
 {
   byte data;
   hex_to_byte_buffer[2]=get_char();
@@ -1480,7 +1619,7 @@ char read_hex()
  \brief Read a command from the serial port
  @return char 
  *************************************************************/
-char get_char()
+char get_char(void)
 {
   // read a command from the serial port
   while (Serial.available() <= 0);

--- a/LTSketchbook/Part Number/6000/6813/DC2350AB/DC2350AB.ino
+++ b/LTSketchbook/Part Number/6000/6813/DC2350AB/DC2350AB.ino
@@ -58,73 +58,87 @@
     @ingroup LTC6813-1
 */
 
-/*
-NOTES
- Setup:
-   Set the terminal baud rate to 115200 and select the newline terminator.
-   Ensure all jumpers on the demo board are installed in their default positions from the factory.
-   Refer to Demo Manual DC2259.
+/************************************* Read me *******************************************
+In this sketch book:
+  -All Global Variables are in Upper casing
+  -All Local Variables are in lower casing
+  -The Function wakeup_sleep(TOTAL_IC) : is used to wake the LTC681x from sleep state.
+   It is defined in LTC681x.cpp
+  -The Function wakeup_idle(TOTAL_IC) : is used to wake the ICs connected in daisy chain 
+   via the LTC6820 by initiating a dummy SPI communication. It is defined in LTC681x.cpp 
+*******************************************************************************************/
 
-USER INPUT DATA FORMAT:
- decimal : 1024
- hex     : 0x400
- octal   : 02000  (leading 0)
- binary  : B10000000000
- float   : 1024.0
- */
-
+/************************* Includes ***************************/
 #include <Arduino.h>
 #include <stdint.h>
+#include <SPI.h>
 #include "Linduino.h"
 #include "LT_SPI.h"
 #include "UserInterface.h"
 #include "LTC681x.h"
 #include "LTC6813.h"
-#include <SPI.h>
 
+/************************* Defines *****************************/
 #define ENABLED 1
 #define DISABLED 0
-
 #define DATALOG_ENABLED 1
 #define DATALOG_DISABLED 0
+#define PWM 1
+#define SCTL 2
 
-void print_menu();
-void print_config();
-void print_rxconfig();
+/**************** Local Function Declaration *******************/
+void measurement_loop(uint8_t datalog_en);
+void print_menu(void);
+void print_wrconfig(void);
+void print_wrconfigb(void);
+void print_rxconfig(void);
+void print_rxconfigb(void);
 void print_cells(uint8_t datalog_en);
 void print_aux(uint8_t datalog_en);
-void print_stat();
-void print_aux1();
-void print_statsoc();
-void print_open();
-void print_pwm();
-void print_rxpwm();
-void print_sctrl();
-void print_rxsctrl();
-void print_comm();
-void print_rxcomm();
+void print_stat(void);
+void print_aux1(uint8_t datalog_en);
+void print_sumofcells(void);
+void check_mux_fail(void);
+void print_selftest_errors(uint8_t adc_reg ,int8_t error);
+void print_overlap_results(int8_t error);
+void print_digital_redundancy_errors(uint8_t adc_reg ,int8_t error);
+void print_open_wires(void);
+void print_pec_error_count(void);
+int8_t select_s_pin(void);
+void print_wrpwm(void);
+void print_rxpwm(void);
+void print_wrsctrl(void);
+void print_rxsctrl(void);
+void print_wrpsb(uint8_t type);
+void print_rxpsb(uint8_t type);
+void print_wrcomm(void);
+void print_rxcomm(void);
+void check_mute_bit(void);
+void print_conv_time(uint32_t conv_time);
 void check_error(int error);
-void print_pec();
+void serial_print_text(char data[]);
 void serial_print_hex(uint8_t data);
-char get_char();
+char read_hex(void); 
+char get_char(void);
 
-/**********************************************************
+/*******************************************************************
   Setup Variables
-  The following variables can be modified to
-  configure the software.
-***********************************************************/
-const uint8_t TOTAL_IC = 2;//!<number of ICs in the daisy chain
+  The following variables can be modified to configure the software.
+********************************************************************/
+const uint8_t TOTAL_IC = 2;//!< Number of ICs in the daisy chain
 
-/*************************************************************************
+/********************************************************************
  ADC Command Configurations. See LTC681x.h for options
-**************************************************************************/
+*********************************************************************/
 const uint8_t ADC_OPT = ADC_OPT_DISABLED; //!< ADC Mode option bit
 const uint8_t ADC_CONVERSION_MODE =MD_7KHZ_3KHZ; //!< ADC Mode
 const uint8_t ADC_DCP = DCP_DISABLED; //!< Discharge Permitted 
 const uint8_t CELL_CH_TO_CONVERT =CELL_CH_ALL; //!< Channel Selection for ADC conversion
 const uint8_t AUX_CH_TO_CONVERT = AUX_CH_ALL; //!< Channel Selection for ADC conversion
 const uint8_t STAT_CH_TO_CONVERT = STAT_CH_ALL; //!< Channel Selection for ADC conversion
-const uint8_t NO_OF_REG = REG_ALL; //!< Register Selection
+const uint8_t SEL_ALL_REG = REG_ALL; //!< Register Selection 
+const uint8_t SEL_REG_A = REG_1; //!< Register Selection 
+const uint8_t SEL_REG_B = REG_2; //!< Register Selection 
 
 const uint16_t MEASUREMENT_LOOP_TIME = 500; //!< Loop Time in milliseconds(ms)
 
@@ -133,12 +147,12 @@ const uint16_t OV_THRESHOLD = 41000; //!< Over voltage threshold ADC Code. LSB =
 const uint16_t UV_THRESHOLD = 30000; //!< Under voltage threshold ADC Code. LSB = 0.0001 ---(3V)
 
 //Loop Measurement Setup. These Variables are ENABLED or DISABLED. Remember ALL CAPS
-const uint8_t WRITE_CONFIG = DISABLED; //!< Loop Measurement Setup
-const uint8_t READ_CONFIG = DISABLED; //!< Loop Measurement Setup
-const uint8_t MEASURE_CELL = ENABLED; //!< Loop Measurement Setup
-const uint8_t MEASURE_AUX = DISABLED; //!< Loop Measurement Setup
-const uint8_t MEASURE_STAT = DISABLED; //!< Loop Measurement Setup
-const uint8_t PRINT_PEC = DISABLED; //!< Loop Measurement Setup
+const uint8_t WRITE_CONFIG = DISABLED;  //!< This is to ENABLED or DISABLED writing into to configuration registers in a continuous loop
+const uint8_t READ_CONFIG = DISABLED; //!< This is to ENABLED or DISABLED reading the configuration registers in a continuous loop
+const uint8_t MEASURE_CELL = ENABLED; //!< This is to ENABLED or DISABLED measuring the cell voltages in a continuous loop
+const uint8_t MEASURE_AUX = DISABLED; //!< This is to ENABLED or DISABLED reading the auxiliary registers in a continuous loop
+const uint8_t MEASURE_STAT = DISABLED; //!< This is to ENABLED or DISABLED reading the status registers in a continuous loop
+const uint8_t PRINT_PEC = DISABLED; //!< This is to ENABLED or DISABLED printing the PEC Error Count in a continuous loop
 /************************************
   END SETUP
 *************************************/
@@ -149,27 +163,24 @@ const uint8_t PRINT_PEC = DISABLED; //!< Loop Measurement Setup
  register reads and the array lengths must be based
  on the number of ICs on the stack
  ******************************************************/
-
-cell_asic bms_ic[TOTAL_IC]; //!< Global Battery Variable
+cell_asic BMS_IC[TOTAL_IC]; //!< Global Battery Variable
 
 /*************************************************************************
  Set configuration register. Refer to the data sheet
 **************************************************************************/
-
 bool REFON = true; //!< Reference Powered Up Bit
 bool ADCOPT = false; //!< ADC Mode option bit
-bool gpioBits_a[5] = {false,false,false,false,false}; //!< GPIO Pin Control // Gpio 1,2,3,4,5
-bool gpioBits_b[4] = {false,false,false,false}; //!< GPIO Pin Control // Gpio 6,7,8,9
+bool GPIOBITS_A[5] = {false,false,true,true,true}; //!< GPIO Pin Control // Gpio 1,2,3,4,5
+bool GPIOBITS_B[4] = {false,false,false,false}; //!< GPIO Pin Control // Gpio 6,7,8,9
 uint16_t UV=UV_THRESHOLD; //!< Under voltage Comparison Voltage
 uint16_t OV=OV_THRESHOLD; //!< Over voltage Comparison Voltage
-bool dccBits_a[12] = {false,false,false,false,false,false,false,false,false,false,false,false}; //!< Discharge cell switch //Dcc 1,2,3,4,5,6,7,8,9,10,11,12
-bool dccBits_b[7]= {false,false,false,false,false,false,false}; //!< Discharge cell switch //Dcc 0,13,14,15
-bool dctoBits[4] = {true,false,true,false}; //!< Discharge time value //Dcto 0,1,2,3  // Programed for 4 min 
+bool DCCBITS_A[12] = {false,false,false,false,false,false,false,false,false,false,false,false}; //!< Discharge cell switch //Dcc 1,2,3,4,5,6,7,8,9,10,11,12
+bool DCCBITS_B[7]= {false,false,false,false,false,false,false}; //!< Discharge cell switch //Dcc 0,13,14,15
+bool DCTOBITS[4] = {true,false,true,false}; //!< Discharge time value //Dcto 0,1,2,3  // Programed for 4 min 
 /*Ensure that Dcto bits are set according to the required discharge time. Refer to the data sheet */
 bool FDRF = false; //!< Force Digital Redundancy Failure Bit
 bool DTMEN = true; //!< Enable Discharge Timer Monitor
-bool psBits[2]= {false,false}; //!< Digital Redundancy Path Selection//ps-0,1
-
+bool PSBITS[2]= {false,false}; //!< Digital Redundancy Path Selection//ps-0,1
 
 /*!**********************************************************************
  \brief  Initializes hardware and variables
@@ -180,15 +191,15 @@ void setup()
   Serial.begin(115200);
   quikeval_SPI_connect();
   spi_enable(SPI_CLOCK_DIV16); // This will set the Linduino to have a 1MHz Clock
-  LTC6813_init_cfg(TOTAL_IC, bms_ic);
-  LTC6813_init_cfgb(TOTAL_IC,bms_ic);
+  LTC6813_init_cfg(TOTAL_IC, BMS_IC);
+  LTC6813_init_cfgb(TOTAL_IC,BMS_IC);
   for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
   {
-    LTC6813_set_cfgr(current_ic,bms_ic,REFON,ADCOPT,gpioBits_a,dccBits_a, dctoBits, UV, OV);
-    LTC6813_set_cfgrb(current_ic,bms_ic,FDRF,DTMEN,psBits,gpioBits_b,dccBits_b);   
+    LTC6813_set_cfgr(current_ic,BMS_IC,REFON,ADCOPT,GPIOBITS_A,DCCBITS_A, DCTOBITS, UV, OV);
+    LTC6813_set_cfgrb(current_ic,BMS_IC,FDRF,DTMEN,PSBITS,GPIOBITS_B,DCCBITS_B);   
   }   
-  LTC6813_reset_crc_count(TOTAL_IC,bms_ic);
-  LTC6813_init_reg_limits(TOTAL_IC,bms_ic);
+  LTC6813_reset_crc_count(TOTAL_IC,BMS_IC);
+  LTC6813_init_reg_limits(TOTAL_IC,BMS_IC);
   print_menu();
 }
 
@@ -221,52 +232,49 @@ void loop()
 void run_command(uint32_t cmd)
 {
   
-  const uint8_t STREG=0; 
+  uint8_t streg=0; 
   int8_t error = 0;
   uint32_t conv_time = 0;
-  uint32_t user_command;
-  int8_t readIC=0;
-  char input = 0;
+  int8_t s_pin_read=0;
   
   switch (cmd)
   {
-  
     case 1: // Write and read Configuration Register
       wakeup_sleep(TOTAL_IC);
-      LTC6813_wrcfg(TOTAL_IC,bms_ic);
-      LTC6813_wrcfgb(TOTAL_IC,bms_ic);
-      print_config();
+      LTC6813_wrcfg(TOTAL_IC,BMS_IC); // Write into Configuration Register
+      LTC6813_wrcfgb(TOTAL_IC,BMS_IC); // Write into Configuration Register B
+      print_wrconfig();
+      print_wrconfigb();
       
       wakeup_idle(TOTAL_IC);
-      error = LTC6813_rdcfg(TOTAL_IC,bms_ic); // Read Configuration Register
+      error = LTC6813_rdcfg(TOTAL_IC,BMS_IC); // Read Configuration Register
       check_error(error);
-      error = LTC6813_rdcfgb(TOTAL_IC,bms_ic); // Read Configuration Register
+      error = LTC6813_rdcfgb(TOTAL_IC,BMS_IC); // Read Configuration Register B
       check_error(error);
       print_rxconfig();
+      print_rxconfigb();
       break;
 
     case 2: // Read Configuration Register
       wakeup_sleep(TOTAL_IC);
-      error = LTC6813_rdcfg(TOTAL_IC,bms_ic);
+      error = LTC6813_rdcfg(TOTAL_IC,BMS_IC);
       check_error(error);
-      error = LTC6813_rdcfgb(TOTAL_IC,bms_ic);
+      error = LTC6813_rdcfgb(TOTAL_IC,BMS_IC);
       check_error(error);
       print_rxconfig();
+      print_rxconfigb();
       break;
       
     case 3: // Start Cell ADC Measurement
       wakeup_sleep(TOTAL_IC);
       LTC6813_adcv(ADC_CONVERSION_MODE,ADC_DCP,CELL_CH_TO_CONVERT);
       conv_time = LTC6813_pollAdc();
-      Serial.print(F("cell conversion completed in:"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       break;
     
     case 4: // Read Cell Voltage Registers
       wakeup_sleep(TOTAL_IC);
-      error = LTC6813_rdcv(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all cell voltage registers 
+      error = LTC6813_rdcv(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all cell voltage registers 
       check_error(error);
       print_cells(DATALOG_DISABLED);
       break;
@@ -275,15 +283,12 @@ void run_command(uint32_t cmd)
       wakeup_sleep(TOTAL_IC);
       LTC6813_adax(ADC_CONVERSION_MODE, AUX_CH_TO_CONVERT);
       conv_time = LTC6813_pollAdc();
-      Serial.print(F("Auxiliary conversion completed in :"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       break;
     
     case 6: // Read AUX Voltage Registers
       wakeup_sleep(TOTAL_IC);
-      error = LTC6813_rdaux(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all aux registers
+      error = LTC6813_rdaux(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all aux registers
       check_error(error);
       print_aux(DATALOG_DISABLED);
       break;
@@ -292,15 +297,12 @@ void run_command(uint32_t cmd)
       wakeup_sleep(TOTAL_IC);
       LTC6813_adstat(ADC_CONVERSION_MODE, STAT_CH_TO_CONVERT);
       conv_time = LTC6813_pollAdc();
-      Serial.print(F("stat conversion completed in :"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       break;
     
     case 8: // Read Status registers
       wakeup_sleep(TOTAL_IC);
-      error = LTC6813_rdstat(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all aux registers
+      error = LTC6813_rdstat(SEL_ALL_REG,TOTAL_IC,BMS_IC); // Set to read back all stat registers
       check_error(error);
       print_stat();
       break;
@@ -309,188 +311,164 @@ void run_command(uint32_t cmd)
       wakeup_sleep(TOTAL_IC);
       LTC6813_adcvax(ADC_CONVERSION_MODE,ADC_DCP);
       conv_time = LTC6813_pollAdc();
-      Serial.println(F("Start Combined Cell Voltage and GPIO1, GPIO2 conversion completed"));
-      Serial.print(F("conversion completed in:"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       wakeup_idle(TOTAL_IC);
-      error = LTC6813_rdcv(NO_OF_REG, TOTAL_IC,bms_ic); // Set to read back all cell voltage registers
+      error = LTC6813_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC); // Set to read back all cell voltage registers
       check_error(error);
       print_cells(DATALOG_DISABLED);
       wakeup_idle(TOTAL_IC);
-      error = LTC6813_rdaux(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all aux registers
+      error = LTC6813_rdaux(SEL_REG_A,TOTAL_IC,BMS_IC); // Set to read back aux register A
       check_error(error);
       print_aux1(DATALOG_DISABLED);
-      Serial.println();
       break;
       
     case 10: //Start Combined Cell Voltage and Sum of cells
       wakeup_sleep(TOTAL_IC);
       LTC6813_adcvsc(ADC_CONVERSION_MODE,ADC_DCP);
       conv_time = LTC6813_pollAdc();
-      Serial.print(F("Combined Cell Voltage conversion completed in:"));
-      Serial.print(((float)conv_time/1000), 1);
-      Serial.println(F("ms"));
-      Serial.println();
+      print_conv_time(conv_time);
       wakeup_idle(TOTAL_IC);
-      error = LTC6813_rdcv(NO_OF_REG, TOTAL_IC,bms_ic); // Set to read back all cell voltage registers
+      error = LTC6813_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC); // Set to read back all cell voltage registers
       check_error(error);
       print_cells(DATALOG_DISABLED);
       wakeup_idle(TOTAL_IC);
-      error = LTC6813_rdstat(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all stat registers
+      error = LTC6813_rdstat(SEL_REG_A,TOTAL_IC,BMS_IC); // Set to read back stat register A
       check_error(error);
-      print_statsoc();
-      Serial.println();
+      print_sumofcells();
       break;
       
-    case 11:  // Loop Measurements with out data-log output
-      Serial.println(F("transmit 'm' to quit"));
+    case 11: // Loop Measurements of configuration register or cell voltages or auxiliary register or status register without data-log output
       wakeup_sleep(TOTAL_IC);
-      LTC6813_wrcfg(TOTAL_IC,bms_ic);
-      LTC6813_wrcfgb(TOTAL_IC,bms_ic);
-      while (input != 'm')
-      {
-        if (Serial.available() > 0)
-        {
-          input = read_char();
-        }
-        measurement_loop(DATALOG_DISABLED);
-      
-        delay(MEASUREMENT_LOOP_TIME);
-      }
+      LTC6813_wrcfg(TOTAL_IC,BMS_IC);
+      LTC6813_wrcfgb(TOTAL_IC,BMS_IC);
+      measurement_loop(DATALOG_DISABLED);
       print_menu();
       break;
       
-    case 12: //Data-log print option Loop Measurements
-      Serial.println(F("transmit 'm' to quit"));
+    case 12: // Data-log print option Loop Measurements of configuration register or cell voltages or auxiliary register or status register
       wakeup_sleep(TOTAL_IC);
-      LTC6813_wrcfg(TOTAL_IC,bms_ic);
-      LTC6813_wrcfgb(TOTAL_IC,bms_ic);
-      while (input != 'm')
-      {
-        if (Serial.available() > 0)
-        {
-          input = read_char();
-        }
-        measurement_loop(DATALOG_ENABLED);
-        delay(MEASUREMENT_LOOP_TIME);
-       }
-      Serial.println(); 
+      LTC6813_wrcfg(TOTAL_IC,BMS_IC);
+      LTC6813_wrcfgb(TOTAL_IC,BMS_IC);
+      measurement_loop(DATALOG_ENABLED);
       print_menu();
       break;
+
+    case 13: // Clear all ADC measurement registers
+      wakeup_sleep(TOTAL_IC);
+      LTC6813_clrcell();
+      LTC6813_clraux();
+      LTC6813_clrstat();
+      wakeup_idle(TOTAL_IC);
+      LTC6813_rdcv(SEL_ALL_REG, TOTAL_IC,BMS_IC); // read back all cell voltage registers
+      print_cells(DATALOG_DISABLED);
+      LTC6813_rdaux(SEL_ALL_REG,TOTAL_IC,BMS_IC); // read back all auxiliary registers
+      print_aux(DATALOG_DISABLED);
+      LTC6813_rdstat(SEL_ALL_REG,TOTAL_IC,BMS_IC); // read back all status registers
+      print_stat();         
+      break; 
       
-    case 13: // Run the Mux Decoder Self Test
+    case 14: // Run the Mux Decoder Self Test
       wakeup_sleep(TOTAL_IC);
       LTC6813_diagn();
       LTC6813_pollAdc();
-      error = LTC6813_rdstat(NO_OF_REG,TOTAL_IC,bms_ic); // Set to read back all aux registers
+      error = LTC6813_rdstat(SEL_REG_B,TOTAL_IC,BMS_IC); // Set to read back register B
       check_error(error);
-      for (int ic = 0; ic<TOTAL_IC; ic++)
-        { error = 0;
-          Serial.print(" IC ");
-          Serial.println(ic+1,DEC);
-          if (bms_ic[ic].stat.mux_fail[0] != 0) error++;
-        
-          if (error==0) Serial.println(F("Mux Test: PASS "));
-          else Serial.println(F("Mux Test: FAIL "));
-        }
-      Serial.println("");
+      check_mux_fail();
       break;
       
-    case 14:  // Run the ADC/Memory Self Test
+    case 15:  // Run the ADC/Memory Self Test
+      error = 0;
       wakeup_sleep(TOTAL_IC);
-      error = LTC6813_run_cell_adc_st(CELL,TOTAL_IC,bms_ic,ADC_CONVERSION_MODE,ADCOPT);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in Digital Filter and CELL Memory \n"));
+      error = LTC6813_run_cell_adc_st(CELL,TOTAL_IC,BMS_IC,ADC_CONVERSION_MODE,ADCOPT);
+      print_selftest_errors(CELL, error);
+
+      error = 0;
+      wakeup_sleep(TOTAL_IC);
+      error = LTC6813_run_cell_adc_st(AUX,TOTAL_IC, BMS_IC,ADC_CONVERSION_MODE,ADCOPT);
+      print_selftest_errors(AUX, error);
       
+      error = 0;
       wakeup_sleep(TOTAL_IC);
-      error = LTC6813_run_cell_adc_st(AUX,TOTAL_IC, bms_ic,ADC_CONVERSION_MODE,ADCOPT);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in Digital Filter and AUX Memory \n"));
-      
-      wakeup_sleep(TOTAL_IC);
-      error = LTC6813_run_cell_adc_st(STAT,TOTAL_IC, bms_ic,ADC_CONVERSION_MODE,ADCOPT);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in Digital Filter and STAT Memory \n"));
+      error = LTC6813_run_cell_adc_st(STAT,TOTAL_IC, BMS_IC,ADC_CONVERSION_MODE,ADCOPT);
+      print_selftest_errors(STAT, error);
       break;
 
-    case 15: // Run ADC Overlap self test
+    case 16: // Run ADC Overlap self test
       wakeup_sleep(TOTAL_IC);
-      error = (int8_t)LTC6813_run_adc_overlap(TOTAL_IC,bms_ic);
-      if (error==0) Serial.println(F("Overlap Test: PASS "));
-      else Serial.println(F("Overlap Test: FAIL"));
-      Serial.println();
+      error = (int8_t)LTC6813_run_adc_overlap(TOTAL_IC,BMS_IC);
+      print_overlap_results(error);
       break;
     
-    case 16: // Run ADC Redundancy self test
+    case 17: // Run ADC Redundancy self test
       wakeup_sleep(TOTAL_IC);
-      error = LTC6813_run_adc_redundancy_st(ADC_CONVERSION_MODE,AUX,TOTAL_IC, bms_ic);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in AUX Measurement \n"));
+      error = LTC6813_run_adc_redundancy_st(ADC_CONVERSION_MODE,AUX,TOTAL_IC, BMS_IC);
+      print_digital_redundancy_errors(AUX, error);
       
       wakeup_sleep(TOTAL_IC);
-      error = LTC6813_run_adc_redundancy_st(ADC_CONVERSION_MODE,STAT,TOTAL_IC, bms_ic);
-      Serial.print(error, DEC);
-      Serial.println(F(" : errors detected in STAT Measurement \n"));
+      error = LTC6813_run_adc_redundancy_st(ADC_CONVERSION_MODE,STAT,TOTAL_IC, BMS_IC);
+      print_digital_redundancy_errors(STAT, error);
       break;
       
-    case 17: // Run open wire self test for single cell detection
+    case 18: // Run open wire self test for single cell detection
       wakeup_sleep(TOTAL_IC);
-      LTC6813_run_openwire_single(TOTAL_IC, bms_ic);
-      print_open();
-      Serial.println();   
+      LTC6813_run_openwire_single(TOTAL_IC, BMS_IC);
+      print_open_wires();
       break;
 
-    case 18: // Run open wire self test for multiple cell and two consecutive cells detection
+    case 19: // Run open wire self test for multiple cell and two consecutive cells detection
       wakeup_sleep(TOTAL_IC);
-      LTC6813_run_openwire_multi(TOTAL_IC, bms_ic);
-      Serial.println();   
+      LTC6813_run_openwire_multi(TOTAL_IC, BMS_IC);  
       break;
+
+    case 20: // Open wire Diagnostic for Auxiliary Measurements
+      wakeup_sleep(TOTAL_IC);
+      LTC6813_run_gpio_openwire(TOTAL_IC, BMS_IC);
+      print_open_wires();
+      break;  
       
-    case 19: //print pec counter
-      print_pec();
-      Serial.println();
+    case 21: // Print pec counter
+      print_pec_error_count();
       break;
     
-    case 20:// Reset pec counter
-      LTC6813_reset_crc_count(TOTAL_IC,bms_ic);
-      Serial.println("PEC Counters is Reset");
-      Serial.println();
+    case 22:// Reset pec counter
+      LTC6813_reset_crc_count(TOTAL_IC,BMS_IC);
+      print_pec_error_count();
       break;
        
-    case 21: // Enable a discharge transistor
-      Serial.println(F("Please enter the Spin number"));
-      readIC = (int8_t)read_int();
-      Serial.println(readIC);
+    case 23: // Enable a discharge transistor
+      s_pin_read = select_s_pin();
       wakeup_sleep(TOTAL_IC);
-      LTC6813_set_discharge(readIC,TOTAL_IC,bms_ic);
-      LTC6813_wrcfg(TOTAL_IC,bms_ic);
-      LTC6813_wrcfgb(TOTAL_IC,bms_ic);
-      print_config();
+      LTC6813_set_discharge(s_pin_read,TOTAL_IC,BMS_IC);
+      LTC6813_wrcfg(TOTAL_IC,BMS_IC);
+      LTC6813_wrcfgb(TOTAL_IC,BMS_IC);
+      print_wrconfig();
+      print_wrconfigb();
       wakeup_idle(TOTAL_IC);
-      error = LTC6813_rdcfg(TOTAL_IC,bms_ic);
+      error = LTC6813_rdcfg(TOTAL_IC,BMS_IC);
       check_error(error);
-      error = LTC6813_rdcfgb(TOTAL_IC,bms_ic);
+      error = LTC6813_rdcfgb(TOTAL_IC,BMS_IC);
       check_error(error);
       print_rxconfig();
+      print_rxconfigb();
       break;
     
-    case 22: // Clear all discharge transistors
+    case 24: // Clear all discharge transistors
       wakeup_sleep(TOTAL_IC);
-      LTC6813_clear_discharge(TOTAL_IC,bms_ic);
-      LTC6813_wrcfg(TOTAL_IC,bms_ic);
-      LTC6813_wrcfgb(TOTAL_IC,bms_ic);
-      print_config();
+      LTC6813_clear_discharge(TOTAL_IC,BMS_IC);
+      LTC6813_wrcfg(TOTAL_IC,BMS_IC);
+      LTC6813_wrcfgb(TOTAL_IC,BMS_IC);
+      print_wrconfig();
+      print_wrconfigb();
       wakeup_idle(TOTAL_IC);
-      error = LTC6813_rdcfg(TOTAL_IC,bms_ic);
+      error = LTC6813_rdcfg(TOTAL_IC,BMS_IC);
       check_error(error);
-      error = LTC6813_rdcfgb(TOTAL_IC,bms_ic);
+      error = LTC6813_rdcfgb(TOTAL_IC,BMS_IC);
       check_error(error);
       print_rxconfig();
+      print_rxconfigb();
       break;
       
-    case 23://Write and read pwm configuration
+    case 25://Write and read pwm configuration
        /*****************************************************
          PWM configuration data.
          1)Set the corresponding DCC bit to one for pwm operation. 
@@ -503,338 +481,336 @@ void run_command(uint32_t cmd)
 
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        bms_ic[current_ic].pwm.tx_data[0]= 0x88; //Duty cycle for S pin 2 and 1
-        bms_ic[current_ic].pwm.tx_data[1]= 0x88; //Duty cycle for S pin 4 and 3
-        bms_ic[current_ic].pwm.tx_data[2]= 0x88; //Duty cycle for S pin 6 and 5
-        bms_ic[current_ic].pwm.tx_data[3]= 0x88; //Duty cycle for S pin 8 and 7
-        bms_ic[current_ic].pwm.tx_data[4]= 0x88; //Duty cycle for S pin 10 and 9
-        bms_ic[current_ic].pwm.tx_data[5]= 0x88; //Duty cycle for S pin 12 and 11
+        BMS_IC[current_ic].pwm.tx_data[0]= 0x88; //Duty cycle for S pin 2 and 1
+        BMS_IC[current_ic].pwm.tx_data[1]= 0x88; //Duty cycle for S pin 4 and 3
+        BMS_IC[current_ic].pwm.tx_data[2]= 0x88; //Duty cycle for S pin 6 and 5
+        BMS_IC[current_ic].pwm.tx_data[3]= 0x88; //Duty cycle for S pin 8 and 7
+        BMS_IC[current_ic].pwm.tx_data[4]= 0x88; //Duty cycle for S pin 10 and 9
+        BMS_IC[current_ic].pwm.tx_data[5]= 0x88; //Duty cycle for S pin 12 and 11
       } 
          
-      LTC6813_wrpwm(TOTAL_IC,0,bms_ic); //Write pwm configuration  
+      LTC6813_wrpwm(TOTAL_IC,0,BMS_IC); //Write pwm configuration  
 
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        bms_ic[current_ic].pwmb.tx_data[0]= 0x88; //Duty cycle for S pin 14 and 13
-        bms_ic[current_ic].pwmb.tx_data[1]= 0x88; //Duty cycle for S pin 16 and 15
-        bms_ic[current_ic].pwmb.tx_data[2]= 0x88; //Duty cycle for S pin 18 and 17
+        BMS_IC[current_ic].pwmb.tx_data[0]= 0x88; //Duty cycle for S pin 14 and 13
+        BMS_IC[current_ic].pwmb.tx_data[1]= 0x88; //Duty cycle for S pin 16 and 15
+        BMS_IC[current_ic].pwmb.tx_data[2]= 0x88; //Duty cycle for S pin 18 and 17
       }
    
-      LTC6813_wrpsb(TOTAL_IC,bms_ic); //  Write PWM/S control register  group B
-      print_pwm();
+      LTC6813_wrpsb(TOTAL_IC,BMS_IC); //  Write PWM/S control register  group B
+      print_wrpwm();
+      print_wrpsb(PWM);
 
       wakeup_idle(TOTAL_IC);
-      error=LTC6813_rdpwm(TOTAL_IC,0,bms_ic); // Read pwm configuration  
+      error=LTC6813_rdpwm(TOTAL_IC,0,BMS_IC); // Read pwm configuration  
       check_error(error);
       
-      error=LTC6813_rdpsb(TOTAL_IC,bms_ic); // Read PWM/S Control Register Group
+      error=LTC6813_rdpsb(TOTAL_IC,BMS_IC); // Read PWM/S Control Register Group
       check_error(error);        
-      print_rxpwm();                              
+      print_rxpwm();
+      print_rxpsb(PWM);                              
       break;
 
-    case 24: // Write and read S Control Register Group
+    case 26: // Write and read S Control Register Group
       /**************************************************************************************
          S pin control. 
          1)Ensure that the pwm is set according to the requirement using the previous case.
          2)Choose the value depending on the required number of pulses on S pin. 
-         Reffer to the data sheet. 
+         Refer to the data sheet. 
       ***************************************************************************************/
       wakeup_sleep(TOTAL_IC);
       
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        bms_ic[current_ic].sctrl.tx_data[0]= 0xFF; // No. of high pulses on S pin 2 and 1
-        bms_ic[current_ic].sctrl.tx_data[1]= 0xFF; // No. of high pulses on S pin 4 and 3
-        bms_ic[current_ic].sctrl.tx_data[2]= 0xFF; // No. of high pulses on S pin 6 and 5
-        bms_ic[current_ic].sctrl.tx_data[3]= 0xFF; // No. of high pulses on S pin 8 and 7
-        bms_ic[current_ic].sctrl.tx_data[4]= 0xFF; // No. of high pulses on S pin 10 and 9
-        bms_ic[current_ic].sctrl.tx_data[5]= 0xFF; // No. of high pulses on S pin 12 and 11
+        BMS_IC[current_ic].sctrl.tx_data[0]= 0xFF; // No. of high pulses on S pin 2 and 1
+        BMS_IC[current_ic].sctrl.tx_data[1]= 0xFF; // No. of high pulses on S pin 4 and 3
+        BMS_IC[current_ic].sctrl.tx_data[2]= 0xFF; // No. of high pulses on S pin 6 and 5
+        BMS_IC[current_ic].sctrl.tx_data[3]= 0xFF; // No. of high pulses on S pin 8 and 7
+        BMS_IC[current_ic].sctrl.tx_data[4]= 0xFF; // No. of high pulses on S pin 10 and 9
+        BMS_IC[current_ic].sctrl.tx_data[5]= 0xFF; // No. of high pulses on S pin 12 and 11
       }
     
-      LTC6813_wrsctrl(TOTAL_IC,STREG,bms_ic); // Write S Control Register Group
+      LTC6813_wrsctrl(TOTAL_IC,streg,BMS_IC); // Write S Control Register Group
 
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        bms_ic[current_ic].sctrlb.tx_data[3]= 0xFF; // No. of high pulses on S pin 14 and 13
-        bms_ic[current_ic].sctrlb.tx_data[4]= 0xFF; // No. of high pulses on S pin 16 and 15
-        bms_ic[current_ic].sctrlb.tx_data[5]= 0xFF; // No. of high pulses on S pin 18 and 17
+        BMS_IC[current_ic].sctrlb.tx_data[3]= 0xFF; // No. of high pulses on S pin 14 and 13
+        BMS_IC[current_ic].sctrlb.tx_data[4]= 0xFF; // No. of high pulses on S pin 16 and 15
+        BMS_IC[current_ic].sctrlb.tx_data[5]= 0xFF; // No. of high pulses on S pin 18 and 17
       }
 
-      LTC6813_wrpsb(TOTAL_IC,bms_ic); //  Write PWM/S control register group B
-      print_sctrl();     
+      LTC6813_wrpsb(TOTAL_IC,BMS_IC); //  Write PWM/S control register group B
+      print_wrsctrl();
+      print_wrpsb(SCTL);     
 
       wakeup_idle(TOTAL_IC);
       LTC6813_stsctrl(); // Start S Control pulsing
-      LTC6813_pollAdc();
-      Serial.println(F("Start S Control Pulsing"));
-      Serial.println();
-
+      
       wakeup_idle(TOTAL_IC);
-      error=LTC6813_rdsctrl(TOTAL_IC,STREG,bms_ic); // Read S Control Register Group
+      error=LTC6813_rdsctrl(TOTAL_IC,streg,BMS_IC); // Read S Control Register Group
       check_error(error);
       
-      error=LTC6813_rdpsb(TOTAL_IC,bms_ic); // Read PWM/S Control Register Group
+      error=LTC6813_rdpsb(TOTAL_IC,BMS_IC); // Read PWM/S Control Register Group
       check_error(error); 
       print_rxsctrl(); 
+      print_rxpsb(SCTL);
       break;
         
-    case 25: // Clear S Control Register Group
+    case 27: // Clear S Control Register Group
       wakeup_sleep(TOTAL_IC);
       LTC6813_clrsctrl();
-      Serial.println(F("S Control Register Cleared"));
-      error=LTC6813_rdsctrl(TOTAL_IC,STREG,bms_ic);
+      wakeup_idle(TOTAL_IC);
+      error=LTC6813_rdsctrl(TOTAL_IC,streg,BMS_IC);
       check_error(error);
-      LTC6813_rdpsb(TOTAL_IC,bms_ic);       
+      LTC6813_rdpsb(TOTAL_IC,BMS_IC);       
       print_rxsctrl();
+      print_rxpsb(SCTL);
       break;
       
-    case 26://SPI Communication 
-      wakeup_sleep(TOTAL_IC);
-       /************************************************************
-         Communication control bits and communication data bytes. 
-         Refer to the data sheet. 
+    case 28://SPI Communication 
+      /************************************************************
+         Ensure to set the GPIO bits to 1 in the CFG register group. 
       *************************************************************/  
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        bms_ic[current_ic].com.tx_data[0]= 0x80; //comm data to be transmitted
-        bms_ic[current_ic].com.tx_data[1]= 0x00;
-        bms_ic[current_ic].com.tx_data[2]= 0xA2;
-        bms_ic[current_ic].com.tx_data[3]= 0x20;
-        bms_ic[current_ic].com.tx_data[4]= 0xA3;
-        bms_ic[current_ic].com.tx_data[5]= 0x39;
+        //Communication control bits and communication data bytes. Refer to the data sheet.
+        BMS_IC[current_ic].com.tx_data[0]= 0x81; // Icom CSBM Low(8) + data D0 (0x11)
+        BMS_IC[current_ic].com.tx_data[1]= 0x10; // Fcom CSBM Low(0) 
+        BMS_IC[current_ic].com.tx_data[2]= 0xA2; // Icom CSBM Falling Edge (A) + data D1 (0x25)
+        BMS_IC[current_ic].com.tx_data[3]= 0x50; // Fcom CSBM Low(0)    
+        BMS_IC[current_ic].com.tx_data[4]= 0xA1; // Icom CSBM Falling Edge (A) + data D2 (0x17)
+        BMS_IC[current_ic].com.tx_data[5]= 0x79; // Fcom CSBM High(9)
       }
-      LTC6813_wrcomm(TOTAL_IC,bms_ic);               
-      print_comm();
+      wakeup_sleep(TOTAL_IC);   
+      LTC6813_wrcomm(TOTAL_IC,BMS_IC);               
+      print_wrcomm();
+
       wakeup_idle(TOTAL_IC);
-      LTC6813_stcomm();
-      LTC6813_pollAdc();      
-      Serial.println(F("SPI Communication completed"));
-      Serial.println();
+      LTC6813_stcomm(3); 
+
       wakeup_idle(TOTAL_IC);
-      error = LTC6813_rdcomm(TOTAL_IC,bms_ic);                       
+      error = LTC6813_rdcomm(TOTAL_IC,BMS_IC);                       
       check_error(error);
       print_rxcomm();  
       break;
-      
-    case 27: // write byte I2C Communication on the GPIO Ports(using eeprom 24AA01)
-      wakeup_sleep(TOTAL_IC); 
-      /************************************************************
-         Communication control bits and communication data bytes. 
-         Refer to the data sheet. 
-      *************************************************************/    
-      for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
-      {        
-        bms_ic[current_ic].com.tx_data[0]= 0x6A; // Icom(6)Start + I2C_address D0 (1010 0000)
-        bms_ic[current_ic].com.tx_data[1]= 0x00; // Fcom master ack  
-        bms_ic[current_ic].com.tx_data[2]= 0x00; // eeprom address D1 (0000 0000)
-        bms_ic[current_ic].com.tx_data[3]= 0x00; // Fcom master ack 
-        bms_ic[current_ic].com.tx_data[4]= 0x01; // Icom BLANCK D2 (0Xxx)
-        bms_ic[current_ic].com.tx_data[5]= 0x29; // Fcom master nack+stop 
-      }
-      LTC6813_wrcomm(TOTAL_IC,bms_ic);// write comm register    
-      print_comm();
-      wakeup_idle(TOTAL_IC);                 
-      LTC6813_stcomm();
-      LTC6813_pollAdc();
-      Serial.println(F("I2C Communication completed"));
-      Serial.println();
-      wakeup_idle(TOTAL_IC);             
-      error = LTC6813_rdcomm(TOTAL_IC,bms_ic); // Read comm register                       
-      check_error(error);
-      print_rxcomm(); // Print comm register  
-      break; 
-      
-    case 28: // Read byte data I2C Communication on the GPIO Ports(using eeprom 24AA01)
-      wakeup_sleep(TOTAL_IC);
-        /************************************************************
-         Communication control bits and communication data bytes. 
-         Refer to the data sheet. 
+
+  case 29: // Write byte I2C Communication on the GPIO Ports(using I2C eeprom 24LC025)
+       /************************************************************
+         Ensure to set the GPIO bits to 1 in the CFG register group. 
       *************************************************************/   
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
-      {      
-        bms_ic[current_ic].com.tx_data[0]= 0x6A; // Icom(6)Start + I2C_address D0 (1010 0000)
-        bms_ic[current_ic].com.tx_data[1]= 0x10; // Fcom master ack 
-        bms_ic[current_ic].com.tx_data[2]= 0x60; // again start I2C with I2C_address (1010 0001)
-        bms_ic[current_ic].com.tx_data[3]= 0x19; // fcom master nack + stop 
-      }          
-      LTC6813_wrcomm(TOTAL_IC,bms_ic);
-      wakeup_idle(TOTAL_IC);              
-      LTC6813_stcomm();// I2C for write data in slave device    
-      LTC6813_pollAdc();
-      error = LTC6813_rdcomm(TOTAL_IC,bms_ic); // Read comm register                 
-      check_error(error);
-      print_rxcomm(); // Print comm register   
-      break;  
+      {
+        //Communication control bits and communication data bytes. Refer to the data sheet.
+        BMS_IC[current_ic].com.tx_data[0]= 0x6A; // Icom Start(6) + I2C_address D0 (0xA0)
+        BMS_IC[current_ic].com.tx_data[1]= 0x08; // Fcom master NACK(8)  
+        BMS_IC[current_ic].com.tx_data[2]= 0x00; // Icom Blank (0) + eeprom address D1 (0x00)
+        BMS_IC[current_ic].com.tx_data[3]= 0x08; // Fcom master NACK(8)   
+        BMS_IC[current_ic].com.tx_data[4]= 0x01; // Icom Blank (0) + data D2 (0x13)
+        BMS_IC[current_ic].com.tx_data[5]= 0x39; // Fcom master NACK + Stop(9) 
+      }
+      wakeup_sleep(TOTAL_IC);       
+      LTC6813_wrcomm(TOTAL_IC,BMS_IC); // write to comm register    
+      print_wrcomm(); // print transmitted data from the comm register
 
-    case 29: //  Enable MUTE
-      wakeup_sleep(TOTAL_IC);
-      LTC6813_wrcfg(TOTAL_IC,bms_ic);
-      LTC6813_wrcfgb(TOTAL_IC,bms_ic);
-      LTC6813_mute(); 
-      Serial.println("Received Configuration register after enabling MUTE");
       wakeup_idle(TOTAL_IC);
-      error = LTC6813_rdcfg(TOTAL_IC,bms_ic);
-      check_error(error);
-      error = LTC6813_rdcfgb(TOTAL_IC,bms_ic);
-      check_error(error);
-      print_rxconfig();
-      break;
-      
-    case 30: // TO enable UNMUTE 
-      wakeup_sleep(TOTAL_IC);
-      LTC6813_wrcfg(TOTAL_IC,bms_ic);
-      LTC6813_wrcfgb(TOTAL_IC,bms_ic);
-      LTC6813_unmute();
-      Serial.println(" Received Configuration register after disabling MUTE");
+      LTC6813_stcomm(3); // data length=3 // initiates communication between master and the I2C slave
+
       wakeup_idle(TOTAL_IC);
-      error = LTC6813_rdcfg(TOTAL_IC,bms_ic);
+      error = LTC6813_rdcomm(TOTAL_IC,BMS_IC); // read from comm register                        
       check_error(error);
-      error = LTC6813_rdcfgb(TOTAL_IC,bms_ic);
-      check_error(error);
-      print_rxconfig();
-      break;
-      
-    case 31: // Clear all ADC measurement registers
-      wakeup_sleep(TOTAL_IC);
-      LTC6813_clrcell();
-      LTC6813_clraux();
-      LTC6813_clrstat();
-      Serial.println(F("All Registers Cleared"));
-      wakeup_idle(TOTAL_IC);
-      error = LTC6813_rdcv(NO_OF_REG, TOTAL_IC,bms_ic); // read back all cell voltage registers
-      check_error(error);
-      print_cells(DATALOG_DISABLED);
-      error = LTC6813_rdaux(NO_OF_REG,TOTAL_IC,bms_ic); // read back all auxiliary registers
-      check_error(error);
-      print_aux(DATALOG_DISABLED);
-      error = LTC6813_rdstat(NO_OF_REG,TOTAL_IC,bms_ic); // read back all status registers
-      check_error(error);
-      print_stat();         
+      print_rxcomm(); // print received data into the comm register    
       break; 
 
-    case 32: // Set and reset the gpio pins(to drive output on gpio pins)
+    case 30: // Read byte data I2C Communication on the GPIO Ports(using I2C eeprom 24LC025)
+      /************************************************************
+        Ensure to set the GPIO bits to 1 in the CFG register group. 
+      *************************************************************/     
+      for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
+      { 
+        //Communication control bits and communication data bytes. Refer to the data sheet.       
+        BMS_IC[current_ic].com.tx_data[0]= 0x6A; // Icom Start (6) + I2C_address D0 (A0) (Write operation to set the word address)
+        BMS_IC[current_ic].com.tx_data[1]= 0x08; // Fcom master NACK(8)  
+        BMS_IC[current_ic].com.tx_data[2]= 0x00; // Icom Blank (0) + eeprom address(word address) D1 (0x00)
+        BMS_IC[current_ic].com.tx_data[3]= 0x08; // Fcom master NACK(8)
+        BMS_IC[current_ic].com.tx_data[4]= 0x6A; // Icom Start (6) + I2C_address D2 (0xA1)(Read operation)
+        BMS_IC[current_ic].com.tx_data[5]= 0x18; // Fcom master NACK(8)  
+      }
+      wakeup_sleep(TOTAL_IC);         
+      LTC6813_wrcomm(TOTAL_IC,BMS_IC); // write to comm register
+
+      wakeup_idle(TOTAL_IC);      
+      LTC6813_stcomm(3); // data length=3 // initiates communication between master and the I2C slave
+
+      for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
+      {  
+        //Communication control bits and communication data bytes. Refer to the data sheet.
+        BMS_IC[current_ic].com.tx_data[0]= 0x0F; // Icom Blank (0) + data D0 (FF)
+        BMS_IC[current_ic].com.tx_data[1]= 0xF9; // Fcom master NACK + Stop(9)  
+        BMS_IC[current_ic].com.tx_data[2]= 0x7F; // Icom No Transmit (7) + data D1 (FF)
+        BMS_IC[current_ic].com.tx_data[3]= 0xF9; // Fcom master NACK + Stop(9)
+        BMS_IC[current_ic].com.tx_data[4]= 0x7F; // Icom No Transmit (7) + data D2 (FF)
+        BMS_IC[current_ic].com.tx_data[5]= 0xF9; // Fcom master NACK + Stop(9)   
+      }  
+      wakeup_idle(TOTAL_IC);
+      LTC6813_wrcomm(TOTAL_IC,BMS_IC); // write to comm register
+
+      wakeup_idle(TOTAL_IC);
+      LTC6813_stcomm(1); // data length=1 // initiates communication between master and the I2C slave
+
+      wakeup_idle(TOTAL_IC);
+      error = LTC6813_rdcomm(TOTAL_IC,BMS_IC); // read from comm register                
+      check_error(error);
+      print_rxcomm(); // print received data from the comm register   
+      break;
+
+    case 31: //  Enable MUTE
+      wakeup_sleep(TOTAL_IC);
+      LTC6813_mute(); 
+      wakeup_idle(TOTAL_IC);
+      error = LTC6813_rdcfgb(TOTAL_IC,BMS_IC);
+      check_error(error);
+      check_mute_bit();
+      break;
+      
+    case 32: // To enable UNMUTE 
+      wakeup_sleep(TOTAL_IC);
+      LTC6813_unmute();
+      wakeup_idle(TOTAL_IC);
+      error = LTC6813_rdcfgb(TOTAL_IC,BMS_IC);
+      check_error(error);
+      check_mute_bit();
+      break;
+
+    case 33: // Set and reset the gpio pins(to drive output on gpio pins)
       /***********************************************************************
        Please ensure you have set the GPIO bits according to your requirement 
-       in the configuration register.( check the global variable gpioBits_a )
+       in the configuration register.( check the global variable GPIOBITS_A )
       ************************************************************************/  
       wakeup_sleep(TOTAL_IC);
       for (uint8_t current_ic = 0; current_ic<TOTAL_IC;current_ic++) 
       {
-        LTC6813_set_cfgr(current_ic,bms_ic,REFON,ADCOPT,gpioBits_a,dccBits_a, dctoBits, UV, OV);
-        LTC6813_set_cfgrb(current_ic,bms_ic,FDRF,DTMEN,psBits,gpioBits_b,dccBits_b);   
+        LTC6813_set_cfgr(current_ic,BMS_IC,REFON,ADCOPT,GPIOBITS_A,DCCBITS_A, DCTOBITS, UV, OV);
+        LTC6813_set_cfgrb(current_ic,BMS_IC,FDRF,DTMEN,PSBITS,GPIOBITS_B,DCCBITS_B);   
       } 
 
-      LTC6813_wrcfg(TOTAL_IC,bms_ic);
-      LTC6813_wrcfgb(TOTAL_IC,bms_ic);
-      print_config();     
-      break; 
-
-    case 33: // Open wire Diagnostic for Auxiliary Measurements
-      wakeup_sleep(TOTAL_IC);
-      LTC6813_run_gpio_openwire(TOTAL_IC, bms_ic);
-      print_open();
-      Serial.println();
-      break;   
+      LTC6813_wrcfg(TOTAL_IC,BMS_IC);
+      LTC6813_wrcfgb(TOTAL_IC,BMS_IC);
+      print_wrconfig();
+      print_wrconfigb();     
+      break;  
                
     case 'm': //prints menu
       print_menu();
       break;
 
     default:
-      Serial.println(F("Incorrect Option"));
-      Serial.println();
+      char str_error[]="Incorrect Option \n";
+      serial_print_text(str_error);
       break;
   }
 }
 
-/*!*********************************
-  \brief For Loop Measurement
+/*!**********************************************************************************************************************************************
+ \brief For writing/reading configuration data or measuring cell voltages or reading aux register or reading status register in a continuous loop  
  @return void
-***********************************/
+*************************************************************************************************************************************************/
 void measurement_loop(uint8_t datalog_en)
 {
   int8_t error = 0;
+  char input = 0;
   
-  if (WRITE_CONFIG == ENABLED)
+  Serial.println(F("Transmit 'm' to quit"));
+  
+  while (input != 'm')
   {
-    wakeup_idle(TOTAL_IC);
-    LTC6813_wrcfg(TOTAL_IC,bms_ic);
-    LTC6813_wrcfgb(TOTAL_IC,bms_ic);
-    print_config();
-  }
-
-  if (READ_CONFIG == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    error = LTC6813_rdcfg(TOTAL_IC,bms_ic);
-    check_error(error);
-    error = LTC6813_rdcfgb(TOTAL_IC,bms_ic); 
-    check_error(error);
-    print_rxconfig();
-  }
-
-  if (MEASURE_CELL == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    LTC6813_adcv(ADC_CONVERSION_MODE,ADC_DCP,CELL_CH_TO_CONVERT);
-    LTC6813_pollAdc();
-    wakeup_idle(TOTAL_IC);
-    error = LTC6813_rdcv(0, TOTAL_IC,bms_ic);
-    check_error(error);
-    print_cells(datalog_en);
-
-  }
-
-  if (MEASURE_AUX == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    LTC6813_adax(ADC_CONVERSION_MODE , AUX_CH_ALL);
-    LTC6813_pollAdc();
-    wakeup_idle(TOTAL_IC);
-    error = LTC6813_rdaux(0,TOTAL_IC,bms_ic); // Set to read back all aux registers
-    check_error(error);
-    print_aux(datalog_en);
-  }
-
-  if (MEASURE_STAT == ENABLED)
-  {
-    wakeup_idle(TOTAL_IC);
-    LTC6813_adstat(ADC_CONVERSION_MODE, STAT_CH_ALL);
-    LTC6813_pollAdc();
-    wakeup_idle(TOTAL_IC);
-    error = LTC6813_rdstat(0,TOTAL_IC,bms_ic); // Set to read back all aux registers
-    check_error(error);
-    print_stat();
-  }
-
-  if(PRINT_PEC == ENABLED)
-  {
-    print_pec();
-  }  
+     if (Serial.available() > 0)
+      {
+        input = read_char();
+      } 
+  
+      if (WRITE_CONFIG == ENABLED)
+      {
+        wakeup_idle(TOTAL_IC);
+        LTC6813_wrcfg(TOTAL_IC,BMS_IC);
+        LTC6813_wrcfgb(TOTAL_IC,BMS_IC);
+        print_wrconfig();
+        print_wrconfigb();
+      }
+    
+      if (READ_CONFIG == ENABLED)
+      {
+        wakeup_idle(TOTAL_IC);
+        error = LTC6813_rdcfg(TOTAL_IC,BMS_IC);
+        check_error(error);
+        error = LTC6813_rdcfgb(TOTAL_IC,BMS_IC); 
+        check_error(error);
+        print_rxconfig();
+        print_rxconfigb();
+      }
+    
+      if (MEASURE_CELL == ENABLED)
+      {
+        wakeup_idle(TOTAL_IC);
+        LTC6813_adcv(ADC_CONVERSION_MODE,ADC_DCP,CELL_CH_TO_CONVERT);
+        LTC6813_pollAdc();
+        wakeup_idle(TOTAL_IC);
+        error = LTC6813_rdcv(0, TOTAL_IC,BMS_IC);
+        check_error(error);
+        print_cells(datalog_en);
+      }
+    
+      if (MEASURE_AUX == ENABLED)
+      {
+        wakeup_idle(TOTAL_IC);
+        LTC6813_adax(ADC_CONVERSION_MODE , AUX_CH_ALL);
+        LTC6813_pollAdc();
+        wakeup_idle(TOTAL_IC);
+        error = LTC6813_rdaux(0,TOTAL_IC,BMS_IC); // Set to read back all aux registers
+        check_error(error);
+        print_aux(datalog_en);
+      }
+    
+      if (MEASURE_STAT == ENABLED)
+      {
+        wakeup_idle(TOTAL_IC);
+        LTC6813_adstat(ADC_CONVERSION_MODE, STAT_CH_ALL);
+        LTC6813_pollAdc();
+        wakeup_idle(TOTAL_IC);
+        error = LTC6813_rdstat(0,TOTAL_IC,BMS_IC); // Set to read back all aux registers
+        check_error(error);
+        print_stat();
+      }
+    
+      if(PRINT_PEC == ENABLED)
+      {
+        print_pec_error_count();
+      } 
+      
+       delay(MEASUREMENT_LOOP_TIME);
+  } 
 }
 
 /*!*********************************
   \brief Prints the main menu
   @return void
 ***********************************/
-void print_menu()
+void print_menu(void)
 {
   Serial.println(F("List of LTC6813 Command:"));
-  Serial.println(F("Write and Read Configuration: 1                            |Loop measurements with data-log output : 12                            |Write and Read of PWM : 23"));
-  Serial.println(F("Read Configuration: 2                                      |Run Mux Self Test: 13                                                  |Write and  Read of S control : 24"));
-  Serial.println(F("Start Cell Voltage Conversion: 3                           |Run ADC Self Test: 14                                                  |Clear S control register : 25"));
-  Serial.println(F("Read Cell Voltages: 4                                      |ADC overlap Test : 15                                                  |SPI Communication  : 26"));
-  Serial.println(F("Start Aux Voltage Conversion: 5                            |Run Digital Redundancy Test: 16                                        |I2C Communication Write to Slave :27"));
-  Serial.println(F("Read Aux Voltages: 6                                       |Open Wire Test for single cell detection: 17                           |I2C Communication Read from Slave :28"));
-  Serial.println(F("Start Stat Voltage Conversion: 7                           |Open Wire Test for multiple cell or two consecutive cells detection:18 |Enable MUTE : 29"));
-  Serial.println(F("Read Stat Voltages: 8                                      |Print PEC Counter: 19                                                  |Disable MUTE : 30"));
-  Serial.println(F("Start Combined Cell Voltage and GPIO1, GPIO2 Conversion: 9 |Reset PEC Counter: 20                                                  |Clear Registers: 31"));
-  Serial.println(F("Start  Cell Voltage and Sum of cells : 10                  |Set Discharge: 21                                                      |Set or reset the gpio pins: 32"));
-  Serial.println(F("Loop Measurements: 11                                      |Clear Discharge: 22                                                    |Open wire for Auxiliary Measurement: 33"));
-  Serial.println();
+  Serial.println(F("Write and Read Configuration: 1                            |Loop measurements with data-log output : 12                            |Set Discharge: 23   "));  
+  Serial.println(F("Read Configuration: 2                                      |Clear Registers: 13                                                    |Clear Discharge: 24   "));
+  Serial.println(F("Start Cell Voltage Conversion: 3                           |Run Mux Self Test: 14                                                  |Write and Read of PWM : 25"));
+  Serial.println(F("Read Cell Voltages: 4                                      |Run ADC Self Test: 15                                                  |Write and  Read of S control : 26"));
+  Serial.println(F("Start Aux Voltage Conversion: 5                            |ADC overlap Test : 16                                                  |Clear S control register : 27"));
+  Serial.println(F("Read Aux Voltages: 6                                       |Run Digital Redundancy Test: 17                                        |SPI Communication  : 28"));
+  Serial.println(F("Start Stat Voltage Conversion: 7                           |Open Wire Test for single cell detection: 18                           |I2C Communication Write to Slave :29"));
+  Serial.println(F("Read Stat Voltages: 8                                      |Open Wire Test for multiple cell or two consecutive cells detection:19 |I2C Communication Read from Slave :30"));
+  Serial.println(F("Start Combined Cell Voltage and GPIO1, GPIO2 Conversion: 9 |Open wire for Auxiliary Measurement: 20                                |Enable MUTE : 31"));
+  Serial.println(F("Start  Cell Voltage and Sum of cells : 10                  |Print PEC Counter: 21                                                  |Disable MUTE : 32")); 
+  Serial.println(F("Loop Measurements: 11                                      |Reset PEC Counter: 22                                                  |Set or reset the gpio pins: 33 \n "));
   Serial.println(F("Print 'm' for menu"));
-  Serial.println(F("Please enter command: "));
-  Serial.println();
+  Serial.println(F("Please enter command: \n "));
 }
 
 /*!******************************************************************************
@@ -842,41 +818,53 @@ void print_menu()
  to the serial port.
  @return void
  ********************************************************************************/
-void print_config()
+void print_wrconfig(void)
 {
-  int cfg_pec;
-  Serial.println(F("Written Configuration: "));
-  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F("CFGA IC "));
-    Serial.print(current_ic+1,DEC);
-    for(int i = 0;i<6;i++)
+    int cfg_pec;
+    Serial.println(F("Written Configuration A Register: "));
+    for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
     {
+      Serial.print(F("CFGA IC "));
+      Serial.print(current_ic+1,DEC);
+      for(int i = 0;i<6;i++)
+      {
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].config.tx_data[i]);
+      }
+      Serial.print(F(", Calculated PEC: 0x"));
+      cfg_pec = pec15_calc(6,&BMS_IC[current_ic].config.tx_data[0]);
+      serial_print_hex((uint8_t)(cfg_pec>>8));
       Serial.print(F(", 0x"));
-      serial_print_hex(bms_ic[current_ic].config.tx_data[i]);
+      serial_print_hex((uint8_t)(cfg_pec));
+      Serial.println("\n");
     }
-    Serial.print(F(", Calculated PEC: 0x"));
-    cfg_pec = pec15_calc(6,&bms_ic[current_ic].config.tx_data[0]);
-    serial_print_hex((uint8_t)(cfg_pec>>8));
-    Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(cfg_pec));
-    Serial.println();
-    
-    Serial.print(F("CFGB IC "));
-    Serial.print(current_ic+1,DEC);
-    for(int i = 0;i<6;i++)
-    {
+}
+
+/*!******************************************************************************
+ \brief Prints the Configuration Register B data that is going to be written to 
+ the LTC6813 to the serial port.
+  @return void
+ ********************************************************************************/
+void print_wrconfigb(void)
+{
+    int cfg_pec;
+    Serial.println(F("Written Configuration B Register: "));
+    for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
+    { 
+      Serial.print(F("CFGB IC "));
+      Serial.print(current_ic+1,DEC);
+      for(int i = 0;i<6;i++)
+      {
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].configb.tx_data[i]);
+      }
+      Serial.print(F(", Calculated PEC: 0x"));
+      cfg_pec = pec15_calc(6,&BMS_IC[current_ic].configb.tx_data[0]);
+      serial_print_hex((uint8_t)(cfg_pec>>8));
       Serial.print(F(", 0x"));
-      serial_print_hex(bms_ic[current_ic].configb.tx_data[i]);
+      serial_print_hex((uint8_t)(cfg_pec));
+      Serial.println("\n");
     }
-    Serial.print(F(", Calculated PEC: 0x"));
-    cfg_pec = pec15_calc(6,&bms_ic[current_ic].configb.tx_data[0]);
-    serial_print_hex((uint8_t)(cfg_pec>>8));
-    Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(cfg_pec));
-    Serial.println();
-  }
-  Serial.println();
 }
 
 /*!*****************************************************************
@@ -884,38 +872,49 @@ void print_config()
  LTC6813 to the serial port.
  @return void
  *******************************************************************/
-void print_rxconfig()
+void print_rxconfig(void)
 {
-  Serial.println(F("Received Configuration: "));
+  Serial.println(F("Received Configuration A Register: "));
   for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
   {
     Serial.print(F("CFGA IC "));
     Serial.print(current_ic+1,DEC);
-    for(int i = 0;i<6;i++)
+    for(int i = 0; i < 6; i++)
     {
       Serial.print(F(", 0x"));
-      serial_print_hex(bms_ic[current_ic].config.rx_data[i]);
-    };
+      serial_print_hex(BMS_IC[current_ic].config.rx_data[i]);
+    }
     Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].config.rx_data[6]);
+    serial_print_hex(BMS_IC[current_ic].config.rx_data[6]);
     Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].config.rx_data[7]);
-    Serial.println();
+    serial_print_hex(BMS_IC[current_ic].config.rx_data[7]);
+    Serial.println("\n");
+  }
+}
 
+/*!*****************************************************************
+ \brief Prints the Configuration Register B that was read back from 
+ the LTC6813 to the serial port.
+  @return void
+ *******************************************************************/
+void print_rxconfigb(void)
+{
+  Serial.println(F("Received Configuration B Register: "));
+  for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
+  {
     Serial.print(F("CFGB IC "));
     Serial.print(current_ic+1,DEC);
-    for(int i = 0;i<6;i++)
+    for(int i = 0; i < 6; i++)
     {
       Serial.print(F(", 0x"));
-      serial_print_hex(bms_ic[current_ic].configb.rx_data[i]);
-    };
+      serial_print_hex(BMS_IC[current_ic].configb.rx_data[i]);
+    }
     Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].configb.rx_data[6]);
+    serial_print_hex(BMS_IC[current_ic].configb.rx_data[6]);
     Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].configb.rx_data[7]);
-    Serial.println();
+    serial_print_hex(BMS_IC[current_ic].configb.rx_data[7]);
+    Serial.println("\n");
   }
-  Serial.println();
 }
 
 /*!************************************************************
@@ -931,28 +930,27 @@ void print_cells(uint8_t datalog_en)
       Serial.print(" IC ");
       Serial.print(current_ic+1,DEC);
       Serial.print(", ");
-      for (int i=0; i<bms_ic[0].ic_reg.cell_channels; i++)
+      for (int i=0; i<BMS_IC[0].ic_reg.cell_channels; i++)
       {
-
         Serial.print(" C");
         Serial.print(i+1,DEC);
         Serial.print(":");
-        Serial.print(bms_ic[current_ic].cells.c_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].cells.c_codes[i]*0.0001,4);
         Serial.print(",");
       }
       Serial.println();
     }
     else
     {
-      Serial.print("Cells, ");
-      for (int i=0; i<bms_ic[0].ic_reg.cell_channels; i++)
+      Serial.print(" Cells, ");
+      for (int i=0; i<BMS_IC[0].ic_reg.cell_channels; i++)
       {
-        Serial.print(bms_ic[current_ic].cells.c_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].cells.c_codes[i]*0.0001,4);
         Serial.print(",");
       }
     }
   }
-  Serial.println();
+  Serial.println("\n");
 }
 
 /*!****************************************************************************
@@ -972,7 +970,7 @@ void print_aux(uint8_t datalog_en)
         Serial.print(F(" GPIO-"));
         Serial.print(i+1,DEC);
         Serial.print(":");
-        Serial.print(bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].aux.a_codes[i]*0.0001,4);
         Serial.print(",");
       }
       
@@ -981,31 +979,73 @@ void print_aux(uint8_t datalog_en)
         Serial.print(F(" GPIO-"));
         Serial.print(i,DEC);
         Serial.print(":");
-        Serial.print(bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
-        
+        Serial.print(BMS_IC[current_ic].aux.a_codes[i]*0.0001,4);        
       }
 
       Serial.print(F(" Vref2"));
       Serial.print(":");
-      Serial.print(bms_ic[current_ic].aux.a_codes[5]*0.0001,4);
+      Serial.print(BMS_IC[current_ic].aux.a_codes[5]*0.0001,4);
       Serial.println();
       
-      Serial.print(" Flags : 0x");
-      Serial.print((uint8_t)bms_ic[current_ic].aux.a_codes[11],HEX);
+      Serial.print(" OV/UV Flags : 0x");
+      Serial.print((uint8_t)BMS_IC[current_ic].aux.a_codes[11],HEX);
       Serial.println();
     }
     else
     {
-      Serial.print("AUX, ");
+      Serial.print(" AUX, ");
 
       for (int i=0; i < 12; i++)
       {
-        Serial.print((uint8_t)bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
+        Serial.print((uint8_t)BMS_IC[current_ic].aux.a_codes[i]*0.0001,4);
         Serial.print(",");
       }
     }
   }
-  Serial.println();
+ Serial.println("\n");
+}
+
+/*!****************************************************************************
+  \brief Prints Status voltage codes and Vref2 voltage code onto the serial port
+  @return void
+ *****************************************************************************/
+void print_stat(void)
+{
+  for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
+  {
+    double itmp;
+    
+    Serial.print(F(" IC "));
+    Serial.print(current_ic+1,DEC);
+    Serial.print(F(" SOC:"));
+    Serial.print(BMS_IC[current_ic].stat.stat_codes[0]*0.0001*30,4);
+    Serial.print(F(","));
+    Serial.print(F(" Itemp:"));
+    itmp = (double)((BMS_IC[current_ic].stat.stat_codes[1] * (0.0001 / 0.0076)) - 276);   //Internal Die Temperature(°C) = ITMP • (100 µV / 7.6mV)°C - 276°C
+    Serial.print(itmp,4);
+    Serial.print(F(","));
+    Serial.print(F(" VregA:"));
+    Serial.print(BMS_IC[current_ic].stat.stat_codes[2]*0.0001,4);
+    Serial.print(F(","));
+    Serial.print(F(" VregD:"));
+    Serial.print(BMS_IC[current_ic].stat.stat_codes[3]*0.0001,4);
+    Serial.println();
+    Serial.print(F(" OV/UV Flags:"));
+    Serial.print(F(", 0x"));
+    serial_print_hex(BMS_IC[current_ic].stat.flags[0]);
+    Serial.print(F(", 0x"));
+    serial_print_hex(BMS_IC[current_ic].stat.flags[1]);
+    Serial.print(F(", 0x"));
+    serial_print_hex(BMS_IC[current_ic].stat.flags[2]);
+     Serial.print(F("\tMux fail flag:"));
+    Serial.print(F(", 0x"));
+    serial_print_hex(BMS_IC[current_ic].stat.mux_fail[0]);
+     Serial.print(F("\tTHSD:"));
+    Serial.print(F(", 0x"));
+    serial_print_hex(BMS_IC[current_ic].stat.thsd[0]);
+    Serial.println();  
+  }
+  Serial.println("\n");
 }
 
 /*!****************************************************************************
@@ -1026,7 +1066,7 @@ void print_aux1(uint8_t datalog_en)
         Serial.print(F(" GPIO-"));
         Serial.print(i+1,DEC);
         Serial.print(":");
-        Serial.print(bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].aux.a_codes[i]*0.0001,4);
         Serial.print(",");
       }
     }
@@ -1036,83 +1076,107 @@ void print_aux1(uint8_t datalog_en)
 
       for (int i=0; i < 12; i++)
       {
-        Serial.print(bms_ic[current_ic].aux.a_codes[i]*0.0001,4);
+        Serial.print(BMS_IC[current_ic].aux.a_codes[i]*0.0001,4);
         Serial.print(",");
       }
     }
   }
-  Serial.println();
-}
-
-/*!****************************************************************************
-  \brief Prints Status voltage codes and Vref2 voltage code onto the serial port
-  @return void
- *****************************************************************************/
-void print_stat()
-{
-
-  for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
-  {
-    double ITMP;
-    
-    Serial.print(F(" IC "));
-    Serial.print(current_ic+1,DEC);
-    Serial.print(F(" SOC:"));
-    Serial.print(bms_ic[current_ic].stat.stat_codes[0]*0.0001*30,4);
-    Serial.print(F(","));
-    Serial.print(F(" Itemp:"));
-    ITMP = (double)((bms_ic[current_ic].stat.stat_codes[1] * (0.0001 / 0.0076)) - 276);   //Internal Die Temperature(°C) = ITMP • (100 µV / 7.5mV)°C - 273°C
-    Serial.print(ITMP,4);
-    Serial.print(F(","));
-    Serial.print(F(" VregA:"));
-    Serial.print(bms_ic[current_ic].stat.stat_codes[2]*0.0001,4);
-    Serial.print(F(","));
-    Serial.print(F(" VregD:"));
-    Serial.print(bms_ic[current_ic].stat.stat_codes[3]*0.0001,4);
-    Serial.println();
-    Serial.print(F("Flags:"));
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.flags[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.flags[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.flags[2]);
-     Serial.print(F("\tMux fail flag:"));
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.mux_fail[0]);
-     Serial.print(F("\tTHSD:"));
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].stat.thsd[0]);
-    Serial.println();  
-  }
-  Serial.println();
+  Serial.println("\n");
 }
 
 /*!****************************************************************************
   \brief Prints Status voltage codes for SOC onto the serial port
  *****************************************************************************/
-void print_statsoc()
+void print_sumofcells(void)
 {
-
   for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
   {
     Serial.print(F(" IC "));
     Serial.print(current_ic+1,DEC);
     Serial.print(F(" SOC:"));
-    Serial.print(bms_ic[current_ic].stat.stat_codes[0]*0.0001*30,4);
+    Serial.print(BMS_IC[current_ic].stat.stat_codes[0]*0.0001*30,4);
     Serial.print(F(","));
   }
-  Serial.println();
+  Serial.println("\n");
+}
+
+/*!****************************************************************
+  \brief Function to check the MUX fail bit in the Status Register
+   @return void
+*******************************************************************/
+void check_mux_fail(void)
+{ 
+  int8_t error = 0;
+  for (int ic = 0; ic<TOTAL_IC; ic++)
+    { 
+      Serial.print(" IC ");
+      Serial.println(ic+1,DEC);
+      if (BMS_IC[ic].stat.mux_fail[0] != 0) error++;
+    
+      if (error==0) Serial.println(F("Mux Test: PASS \n"));
+      else Serial.println(F("Mux Test: FAIL \n"));
+    }
+}
+
+/*!************************************************************
+  \brief Prints Errors Detected during self test
+   @return void
+*************************************************************/
+void print_selftest_errors(uint8_t adc_reg ,int8_t error)
+{
+  if(adc_reg==1)
+  {
+    Serial.println("Cell ");
+    }
+  else if(adc_reg==2)
+  {
+    Serial.println("Aux ");
+    }
+  else if(adc_reg==3)
+  {
+    Serial.println("Stat ");
+    }
+  Serial.print(error, DEC);
+  Serial.println(F(" : errors detected in Digital Filter and Memory \n"));
+}
+
+/*!************************************************************
+  \brief Prints the output of  the ADC overlap test  
+   @return void
+*************************************************************/
+void print_overlap_results(int8_t error)
+{
+  if (error==0) Serial.println(F("Overlap Test: PASS \n"));
+  else Serial.println(F("Overlap Test: FAIL \n"));
+}
+
+/*!************************************************************
+  \brief Prints Errors Detected during Digital Redundancy test
+   @return void
+*************************************************************/
+void print_digital_redundancy_errors(uint8_t adc_reg ,int8_t error)
+{
+  if(adc_reg==2)
+  {
+    Serial.println("Aux ");
+    }
+  else if(adc_reg==3)
+  {
+    Serial.println("Stat ");
+    }
+
+  Serial.print(error, DEC);
+  Serial.println(F(" : errors detected in Measurement \n"));
 }
 
 /*!****************************************************************************
   \brief Prints Open wire test results to the serial port
  *****************************************************************************/
-void print_open()
+void print_open_wires(void)
 {
   for (int current_ic =0 ; current_ic < TOTAL_IC; current_ic++)
   {
-    if (bms_ic[current_ic].system_open_wire == 65535)
+    if (BMS_IC[current_ic].system_open_wire == 65535)
     {
       Serial.print("No Opens Detected on IC ");
       Serial.print(current_ic+1, DEC);
@@ -1123,286 +1187,328 @@ void print_open()
       Serial.print(F("There is an open wire on IC "));
       Serial.print(current_ic + 1,DEC);
       Serial.print(F(" Channel: "));
-      Serial.println(bms_ic[current_ic].system_open_wire);
+      Serial.println(BMS_IC[current_ic].system_open_wire);
     }
   }
-}
-
-/*!****************************************************************************
-  \brief prints data which is written on PWM register onto the serial port
-  @return void
- *****************************************************************************/
-void print_pwm()
-{
-  int pwm_pec;
-  int psb_pec;
-
-  Serial.println(F("Written Data in PWM Registers: "));
-  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC: "));
-    Serial.println(current_ic+1,DEC);
-    Serial.print(F(" PWM register group:0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.tx_data[5]);
-
-    Serial.print(F(", Calculated PEC:0x"));
-    pwm_pec = pec15_calc(6,&bms_ic[current_ic].pwm.tx_data[0]);
-    serial_print_hex((uint8_t)(pwm_pec>>8));
-    Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(pwm_pec));
-    Serial.println();
-
-    Serial.print(F(" PWM/S control register group B:0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.tx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.tx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.tx_data[2]);
-
-    Serial.print(F(", Calculated PEC: 0x"));
-    psb_pec = pec15_calc(6,&bms_ic[current_ic].pwmb.tx_data[0]);
-    serial_print_hex((uint8_t)(psb_pec>>8));
-    Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(psb_pec));
-    Serial.println();
-  }
-  Serial.println();
-}
-
-/*!****************************************************************************
-  \brief Prints received data from PWM register onto the serial port
-  @return void
- *****************************************************************************/
-void print_rxpwm()
-{
-  Serial.println(F("Received Data in PWM register:"));
-  for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC: "));
-    Serial.println(current_ic+1,DEC);
-    Serial.print(F(" PWM register group:0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[5]);
-    Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[6]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwm.rx_data[7]);
-    Serial.println();
-
-    Serial.print(F(" PWM/S control register group B:0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.rx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.rx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.rx_data[2]);
-    
-    Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.rx_data[6]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].pwmb.rx_data[7]);
-    Serial.println();    
-  }
-  Serial.println();
-}
-
-/*!****************************************************************************
-  \brief prints data which is written on S Control register 
-  @return void
- *****************************************************************************/
-void print_sctrl()
-{
-  int sctrl_pec;
-  int psb_pec; 
-
-  Serial.println(F("Written Data in Sctrl register: "));
-  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC: "));
-    Serial.print(current_ic+1,DEC);
-    Serial.print(F(" Sctrl register group:0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.tx_data[5]);
-    
-    Serial.print(F(", Calculated PEC: 0x"));
-    sctrl_pec = pec15_calc(6,&bms_ic[current_ic].sctrl.tx_data[0]);
-    serial_print_hex((uint8_t)(sctrl_pec>>8));
-    Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(sctrl_pec));
-    Serial.println();
-
-    Serial.print(F(" PWM/S control register group B:0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.tx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.tx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.tx_data[5]);
-    
-    Serial.print(F(", Calculated PEC: 0x"));
-    psb_pec = pec15_calc(6,&bms_ic[current_ic].sctrlb.tx_data[0]);
-    serial_print_hex((uint8_t)(psb_pec>>8));
-    Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(psb_pec));
-    Serial.println();
-  }
-  Serial.println();
-}
-
-/*!****************************************************************************
-  \brief prints data which is read back from S Control register 
-  @return void
- *****************************************************************************/
-void print_rxsctrl()
-{
-  Serial.println(F("Received Data in S control register:"));
-  for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC: "));
-    Serial.print(current_ic+1,DEC);
-    Serial.print(F(" Sctrl register group:0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[5]);
-    
-    Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[6]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrl.rx_data[7]);
-    Serial.println();
-
-    Serial.print(F(" PWM/S control register group B:0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.rx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.rx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.rx_data[5]);
-    
-    Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.rx_data[6]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].sctrlb.rx_data[7]);
-    Serial.println();  
-  }
-  Serial.println();
-}
-
-/*!****************************************************************************
-  \brief prints data which is written on COMM register onto the serial port
-  @return void
- *****************************************************************************/
-void print_comm()
-{
-  int comm_pec;
-
-  Serial.println(F("Written Data in COMM Register: "));
-  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC- "));
-    Serial.print(current_ic+1,DEC);
-    Serial.print(F(": "));
-    Serial.print(F("0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.tx_data[5]);
-    Serial.print(F(", Calculated PEC: 0x"));
-    comm_pec = pec15_calc(6,&bms_ic[current_ic].com.tx_data[0]);
-    serial_print_hex((uint8_t)(comm_pec>>8));
-    Serial.print(F(", 0x"));
-    serial_print_hex((uint8_t)(comm_pec));
-    Serial.println();
-  }
-  Serial.println();
-}
-
-/*!****************************************************************************
-  \brief Prints received data from COMM register onto the serial port
-  @return void
- *****************************************************************************/
-
-void print_rxcomm()
-{
-  Serial.println(F("Received Data"));
-  for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
-  {
-    Serial.print(F(" IC "));
-    Serial.print(current_ic+1,DEC);
-    Serial.print(F(": 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[0]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[1]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[2]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[3]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[4]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[5]);
-    Serial.print(F(", Received PEC: 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[6]);
-    Serial.print(F(", 0x"));
-    serial_print_hex(bms_ic[current_ic].com.rx_data[7]);
-    Serial.println();
-  }
-  Serial.println();
+  Serial.println("\n");
 }
 
 /*!****************************************************************************
    \brief Function to print the number of PEC Errors
    @return void
  *****************************************************************************/
-void print_pec()
+void print_pec_error_count(void)
 {
   for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
   {
       Serial.println("");
-      Serial.print(bms_ic[current_ic].crc_count.pec_count,DEC);
+      Serial.print(BMS_IC[current_ic].crc_count.pec_count,DEC);
       Serial.print(F(" : PEC Errors Detected on IC"));
       Serial.println(current_ic+1,DEC);
   }
+  Serial.println("\n");
+}
+
+/*!****************************************************
+  \brief Function to select the S pin for discharge
+  @return void
+ ******************************************************/
+int8_t select_s_pin(void)
+{
+  int8_t read_s_pin=0;
+  
+  Serial.print(F("Please enter the Spin number: "));
+  read_s_pin = (int8_t)read_int();
+  Serial.println(read_s_pin);
+  return(read_s_pin);
+}
+
+/*!****************************************************************************
+  \brief prints data which is written on PWM register onto the serial port
+  @return void
+ *****************************************************************************/
+void print_wrpwm(void)
+{
+  int pwm_pec;
+
+  Serial.println(F("Written PWM Configuration: "));
+  for (uint8_t current_ic = 0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.print(F("IC "));
+    Serial.print(current_ic+1,DEC);
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+     serial_print_hex(BMS_IC[current_ic].pwm.tx_data[i]);
+    }
+    Serial.print(F(", Calculated PEC: 0x"));
+    pwm_pec = pec15_calc(6,&BMS_IC[current_ic].pwm.tx_data[0]);
+    serial_print_hex((uint8_t)(pwm_pec>>8));
+    Serial.print(F(", 0x"));
+    serial_print_hex((uint8_t)(pwm_pec));
+    Serial.println("\n");
+  } 
+}
+
+/*!****************************************************************************
+  \brief Prints received data from PWM register onto the serial port
+  @return void
+ *****************************************************************************/
+void print_rxpwm(void)
+{
+  Serial.println(F("Received pwm Configuration:"));
+  for (uint8_t current_ic=0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.print(F("IC "));
+    Serial.print(current_ic+1,DEC);
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+     serial_print_hex(BMS_IC[current_ic].pwm.rx_data[i]);
+    }
+    Serial.print(F(", Received PEC: 0x"));
+    serial_print_hex(BMS_IC[current_ic].pwm.rx_data[6]);
+    Serial.print(F(", 0x"));
+    serial_print_hex(BMS_IC[current_ic].pwm.rx_data[7]);
+    Serial.println("\n");
+  }
+}
+
+/*!****************************************************************************
+  \brief prints data which is written on S Control register 
+  @return void
+ *****************************************************************************/
+void print_wrsctrl(void)
+{
+    int sctrl_pec;
+
+  Serial.println(F("Written Data in Sctrl register: "));
+  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.print(F(" IC: "));
+    Serial.print(current_ic+1,DEC);
+    Serial.print(F(" Sctrl register group:"));
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].sctrl.tx_data[i]);
+    }
+    
+    Serial.print(F(", Calculated PEC: 0x"));
+    sctrl_pec = pec15_calc(6,&BMS_IC[current_ic].sctrl.tx_data[0]);
+    serial_print_hex((uint8_t)(sctrl_pec>>8));
+    Serial.print(F(", 0x"));
+    serial_print_hex((uint8_t)(sctrl_pec));
+    Serial.println("\n");
+  }
+}
+
+/*!****************************************************************************
+  \brief prints data which is read back from S Control register 
+  @return void
+ *****************************************************************************/
+void print_rxsctrl(void)
+{
+   Serial.println(F("Received Data:"));
+  for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.print(F(" IC "));
+    Serial.print(current_ic+1,DEC);
+    
+    for(int i = 0; i < 6; i++)
+    {
+    Serial.print(F(", 0x"));
+    serial_print_hex(BMS_IC[current_ic].sctrl.rx_data[i]);
+    }
+    
+    Serial.print(F(", Received PEC: 0x"));
+    serial_print_hex(BMS_IC[current_ic].sctrl.rx_data[6]);
+    Serial.print(F(", 0x"));
+    serial_print_hex(BMS_IC[current_ic].sctrl.rx_data[7]);
+    Serial.println("\n");
+  }
+}
+
+/*!****************************************************************************
+  \brief Prints data which is written on PWM/S control register group B onto 
+  the serial port
+   @return void
+ *****************************************************************************/
+void print_wrpsb(uint8_t type)
+{
+  int psb_pec=0;
+
+  Serial.println(F(" PWM/S control register group B: "));
+  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
+  {
+      if(type == 1)
+      {
+        Serial.print(F(" IC: "));
+        Serial.println(current_ic+1,DEC);
+        Serial.print(F(" 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.tx_data[0]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.tx_data[1]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.tx_data[2]);
+    
+        Serial.print(F(", Calculated PEC: 0x"));
+        psb_pec = pec15_calc(6,&BMS_IC[current_ic].pwmb.tx_data[0]);
+        serial_print_hex((uint8_t)(psb_pec>>8));
+        Serial.print(F(", 0x"));
+        serial_print_hex((uint8_t)(psb_pec));
+        Serial.println("\n");
+      } 
+      else if(type == 2)
+      {
+        Serial.print(F(" IC: "));
+        Serial.println(current_ic+1,DEC);
+        Serial.print(F(" 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.tx_data[3]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.tx_data[4]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.tx_data[5]);
+        
+        Serial.print(F(", Calculated PEC: 0x"));
+        psb_pec = pec15_calc(6,&BMS_IC[current_ic].sctrlb.tx_data[0]);
+        serial_print_hex((uint8_t)(psb_pec>>8));
+        Serial.print(F(", 0x"));
+        serial_print_hex((uint8_t)(psb_pec));
+        Serial.println("\n");       
+      }
+  }  
+}
+
+
+/*!****************************************************************************
+  \brief Prints received data from PWM/S control register group B
+   onto the serial port
+   @return void
+ *****************************************************************************/
+void print_rxpsb(uint8_t type)
+{
+  Serial.println(F(" PWM/S control register group B:"));
+  if(type == 1)
+  {
+      for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
+      {
+        Serial.print(F(" IC: "));
+        Serial.println(current_ic+1,DEC);
+        Serial.print(F(" 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.rx_data[0]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.rx_data[1]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.rx_data[2]);
+        
+        Serial.print(F(", Received PEC: 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.rx_data[6]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].pwmb.rx_data[7]);
+       Serial.println("\n");
+      }
+  }
+   else if(type == 2)
+  {
+      for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
+      {
+        Serial.print(F(" IC: "));
+        Serial.println(current_ic+1,DEC);
+        Serial.print(F(" 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.rx_data[3]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.rx_data[4]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.rx_data[5]);
+        
+        Serial.print(F(", Received PEC: 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.rx_data[6]);
+        Serial.print(F(", 0x"));
+        serial_print_hex(BMS_IC[current_ic].sctrlb.rx_data[7]);
+        Serial.println("\n");  
+      }
+  }  
+}
+
+/*!****************************************************************************
+  \brief prints data which is written on COMM register onto the serial port
+  @return void
+ *****************************************************************************/
+void print_wrcomm(void)
+{
+ int comm_pec;
+
+  Serial.println(F("Written Data in COMM Register: "));
+  for (int current_ic = 0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.print(F(" IC- "));
+    Serial.print(current_ic+1,DEC);
+    
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].com.tx_data[i]);
+    }
+    Serial.print(F(", Calculated PEC: 0x"));
+    comm_pec = pec15_calc(6,&BMS_IC[current_ic].com.tx_data[0]);
+    serial_print_hex((uint8_t)(comm_pec>>8));
+    Serial.print(F(", 0x"));
+    serial_print_hex((uint8_t)(comm_pec));
+    Serial.println("\n");
+  }
+}
+
+/*!****************************************************************************
+  \brief Prints received data from COMM register onto the serial port
+  @return void
+ *****************************************************************************/
+void print_rxcomm(void)
+{
+   Serial.println(F("Received Data in COMM register:"));
+  for (int current_ic=0; current_ic<TOTAL_IC; current_ic++)
+  {
+    Serial.print(F(" IC- "));
+    Serial.print(current_ic+1,DEC);
+    
+    for(int i = 0; i < 6; i++)
+    {
+      Serial.print(F(", 0x"));
+      serial_print_hex(BMS_IC[current_ic].com.rx_data[i]);
+    }
+    Serial.print(F(", Received PEC: 0x"));
+    serial_print_hex(BMS_IC[current_ic].com.rx_data[6]);
+    Serial.print(F(", 0x"));
+    serial_print_hex(BMS_IC[current_ic].com.rx_data[7]);
+    Serial.println("\n");
+  }
+}
+
+/*!********************************************************************
+  \brief Function to check the Mute bit in the Configuration Register
+   @return void
+**********************************************************************/
+void check_mute_bit(void)
+{ 
+  for (int current_ic = 0 ; current_ic < TOTAL_IC; current_ic++)
+  {
+    Serial.print(F(" Mute bit in Configuration Register B: 0x"));
+    serial_print_hex((BMS_IC[current_ic].configb.rx_data[1])&(0x80));
+    Serial.println("\n");
+  }
+}
+
+/*!****************************************************************************
+  \brief Function to print the Conversion Time
+  @return void
+ *****************************************************************************/
+void print_conv_time(uint32_t conv_time)
+{
+  uint16_t m_factor=1000;  // to print in ms
+
+  Serial.print(F("Conversion completed in:"));
+  Serial.print(((float)conv_time/m_factor), 1);
+  Serial.println(F("ms \n"));
 }
 
 /*!****************************************************************************
@@ -1415,6 +1521,15 @@ void check_error(int error)
   {
     Serial.println(F("A PEC error was detected in the received data"));
   }
+}
+
+/*!************************************************************
+  \brief Function to print text on serial monitor
+  @return void
+*************************************************************/ 
+void serial_print_text(char data[])
+{       
+  Serial.println(data);
 }
 
 /*!****************************************************************************
@@ -1430,4 +1545,54 @@ void serial_print_hex(uint8_t data)
   }
   else
     Serial.print((byte)data,HEX);
+}
+
+/*!*****************************************************************************
+ \brief Hex conversion constants
+ *******************************************************************************/
+char hex_digits[16]=
+{
+  '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+};
+
+/*!************************************************************
+ \brief Global Variables
+ *************************************************************/
+char hex_to_byte_buffer[5]=
+{
+  '0', 'x', '0', '0', '\0'
+};              
+
+/*!************************************************************
+ \brief Buffer for ASCII hex to byte conversion
+ *************************************************************/
+char byte_to_hex_buffer[3]=
+{
+  '\0','\0','\0'
+};
+
+/*!*****************************************************************************
+ \brief Read 2 hex characters from the serial buffer and convert them to a byte
+ @return char data Read Data
+ ******************************************************************************/
+char read_hex(void)
+{
+  byte data;
+  hex_to_byte_buffer[2]=get_char();
+  hex_to_byte_buffer[3]=get_char();
+  get_char();
+  get_char();
+  data = strtol(hex_to_byte_buffer, NULL, 0);
+  return(data);
+}
+
+/*!************************************************************
+ \brief Read a command from the serial port
+ @return char 
+ *************************************************************/
+char get_char(void)
+{
+  // read a command from the serial port
+  while (Serial.available() <= 0);
+  return(Serial.read());
 }

--- a/LTSketchbook/libraries/LTC6810/LTC6810.cpp
+++ b/LTSketchbook/libraries/LTC6810/LTC6810.cpp
@@ -1,9 +1,9 @@
 /*! LTC6810: 6-Channel Battery Stack Monitors
 *
 *@verbatim
-*The LTC6810 is multicell battery stack monitor that measures up to 6 series 
+*The LTC6810 is multi-cell battery stack monitor that measures up to 6 series 
 *connected battery cells with a total measurement error of less than 1.8mV. 
-*The cell measurement range of 0V to 5V makes the LTC6813 suitable for most 
+*The cell measurement range of 0V to 5V makes the LTC6810 suitable for most 
 *battery chemistries. All 6 cell voltages can be captured in 290uS, and lower 
 *data acquisition rates can be selected for high noise reduction.
 *Using the LTC6810-1, multiple devices are connected in a daisy-chain with one 
@@ -62,8 +62,10 @@
 #include "LTC681x.h"
 #include "LTC6810.h"
 
-//Helper function to initialize register limits.
-void LTC6810_init_reg_limits(uint8_t total_ic, cell_asic *ic)
+/* Helper function to initialize register limits */
+void LTC6810_init_reg_limits(uint8_t total_ic, // Number of ICs in the system
+							cell_asic *ic // A two dimensional array that stores the data
+							)
 {
     for(uint8_t cic=0; cic<total_ic; cic++)
     {
@@ -76,630 +78,160 @@ void LTC6810_init_reg_limits(uint8_t total_ic, cell_asic *ic)
     } 
 }
 
-//Starts cell voltage conversion
-void LTC6810_adcv(
-  uint8_t MD, //ADC Mode
-  uint8_t DCP, //Discharge Permit
-  uint8_t CH //Cell Channels to be measured
-)
+/*
+This command will write into the configuration registers of the LTC6810-1s
+connected in a daisy chain stack. The configuration is written in descending
+order so the last device's configuration is written first.
+*/
+void LTC6810_wrcfg(uint8_t total_ic, //The number of ICs being written to
+				 cell_asic *ic //A two dimensional array of the configuration data that will be written
+				)
+{
+	LTC681x_wrcfg(total_ic,ic);
+}
+
+/* This command reads configuration registers of a LTC6810s connected in a daisy chain */
+int8_t LTC6810_rdcfg(uint8_t total_ic, //Number of ICs in the system
+				   cell_asic *ic //A two dimensional array that the function stores the read configuration data
+				  )
+{
+   int8_t pec_error = 0;
+   pec_error = LTC681x_rdcfg(total_ic,ic);
+   return(pec_error);
+}
+
+/* Starts cell voltage conversion */ 
+void LTC6810_adcv(uint8_t MD, //ADC Mode
+				  uint8_t DCP, //Discharge Permit
+				  uint8_t CH //Cell Channels to be measured
+				 )
 {
     LTC681x_adcv(MD,DCP,CH);
 }
 
-//Starts cell voltage and SOC conversion
-void LTC6810_adcvsc(
-  uint8_t MD, //ADC Mode
-  uint8_t DCP //Discharge Permit
-)
+/* Start a GPIO and Vref2 Conversion */
+void LTC6810_adax(uint8_t MD, //ADC Mode
+				  uint8_t CHG //GPIO Channels to be measured
+				 )
+{
+	LTC681x_adax(MD,CHG);
+}
+
+/* Start a Status ADC Conversion */
+void LTC6810_adstat(uint8_t MD, //ADC Mode
+					uint8_t CHST //Status Channels to be measured
+					)
+{
+	LTC681x_adstat(MD,CHST);
+}
+
+/* Starts cell voltage and Sum of Cells conversion */
+void LTC6810_adcvsc(uint8_t MD, //ADC Mode
+					uint8_t DCP //Discharge Permit
+					)
 {
     LTC681x_adcvsc(MD,DCP);
 }
 
-// Starts cell voltage, SV0 and GPIO1 conversion
-void LTC6810_adcvax(
-  uint8_t MD, //ADC Mode
-  uint8_t DCP //Discharge Permit
-)
+/* Starts cell voltage, SV0 and GPIO1 conversion */
+void LTC6810_adcvax(uint8_t MD, //ADC Mode
+					uint8_t DCP //Discharge Permit
+					)
 {
     LTC681x_adcvax(MD,DCP);
 }
 
-//Starts cell voltage overlap conversion
-void LTC6810_adol(
-  uint8_t MD, //ADC Mode
-  uint8_t DCP //Discharge Permit
-)
-{
-  LTC681x_adol(MD,DCP);
-}
-
-//Starts cell voltage self test conversion
-void LTC6810_cvst(
-  uint8_t MD, //ADC Mode
-  uint8_t ST //Self Test
-)
-{
-    LTC681x_cvst(MD,ST);
-}
-
-//Start an Auxiliary Register Self Test Conversion
-void LTC6810_axst(
-  uint8_t MD, //ADC Mode
-  uint8_t ST //Self Test
-)
-{
-  LTC681x_axst(MD,ST);
-}
-
-//Start a Status Register Self Test Conversion
-void LTC6810_statst(
-  uint8_t MD, //ADC Mode
-  uint8_t ST //Self Test
-)
-{
-    LTC681x_statst(MD,ST);
-}
-
-//Sends the poll ADC command
-uint8_t LTC6810_pladc()
-{
-  return(LTC681x_pladc());
-}
-
-//This function will block operation until the ADC has finished it's conversion
-uint32_t LTC6810_pollAdc()
-{
-  return(LTC681x_pollAdc());
-}
-
-//Start a GPIO and Vref2 Conversion
-void LTC6810_adax(
-  uint8_t MD, //ADC Mode
-  uint8_t CHG //GPIO Channels to be measured)
-)
-{
-  LTC681x_adax(MD,CHG);
-}
-
-//Start an GPIO Redundancy test
-void LTC6810_adaxd(
-  uint8_t MD, //ADC Mode
-  uint8_t CHG //GPIO Channels to be measured)
-)
-{
-  LTC681x_adaxd(MD,CHG);
-}
-
-//Start a Status ADC Conversion
-void LTC6810_adstat(
-  uint8_t MD, //ADC Mode
-  uint8_t CHST //GPIO Channels to be measured
-)
-{
-  LTC681x_adstat(MD,CHST);
-}
-
-// Start a Status register redundancy test Conversion
-void LTC6810_adstatd(
-  uint8_t MD, //ADC Mode
-  uint8_t CHST //GPIO Channels to be measured
-)
-{
- LTC681x_adstatd(MD,CHST);
-}
-
-// Start an open wire Conversion
-void LTC6810_adow(
-  uint8_t MD, //  ADC Conversion Mode
-  uint8_t PUP, //  Controls if Discharge is permitted during conversion
-  uint8_t CH, //Channels
-  uint8_t DCP//Discharge Permit
-)
-{
-    LTC681x_adow(MD,PUP, CH, DCP);
-}
-
-// Reads and parses the LTC6810 cell voltage registers.
-uint8_t LTC6810_rdcv(uint8_t reg, // Controls which cell voltage register is read back.
-                     uint8_t total_ic, // the number of ICs in the system
+/*
+Reads and parses the LTC6810 cell voltage registers.
+The function is used to read the parsed Cell Voltage of the LTC6810.
+This function will send the requested read commands, parse the data 
+and store the gpio voltages in c_codes variable.
+*/
+uint8_t LTC6810_rdcv(uint8_t reg, // Controls which cell voltage register is read back
+                     uint8_t total_ic, // The number of ICs in the system
                      cell_asic *ic // Array of the parsed cell codes
                     )
 {
- 
   int8_t pec_error = 0;
   pec_error = LTC681x_rdcv(reg,total_ic,ic);
   return(pec_error);
 }
 
-  /*
-   The function is used
-   to read the  parsed GPIO codes of the LTC6810. This function will send the requested
-   read commands parse the data and store the gpio voltages in aux_codes variable
-  */
-  int8_t LTC6810_rdaux(uint8_t reg, //Determines which GPIO voltage register is read back.
-                       uint8_t total_ic,//the number of ICs in the system
-                       cell_asic *ic//A two dimensional array of the gpio voltage codes.
-                      )
-  {
-    int8_t pec_error = 0;
-    LTC681x_rdaux(reg,total_ic,ic);
-    return (pec_error);
-  }
+/*
+Reads and parses the LTC6810 Auxiliary registers.
+The function is used to read the parsed GPIO codes of the LTC6810.
+This function will send the requested read commands, parse the data 
+and store the gpio voltages in a_codes variable.
+*/
+int8_t LTC6810_rdaux(uint8_t reg, //Determines which GPIO voltage register is read back
+				   uint8_t total_ic,//The number of ICs in the system
+				   cell_asic *ic//A two dimensional array of the gpio voltage codes
+				  )
+{
+   int8_t pec_error = 0;
+   LTC681x_rdaux(reg,total_ic,ic);
+   return (pec_error);
+}
 
-  /*
-   Reads and parses the LTC6810 stat registers.
-   The function is used
-   to read the  parsed stat codes of the LTC6810. This function will send the requested
-   read commands parse the data and store the stat voltages in stat_codes variable
-  */
- int8_t LTC6810_rdstat(uint8_t reg, //Determines which Stat  register is read back.
-                        uint8_t total_ic,//the number of ICs in the system
-                        cell_asic *ic
-                       )
-  {
-    int8_t pec_error = 0;
-    pec_error = LTC681x_rdstat(reg,total_ic,ic);
-    return (pec_error);
-  }
-  
-  /*
-   The command clears the cell voltage registers and initializes
-   all values to 1. The register will read back hexadecimal 0xFF
-   after the command is sent.
-  */
-  void LTC6810_clrcell()
-  {
-    LTC681x_clrcell();
-  }
+/*
+Reads and parses the LTC6810 stat registers.
+The function is used to read the parsed stat codes of the LTC6810. 
+This function will send the requested read commands, parse the data 
+and store the stat voltages in stat_codes variable.
+*/
+int8_t LTC6810_rdstat(uint8_t reg, //Determines which Stat register is read back
+					uint8_t total_ic,//The number of ICs in the system
+					cell_asic *ic //A two dimensional array of the stat codes
+				   )
+{
+   int8_t pec_error = 0;
+   pec_error = LTC681x_rdstat(reg,total_ic,ic);
+   return (pec_error);
+}
 
-  /*
-   The command clears the Auxiliary registers and initializes
-   all values to 1. The register will read back hexadecimal 0xFF
-   after the command is sent.
-  */
-  void LTC6810_clraux()
-  {
-    LTC681x_clraux();
-  }
-
-  /*
-   The command clears the Stat registers and initializes
-   all values to 1. The register will read back hexadecimal 0xFF
-   after the command is sent.
-  */
-  void LTC6810_clrstat()
-  {
-   LTC681x_clrstat();
-  }
-
-  /*
-   The command clears the Sctrl registers and initializes
-   all values to 0. The register will read back hexadecimal 0x00
-   after the command is sent.
-   */
-  void LTC6810_clrsctrl()
-  {
-     LTC681x_clrsctrl();
-  }
-
-//Starts the Mux Decoder diagnostic self test
-  void LTC6810_diagn()
-  {
-     LTC681x_diagn();
-  }
-
-  /*
-   This command will write the configuration registers of the LTC6810-1s
-   connected in a daisy chain stack. The configuration is written in descending
-   order so the last device's configuration is written first.
-  */
-  void LTC6810_wrcfg(uint8_t total_ic, //The number of ICs being written to
-                     cell_asic *ic //A two dimensional array of the configuration data that will be written
+/*
+Reads and parses the LTC6810 S voltage registers.
+The function is used to read the parsed s voltage codes of the LTC6810. 
+This function will send the requested read commands, parse the data 
+and store the stat voltages in c_codes variable
+*/
+uint8_t LTC6810_rds(uint8_t reg, //Controls which s voltage register is read back.
+                     uint8_t total_ic, //Number of ICs in the daisy chain 
+                     cell_asic *ic //Array of the parsed cell codes
                     )
-  {
-    LTC681x_wrcfg(total_ic,ic);
-  }
-
-
- 
- // Reads configuration registers of a LTC6810 daisy chain
-  int8_t LTC6810_rdcfg(uint8_t total_ic, //Number of ICs in the system
-                       cell_asic *ic //A two dimensional array that the function stores the read configuration data.
-                      )
-  {
+{
     int8_t pec_error = 0;
-    pec_error = LTC681x_rdcfg(total_ic,ic);
-    return(pec_error);
-  }
-
-
- // Writes the pwm registers of a LTC6810 daisy chain
-  void LTC6810_wrpwm(uint8_t total_ic,
-                     uint8_t pwmReg,  
-                     cell_asic *ic //A two dimensional array of the configuration data that will be written
-                    )
-  {
-      LTC681x_wrpwm(total_ic,pwmReg,ic);
-  }
-
-
- //Reads pwm registers of a LTC6810 daisy chain
-  int8_t LTC6810_rdpwm(uint8_t total_ic, //Number of ICs in the system
-                       uint8_t pwmReg,
-                       cell_asic *ic //A two dimensional array that the function stores the read configuration data.
-                      )
-  {
-    int8_t pec_error =0;
-    pec_error = LTC681x_rdpwm(total_ic,pwmReg,ic);
-    return(pec_error);
-  }
-
-  /*
-  Writes the COMM registers of a LTC6810 daisy chain
-  */
-  void LTC6810_wrcomm(uint8_t total_ic, //The number of ICs being written to
-                      cell_asic *ic //A two dimensional array of the comm data that will be written
-                     )
-  {
-      LTC681x_wrcomm(total_ic,ic);
-  }
-
-//Reads COMM registers of a LTC6810 daisy chain
-  int8_t LTC6810_rdcomm(uint8_t total_ic, //Number of ICs in the system
-                        cell_asic *ic //A two dimensional array that the function stores the read configuration data.
-                       )
-  {
-    int8_t pec_error = 0;
-    LTC681x_rdcomm(total_ic, ic);
-    return(pec_error);
-  }
-
-//Shifts data in COMM register out over LTC6810 SPI/I2C port
-void LTC6810_stcomm()
-{
-    LTC681x_stcomm();
-}
-
-//Helper function to set discharge bit in CFG register
-void LTC6810_set_discharge(int Cell, uint8_t total_ic, cell_asic *ic)
-{
-  for (int i=0; i<total_ic; i++)
-  {
-    if (Cell<7)
+    uint8_t *s_data;
+    uint8_t c_ic = 0;
+    s_data = (uint8_t *) malloc((NUM_RX_BYT*total_ic)*sizeof(uint8_t));
+    
+    if (reg == 0)
     {
-      ic[i].config.tx_data[4] = ic[i].config.tx_data[4] | (1<<(Cell-1));
-    }
-    else if (Cell ==0)
-    {
-      ic[i].config.tx_data[4] = ic[i].config.tx_data[4] | (0x80);
-    }
-  }
-}
-
-//Clears all of the DCC bits in the configuration registers
-void LTC6810_clear_discharge(uint8_t total_ic,
-                             cell_asic *ic)
-{
-   for (int i=0; i<total_ic; i++)
-  {
-    ic[i].config.tx_data[4] = ic[i].config.tx_data[4] & (0x40);
-  }
-
-}
-
-// Runs the Digital Filter Self Test
-int16_t LTC6810_run_cell_adc_st(uint8_t adc_reg,uint8_t total_ic, cell_asic *ic, uint8_t md, bool adcopt)
-{
-  int16_t error = 0;
-  error = LTC681x_run_cell_adc_st(adc_reg,total_ic,ic, md, adcopt);
-  return(error);
-}
-
-// Runs the redundancy self test
-int16_t LTC6810_run_adc_redundancy_st(uint8_t adc_mode, uint8_t adc_reg, uint8_t total_ic, cell_asic *ic)
-{
-  int16_t error = 0;
-  LTC681x_run_adc_redundancy_st(adc_mode,adc_reg,total_ic,ic);
-  return(error);
-}
-
-// Runs open wire for GPIOs
-void LTC6810_run_gpio_openwire(uint8_t total_ic, 
-								cell_asic ic[]
-								)
-{
-	      uint16_t OPENWIRE_THRESHOLD = 500;
-		  const uint8_t  N_CHANNELS =5;
-		  
-		  uint16_t aux_val[total_ic][N_CHANNELS];
-		  uint16_t pDwn[total_ic][N_CHANNELS];
-		  uint16_t ow_delta[total_ic][N_CHANNELS];
- 		  
-		  int8_t error;
-		  int8_t i;
-		  uint32_t conv_time=0;
-  
-		  wakeup_sleep(total_ic); 
-		  LTC681x_clraux();
-		   
-		  for (i = 0; i < 3; i++)
-		  { 
-		  wakeup_idle(total_ic);
-		  LTC681x_adax(MD_7KHZ_3KHZ, AUX_CH_ALL);
-		  conv_time= LTC681x_pollAdc();
-		  }
-		  
-		  wakeup_idle(total_ic);
-		  error = LTC681x_rdaux(0, total_ic,ic);
-		  
-		  for (int cic=0; cic<total_ic; cic++)
-		  {
-			  for (int channel=0; channel<N_CHANNELS; channel++)
-				{
-					aux_val[cic][channel]=ic[cic].aux.a_codes[channel];
-				}
-				
-		  }	
-		  LTC681x_clraux();
-		  
-		  // pull ups
-		  for (i = 0; i < 3; i++)
-		  { 
-			wakeup_idle(total_ic);
-			LTC681x_axow(MD_7KHZ_3KHZ,PULL_UP_CURRENT);
-			conv_time =LTC681x_pollAdc();
-		  } 
-		  
-		  wakeup_idle(total_ic);
-		  error = LTC681x_rdaux(0, total_ic,ic);
-		  
-		  for (int cic=0; cic<total_ic; cic++)
-		  {
-			   for (int channel=0; channel<N_CHANNELS; channel++)
-				{
-					pDwn[cic][channel]=ic[cic].aux.a_codes[channel] ;
-				}
-				
-		  }
-		  
-		  
-		for (int cic=0; cic<total_ic; cic++)
-		  {  
-				ic[cic].system_open_wire = 0xFFFF;
-				
-				for (int channel=0; channel<N_CHANNELS; channel++)
-				{
-					if (pDwn[cic][channel] > aux_val[cic][channel])                   
-					{
-						ow_delta[cic][channel] = (pDwn[cic][channel] - aux_val[cic][channel]);
-					}
-					else
-					{
-						ow_delta[cic][channel] = 0;                                             
-					} 
-					
-					if(channel>0)
-					{
-						if (ow_delta[cic][channel] > OPENWIRE_THRESHOLD) 
-						{
-							ic[cic].system_open_wire= channel;
-							
-						}  
-					}			
-				}
-		  }
-		  
-}
-
-// Runs the data sheet algorithm for open wire
-void LTC6810_run_openwire_single(uint8_t total_ic, cell_asic *ic)
-{
-  LTC681x_run_openwire_single(total_ic,ic);
-}
-
-// Runs the data sheet algorithm for open wire for multiple cell and two consecutive cells detection
-void LTC6810_run_openwire_multi(uint8_t total_ic,//Number of ICs in the system  
-						         cell_asic *ic   
-						        )
-{
-  LTC681x_run_openwire_multi(total_ic,ic);
-}
-
-void LTC6810_max_min(uint8_t total_ic, cell_asic ic_cells[],
-             cell_asic ic_min[],
-             cell_asic ic_max[],
-             cell_asic ic_delta[])
-{
-    for(int j=0; j < total_ic; j++)
-    {       
-        for(int i = 0; i< 12;i++)
+      for (uint8_t s_reg = 1; s_reg< 3; s_reg++) //executes once for each of the LTC6810 s voltage registers
+      {
+        LTC6810_rds_reg(s_reg, total_ic, s_data );
+     
+        for (int current_ic = 0; current_ic<total_ic; current_ic++)
         {
-            if(ic_cells[j].cells.c_codes[i]>ic_max[j].cells.c_codes[i])ic_max[j].cells.c_codes[i]=ic_cells[j].cells.c_codes[i];
-            else if (ic_cells[j].cells.c_codes[i]<ic_min[j].cells.c_codes[i])ic_min[j].cells.c_codes[i]=ic_cells[j].cells.c_codes[i];
-            ic_delta[j].cells.c_codes[i] = ic_max[j].cells.c_codes[i] - ic_min[j].cells.c_codes[i];
-        }       
-    }       
-                           
-}
-
-void LTC6810_init_max_min(uint8_t total_ic, cell_asic *ic,cell_asic ic_max[],cell_asic ic_min[])
-{
-    for(int j=0; j < total_ic; j++)
-    {       
-        for(int i = 0; i< ic[j].ic_reg.cell_channels;i++)
-        {
-            ic_max[j].cells.c_codes[i]=0;
-            ic_min[j].cells.c_codes[i]=0xFFFF;
-        }       
-    }       
-                             
-}
-
-//Helper function that increments PEC counters
-void LTC6810_check_pec(uint8_t total_ic,uint8_t reg, cell_asic *ic)
-{
-    LTC681x_check_pec(total_ic,reg,ic);
-}
-
-//Helper Function to reset PEC counters
-void LTC6810_reset_crc_count(uint8_t total_ic, cell_asic *ic)
-{
-     LTC681x_reset_crc_count(total_ic,ic);
-}
-
-//Helper function to initialize CFG variables.
-void LTC6810_init_cfg(uint8_t total_ic, cell_asic *ic)
-{
-   LTC681x_init_cfg(total_ic,ic);
-}
-
-//Helper function to set CFGR variable
-void LTC6810_set_cfgr(uint8_t nIC, cell_asic *ic, bool refon, bool adcopt, bool gpio[4], bool dcc[6],  bool dcc_0,  bool mcal, bool en_dtmen, bool dis_red, bool fdrf, bool sconv, bool dcto[4], uint16_t uv, uint16_t  ov)
-{
-    LTC6810_set_cfgr_refon(nIC,ic,refon);
-    LTC6810_set_cfgr_adcopt(nIC,ic,adcopt);
-    LTC6810_set_cfgr_gpio(nIC,ic,gpio);
-	LTC6810_set_cfgr_uv(nIC, ic, uv);
-    LTC6810_set_cfgr_ov(nIC, ic, ov);
-    LTC6810_set_cfgr_dis(nIC,ic,dcc);
-	LTC6810_set_cfgr_mcal(nIC,ic,mcal);
-	LTC6810_set_cfgr_dcc_0(nIC,ic,dcc_0);
-	LTC6810_set_cfgr_en_dtmen(nIC,ic,en_dtmen);
-	LTC6810_set_cfgr_dis_red(nIC,ic,dis_red);
-	LTC6810_set_cfgr_fdrf(nIC,ic,fdrf);
-	LTC6810_set_cfgr_sconv(nIC,ic,sconv);
-	LTC6810_set_cfgr_dcto(nIC,ic,dcto);
-   
-}
-//Helper function to set the REFON bit
-void LTC6810_set_cfgr_refon(uint8_t nIC, cell_asic *ic, bool refon) 
-{
-  LTC681x_set_cfgr_refon(nIC,ic,refon);
-}
-//Helper function to set the adcopt bit
-void LTC6810_set_cfgr_adcopt(uint8_t nIC, cell_asic *ic, bool adcopt)
-{
-  LTC681x_set_cfgr_adcopt(nIC,ic,adcopt);
-}
-
-//Helper function to set GPIO bits
-void LTC6810_set_cfgr_gpio(uint8_t nIC, cell_asic *ic,bool gpio[4])
-{  
- for (int i =0; i<4; i++)
-  {
-    if (gpio[i])ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]|(0x01<<(i+3));
-    else ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]&(~(0x01<<(i+3)));
-  }
-}
-//Helper function to control discharge
-void LTC6810_set_cfgr_dis(uint8_t nIC, cell_asic *ic,bool dcc[6])
-{  
-  for (int i =0; i<6; i++)
-  {
-    if (dcc[i])ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]|(0x01<<i);
-    else ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]& (~(0x01<<i));
-  }
-}
-//Helper Function to set UV value in CFG register
-void LTC6810_set_cfgr_uv(uint8_t nIC, cell_asic *ic,uint16_t uv)
-{
-    LTC681x_set_cfgr_uv(nIC, ic, uv);
-}
-//Helper function to set OV value in CFG register
-void LTC6810_set_cfgr_ov(uint8_t nIC, cell_asic *ic,uint16_t ov)
-{
-    LTC681x_set_cfgr_ov( nIC, ic, ov);
-}
-
-//Helper function to set the mcal bit
-void LTC6810_set_cfgr_mcal(uint8_t nIC, cell_asic *ic, bool mcal)
-{
-  if (mcal) ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]|0x40;
-  else ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]&0xBF;
-}
-
-//Helper function to set the DDC0 bit
-void LTC6810_set_cfgr_dcc_0(uint8_t nIC, cell_asic *ic, bool dcc_0)
-{
-  if (dcc_0) ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]|0x80;
-  else ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]&0x7F;	
-}
-
-//Helper function to set the en_dtmen bit
-void LTC6810_set_cfgr_en_dtmen(uint8_t nIC, cell_asic *ic, bool en_dtmen)
-{
-  if (en_dtmen) ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]|0x01;
-  else ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]&0xFE;
-}
-
-//Helper function to set the dis_red bit
-void LTC6810_set_cfgr_dis_red(uint8_t nIC, cell_asic *ic, bool dis_red)
-{
-  if (dis_red) ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]|0x02;
-  else ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]&0xFD;
-}
-
-//Helper function to set the fdrf bit
-void LTC6810_set_cfgr_fdrf(uint8_t nIC, cell_asic *ic, bool fdrf)
-{
-  if (fdrf) ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]|0x04;
-  else ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]&0xFB;	
-}
-
-//Helper function to set the sconv bit
-void LTC6810_set_cfgr_sconv(uint8_t nIC, cell_asic *ic, bool sconv)
-{
-  if (sconv) ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]|0x08;
-  else ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]&0xF7;	
-}
-
-//  Helper function to set the REFON bit
-void LTC6810_set_cfgr_dcto(uint8_t nIC, cell_asic *ic, bool dcto[4])
-{
-	LTC681x_set_cfgr_dcto(nIC, ic, dcto);
-}
-
-// Selects the S voltage register to read 
-void LTC6810_rds_reg(uint8_t reg, //Determines which cell voltage register is read back
-                      uint8_t total_ic, //the number of ICs in the
-                      uint8_t *data //An array of the unparsed cell codes
-                     )
-{
-  const uint8_t REG_LEN = 8; //number of bytes in each ICs register + 2 bytes for the PEC
-  uint8_t cmd[4];
-  uint16_t cmd_pec;
-
-  if (reg == 1)     //1: RDSA
-  {
-    cmd[1] = 0x08;
-    cmd[0] = 0x00;
-  }
-  else if (reg == 2) //4: RDSB
-  {
-    cmd[1] = 0x0A;
-    cmd[0] = 0x00;
-  }
- 
-  read_68(total_ic, cmd, data);
-}
-
-//Reads S voltage registers.
-uint8_t LTC6810_rds(uint8_t reg, // Controls which cell voltage register is read back.
-                     uint8_t total_ic, // the number of ICs in the system
-                     cell_asic *ic // Array of the parsed cell codes
-                    )
-{
-  int8_t pec_error = 0;
-  uint8_t *s_data;
-  uint8_t c_ic = 0;
-  s_data = (uint8_t *) malloc((NUM_RX_BYT*total_ic)*sizeof(uint8_t));
-
-  if (reg == 0)
-  {
-    for (uint8_t s_reg = 1; s_reg< 3; s_reg++) //executes once for each of the LTC6811 cell voltage registers
+          if (ic->isospi_reverse == false)
+          {
+            c_ic = current_ic;
+          }
+          else
+          {
+            c_ic = total_ic - current_ic - 1;
+          }
+          pec_error = pec_error + parse_cells(current_ic, (2+ s_reg), s_data,
+                                              &ic[c_ic].cells.c_codes[0],
+                                              &ic[c_ic].cells.pec_match[0]);
+        }
+      }
+     }
+    
+    else
     {
-      LTC6810_rds_reg(s_reg, total_ic, s_data );
-	  
+      LTC6810_rds_reg(reg, total_ic, s_data);
+    
       for (int current_ic = 0; current_ic<total_ic; current_ic++)
       {
         if (ic->isospi_reverse == false)
@@ -710,40 +242,348 @@ uint8_t LTC6810_rds(uint8_t reg, // Controls which cell voltage register is read
         {
           c_ic = total_ic - current_ic - 1;
         }
-        pec_error = pec_error + parse_cells(current_ic, (2+ s_reg), s_data,
+        pec_error = pec_error + parse_cells(current_ic, (2+ reg), &s_data[8*c_ic],
                                             &ic[c_ic].cells.c_codes[0],
                                             &ic[c_ic].cells.pec_match[0]);
       }
     }
-   }
-
-  else
-  {
-    LTC6810_rds_reg(reg, total_ic, s_data);
-
-    for (int current_ic = 0; current_ic<total_ic; current_ic++)
-    {
-      if (ic->isospi_reverse == false)
-      {
-        c_ic = current_ic;
-      }
-      else
-      {
-        c_ic = total_ic - current_ic - 1;
-      }
-      pec_error = pec_error + parse_cells(current_ic, (2+ reg), &s_data[8*c_ic],
-                                          &ic[c_ic].cells.c_codes[0],
-                                          &ic[c_ic].cells.pec_match[0]);
-    }
-  }
-  LTC6810_check_pec(total_ic,CELL,ic);
-  free(s_data);
-  return(pec_error);
+    LTC6810_check_pec(total_ic,CELL,ic);
+    free(s_data);
+    return(pec_error);
 }
 
- // Reads Serial ID registers group.
-uint8_t LTC6810_rdsid(uint8_t total_ic, // the number of ICs in the system
-                     cell_asic *ic // Array of the parsed cell codes
+/* Selects the S voltage register to read  */
+void LTC6810_rds_reg(uint8_t reg, //Determines which S voltage register is read back
+                      uint8_t total_ic, //The number of ICs in the daisy chain 
+                      uint8_t *data //An array of the unparsed cell codes
+                     )
+{
+	const uint8_t REG_LEN = 8; //Number of bytes in each ICs register + 2 bytes for the PEC
+	uint8_t cmd[4];
+	uint16_t cmd_pec;
+
+	if (reg == 1)     // RDSA
+	{
+	cmd[1] = 0x08;
+	cmd[0] = 0x00;
+	}
+	else if (reg == 2) // RDSB
+	{
+	cmd[1] = 0x0A;
+	cmd[0] = 0x00;
+	}
+	
+	read_68(total_ic, cmd, data);
+}
+
+/* Sends the poll ADC command */
+uint8_t LTC6810_pladc()
+{
+	return(LTC681x_pladc());
+}
+
+/* This function will block operation until the ADC has finished it's conversion*/
+uint32_t LTC6810_pollAdc()
+{
+	return(LTC681x_pollAdc());
+}
+
+/*
+The command clears the Cell Voltage registers and initializes
+all values to 1. The register will read back hexadecimal 0xFF
+after the command is sent.
+*/
+void LTC6810_clrcell()
+{
+	LTC681x_clrcell();
+}
+
+/*
+The command clears the Auxiliary registers and initializes
+all values to 1. The register will read back hexadecimal 0xFF
+after the command is sent.
+*/
+void LTC6810_clraux()
+{
+	LTC681x_clraux();
+}
+
+/*
+The command clears the Stat registers and initializes
+all values to 1. The register will read back hexadecimal 0xFF
+after the command is sent.
+*/
+void LTC6810_clrstat()
+{
+	LTC681x_clrstat();
+}
+
+/* Starts the Mux Decoder diagnostic self test */
+void LTC6810_diagn()
+{
+	LTC681x_diagn();
+}
+
+/* Starts cell voltage self test conversion */
+void LTC6810_cvst(uint8_t MD, //ADC Mode
+				  uint8_t ST //Self Test
+				 )
+{
+    LTC681x_cvst(MD,ST);
+}
+
+/* Start an Auxiliary Register Self Test Conversion */
+void LTC6810_axst(uint8_t MD, //ADC Mode
+				  uint8_t ST //Self Test
+				 )
+{
+	LTC681x_axst(MD,ST);
+}
+
+/* Start a Status Register Self Test Conversion */
+void LTC6810_statst(uint8_t MD, //ADC Mode
+					uint8_t ST //Self Test
+					)
+{
+    LTC681x_statst(MD,ST);
+}
+
+/* Start an GPIO Redundancy test */
+void LTC6810_adaxd(uint8_t MD, //ADC Mode
+				   uint8_t CHG //GPIO Channels to be measured
+				  )
+{
+	LTC681x_adaxd(MD,CHG);
+}
+
+/* Start a Status register redundancy test */ 
+void LTC6810_adstatd(uint8_t MD, //ADC Mode
+					 uint8_t CHST //Stat Channels to be measured
+					)
+{
+	LTC681x_adstatd(MD,CHST);
+}
+
+/* Runs the Digital Filter Self Test */
+int16_t LTC6810_run_cell_adc_st(uint8_t adc_reg, //Type of register
+								uint8_t total_ic, //Number of ICs in the daisy chain 
+								cell_asic *ic, //A two dimensional array that will store the data
+								uint8_t md, //ADC Mode
+								bool adcopt //ADCOPT bit in the configuration register
+								)
+{
+  int16_t error = 0;
+  error = LTC681x_run_cell_adc_st(adc_reg,total_ic,ic, md, adcopt);
+  return(error);
+}
+
+/* Runs the redundancy self test */
+int16_t LTC6810_run_adc_redundancy_st(uint8_t adc_mode, //ADC Mode
+									  uint8_t adc_reg,  //Type of register
+									  uint8_t total_ic, //Number of ICs in the daisy chain 
+									  cell_asic *ic  //A two dimensional array that will store the data
+									  )
+{
+  int16_t error = 0;
+  LTC681x_run_adc_redundancy_st(adc_mode,adc_reg,total_ic,ic);
+  return(error);
+}
+
+/* Start an open wire Conversion */
+void LTC6810_adow(uint8_t MD, //ADC Conversion Mode
+				  uint8_t PUP, //Pull up/Pull down current
+				  uint8_t CH, //Cell Channels
+				  uint8_t DCP//Discharge Permit
+				)
+{
+    LTC681x_adow(MD,PUP, CH, DCP);
+}
+
+/* Start GPIOs open wire ADC conversion */
+void LTC6810_axow(uint8_t MD, //ADC Mode
+				  uint8_t PUP //Pull up/Pull down current
+				 )
+{
+    LTC681x_axow(MD, PUP);
+}
+
+/* Runs the data sheet algorithm for open wire for single cell open detection */
+void LTC6810_run_openwire_single(uint8_t total_ic, //Number of ICs in the daisy chain 
+								 cell_asic *ic //A two dimensional array that will store the data
+								 )
+{
+	LTC681x_run_openwire_single(total_ic,ic);
+}
+
+/* Runs the data sheet algorithm for open wire for multiple cell and two consecutive cells open detection */
+void LTC6810_run_openwire_multi(uint8_t total_ic,//Number of ICs in the system  
+						         cell_asic *ic //A two dimensional array that will store the data
+						        )
+{
+	LTC681x_run_openwire_multi(total_ic,ic);
+}
+
+/* Runs open wire for GPIOs */
+void LTC6810_run_gpio_openwire(uint8_t total_ic, //Number of ICs in the daisy chain 
+								cell_asic ic[] //A two dimensional array that will store the data
+								)
+{
+	uint16_t OPENWIRE_THRESHOLD = 500;
+	const uint8_t  N_CHANNELS =5;
+	  
+	uint16_t aux_val[total_ic][N_CHANNELS];
+	uint16_t pDwn[total_ic][N_CHANNELS];
+	uint16_t ow_delta[total_ic][N_CHANNELS];
+	
+	int8_t error;
+	int8_t i;
+	uint32_t conv_time=0;
+
+	wakeup_sleep(total_ic); 
+	LTC6810_clraux();
+	 
+	for (i = 0; i < 3; i++)
+	{ 
+		wakeup_idle(total_ic);
+		LTC6810_adax(MD_7KHZ_3KHZ, AUX_CH_ALL);
+		conv_time= LTC6810_pollAdc();
+	}
+	
+	wakeup_idle(total_ic);
+	error = LTC6810_rdaux(0, total_ic,ic);
+	
+	for (int cic=0; cic<total_ic; cic++)
+	{
+	  for (int channel=0; channel<N_CHANNELS; channel++)
+		{
+			aux_val[cic][channel]=ic[cic].aux.a_codes[channel];
+		}	
+	}	
+	LTC6810_clraux();
+	
+	// pull ups
+	for (i = 0; i < 3; i++)
+	{ 
+		wakeup_idle(total_ic);
+		LTC6810_axow(MD_7KHZ_3KHZ,PULL_UP_CURRENT);
+		conv_time =LTC6810_pollAdc();
+	} 
+	
+	wakeup_idle(total_ic);
+	error = LTC6810_rdaux(0, total_ic,ic);
+	
+	for (int cic=0; cic<total_ic; cic++)
+	{
+	   for (int channel=0; channel<N_CHANNELS; channel++)
+		{
+			pDwn[cic][channel]=ic[cic].aux.a_codes[channel] ;
+		}	
+	}
+	  
+	for (int cic=0; cic<total_ic; cic++)
+	{  
+		ic[cic].system_open_wire = 0xFFFF;
+		
+		for (int channel=0; channel<N_CHANNELS; channel++)
+		{
+			if (pDwn[cic][channel] > aux_val[cic][channel])                   
+			{
+				ow_delta[cic][channel] = (pDwn[cic][channel] - aux_val[cic][channel]);
+			}
+			else
+			{
+				ow_delta[cic][channel] = 0;                                             
+			} 
+			
+			if(channel>0)
+			{
+				if (ow_delta[cic][channel] > OPENWIRE_THRESHOLD) 
+				{
+					ic[cic].system_open_wire = channel;
+				}  
+			}			
+		}
+	}		  
+}
+
+/* Helper function to set discharge bit in CFG register */
+void LTC6810_set_discharge(int Cell, //The cell to be discharged
+						   uint8_t total_ic, //Number of ICs in the daisy chain 
+						   cell_asic *ic //A two dimensional array that will store the data
+						   )
+{
+	for (int i=0; i<total_ic; i++)
+	{
+		if (Cell<7)
+		{
+		  ic[i].config.tx_data[4] = ic[i].config.tx_data[4] | (1<<(Cell-1));
+		}
+		else if (Cell ==0)
+		{
+		  ic[i].config.tx_data[4] = ic[i].config.tx_data[4] | (0x80);
+		}
+	}
+}
+
+/* Clears all of the DCC bits in the configuration registers */
+void LTC6810_clear_discharge(uint8_t total_ic, //Number of ICs in the daisy chain 
+                             cell_asic *ic //A two dimensional array that will store the data
+							 )
+{
+	for (int i=0; i<total_ic; i++)
+	{
+		ic[i].config.tx_data[4] = ic[i].config.tx_data[4] & (0x40);
+	}
+}
+
+/* Writes the pwm registers of a LTC6810 daisy chain */
+void LTC6810_wrpwm(uint8_t total_ic, //Number of ICs in the daisy chain 
+				   uint8_t pwmReg,  //Select register
+				   cell_asic *ic //A two dimensional array that will store the data to be written
+				  )
+{
+  LTC681x_wrpwm(total_ic,pwmReg,ic);
+}
+
+/* Reads pwm registers of a LTC6810 daisy chain */
+int8_t LTC6810_rdpwm(uint8_t total_ic, //Number of ICs in the system
+				   uint8_t pwmReg, // Select register
+				   cell_asic *ic //A two dimensional array that the function stores the read data.
+				  )
+{
+   int8_t pec_error =0;
+   pec_error = LTC681x_rdpwm(total_ic,pwmReg,ic);
+   return(pec_error);
+}
+
+
+/* Writes the COMM registers of a LTC6810 daisy chain */
+void LTC6810_wrcomm(uint8_t total_ic, //The number of ICs being written to
+				  cell_asic *ic //A two dimensional array of the comm data that will be written
+				 )
+{
+	LTC681x_wrcomm(total_ic,ic);
+}
+
+/* Reads COMM registers of a LTC6810 daisy chain */
+int8_t LTC6810_rdcomm(uint8_t total_ic, //Number of ICs in the system
+					cell_asic *ic //A two dimensional array that the function stores the read data.
+				   )
+{
+   int8_t pec_error = 0;
+   LTC681x_rdcomm(total_ic, ic);
+   return(pec_error);
+}
+
+/* Shifts data in COMM register out over LTC6810 SPI/I2C port */
+void LTC6810_stcomm(uint8_t len) //Length of data to be transmitted
+{
+    LTC681x_stcomm(len);  
+}
+
+/* Reads Serial ID registers group. */
+uint8_t LTC6810_rdsid(uint8_t total_ic, // The number of ICs in the system
+                     cell_asic *ic //A two dimensional array that the function stores the read data.
                     )
 {
     uint8_t cmd[4];
@@ -778,7 +618,7 @@ uint8_t LTC6810_rdsid(uint8_t total_ic, // the number of ICs in the system
     return(pec_error);
 } 
 
-//Mutes the LTC6813 discharge transistors
+/* Mutes the LTC6810 discharge transistors */
 void LTC6810_mute()
 {
 	uint8_t cmd[2];
@@ -789,7 +629,7 @@ void LTC6810_mute()
 	cmd_68(cmd);
 }
 
-//Clears the LTC6813 Mute Discharge
+/* Clears the LTC6810 Mute Discharge */
 void LTC6810_unmute()
 {
 	uint8_t cmd[2];
@@ -797,4 +637,137 @@ void LTC6810_unmute()
 	cmd[0] = 0x00;
 	cmd[1] = 0x29;
 	cmd_68(cmd);
+}
+
+/* Helper function that increments PEC counters */
+void LTC6810_check_pec(uint8_t total_ic, //The number of ICs in the system
+					   uint8_t reg, //Type of register
+					   cell_asic *ic //A two dimensional array that will store the data
+					   )
+{
+    LTC681x_check_pec(total_ic,reg,ic);
+}
+
+/* Helper Function to reset PEC counters */
+void LTC6810_reset_crc_count(uint8_t total_ic, //The number of ICs in the system
+							 cell_asic *ic //A two dimensional array that will store the data
+							 )
+{
+    LTC681x_reset_crc_count(total_ic,ic);
+}
+
+/* Helper function to initialize CFG variables. */
+void LTC6810_init_cfg(uint8_t total_ic, cell_asic *ic)
+{
+    LTC681x_init_cfg(total_ic,ic);
+}
+
+/* Helper function to set CFGR variable */
+void LTC6810_set_cfgr(uint8_t nIC, cell_asic *ic, bool refon, bool adcopt, bool gpio[4], bool dcc[6],  bool dcc_0,  bool mcal, bool en_dtmen, bool dis_red, bool fdrf, bool sconv, bool dcto[4], uint16_t uv, uint16_t  ov)
+{
+    LTC6810_set_cfgr_refon(nIC,ic,refon);
+    LTC6810_set_cfgr_adcopt(nIC,ic,adcopt);
+    LTC6810_set_cfgr_gpio(nIC,ic,gpio);
+	LTC6810_set_cfgr_uv(nIC, ic, uv);
+    LTC6810_set_cfgr_ov(nIC, ic, ov);
+    LTC6810_set_cfgr_dis(nIC,ic,dcc);
+	LTC6810_set_cfgr_mcal(nIC,ic,mcal);
+	LTC6810_set_cfgr_dcc_0(nIC,ic,dcc_0);
+	LTC6810_set_cfgr_en_dtmen(nIC,ic,en_dtmen);
+	LTC6810_set_cfgr_dis_red(nIC,ic,dis_red);
+	LTC6810_set_cfgr_fdrf(nIC,ic,fdrf);
+	LTC6810_set_cfgr_sconv(nIC,ic,sconv);
+	LTC6810_set_cfgr_dcto(nIC,ic,dcto);  
+}
+
+/* Helper function to set the REFON bit */
+void LTC6810_set_cfgr_refon(uint8_t nIC, cell_asic *ic, bool refon) 
+{
+	LTC681x_set_cfgr_refon(nIC,ic,refon);
+}
+
+/* Helper function to set the ADCOPT bit */
+void LTC6810_set_cfgr_adcopt(uint8_t nIC, cell_asic *ic, bool adcopt)
+{
+	LTC681x_set_cfgr_adcopt(nIC,ic,adcopt);
+}
+
+/* Helper function to set GPIO bits */
+void LTC6810_set_cfgr_gpio(uint8_t nIC, cell_asic *ic,bool gpio[4])
+{  
+	for (int i =0; i<4; i++)
+	{
+		if (gpio[i])ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]|(0x01<<(i+3));
+		else ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]&(~(0x01<<(i+3)));
+	}
+}
+
+/* Helper function to control discharge */
+void LTC6810_set_cfgr_dis(uint8_t nIC, cell_asic *ic,bool dcc[6])
+{  
+	for (int i =0; i<6; i++)
+	{
+		if (dcc[i])ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]|(0x01<<i);
+		else ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]& (~(0x01<<i));
+	}
+}
+
+/* Helper Function to set UV value in CFG register */
+void LTC6810_set_cfgr_uv(uint8_t nIC, cell_asic *ic,uint16_t uv)
+{
+    LTC681x_set_cfgr_uv(nIC, ic, uv);
+}
+
+/* Helper function to set OV value in CFG register */
+void LTC6810_set_cfgr_ov(uint8_t nIC, cell_asic *ic,uint16_t ov)
+{
+    LTC681x_set_cfgr_ov( nIC, ic, ov);
+}
+
+/* Helper function to set the MCAL bit */
+void LTC6810_set_cfgr_mcal(uint8_t nIC, cell_asic *ic, bool mcal)
+{
+	if (mcal) ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]|0x40;
+	else ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]&0xBF;
+}
+
+/* Helper function to set the DCC0 bit */
+void LTC6810_set_cfgr_dcc_0(uint8_t nIC, cell_asic *ic, bool dcc_0)
+{
+	if (dcc_0) ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]|0x80;
+	else ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]&0x7F;	
+}
+
+/* Helper function to set the EN_DTMEN bit */
+void LTC6810_set_cfgr_en_dtmen(uint8_t nIC, cell_asic *ic, bool en_dtmen)
+{
+	if (en_dtmen) ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]|0x01;
+	else ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]&0xFE;
+}
+
+/* Helper function to set the DIS_RED bit */
+void LTC6810_set_cfgr_dis_red(uint8_t nIC, cell_asic *ic, bool dis_red)
+{
+	if (dis_red) ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]|0x02;
+	else ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]&0xFD;
+}
+
+/* Helper function to set the FDRF bit */
+void LTC6810_set_cfgr_fdrf(uint8_t nIC, cell_asic *ic, bool fdrf)
+{
+	if (fdrf) ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]|0x04;
+	else ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]&0xFB;	
+}
+
+/* Helper function to set the SCONV bit */
+void LTC6810_set_cfgr_sconv(uint8_t nIC, cell_asic *ic, bool sconv)
+{
+	if (sconv) ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]|0x08;
+	else ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]&0xF7;	
+}
+
+/* Helper function to set the discharge timer bits */
+void LTC6810_set_cfgr_dcto(uint8_t nIC, cell_asic *ic, bool dcto[4])
+{
+	LTC681x_set_cfgr_dcto(nIC, ic, dcto);
 }

--- a/LTSketchbook/libraries/LTC6810/LTC6810.h
+++ b/LTSketchbook/libraries/LTC6810/LTC6810.h
@@ -1,9 +1,9 @@
 /*! LTC6810: 6-Channel Battery Stack Monitors
 *
 *@verbatim
-*The LTC6810 is multicell battery stack monitor that measures up to 6 series 
+*The LTC6810 is multi-cell battery stack monitor that measures up to 6 series 
 *connected battery cells with a total measurement error of less than 1.8mV. 
-*The cell measurement range of 0V to 5V makes the LTC6813 suitable for most 
+*The cell measurement range of 0V to 5V makes the LTC6810 suitable for most 
 *battery chemistries. All 6 cell voltages can be captured in 290uS, and lower 
 *data acquisition rates can be selected for high noise reduction.
 *Using the LTC6810-1, multiple devices are connected in a daisy-chain with one 
@@ -63,475 +63,507 @@
 #define AUX 2
 #define STAT 3
 
-//! Initialize the Register limits
-//!@return void
+/*!
+ Initialize the Register limits
+@return void 
+*/
 void LTC6810_init_reg_limits(uint8_t total_ic, //!< Number of ICs in the system
 							cell_asic *ic //!< A two dimensional array that will store the data
 							);
+							
+/*! 
+Write the LTC6810 configuration register
+ @return void 
+ */
+void LTC6810_wrcfg(uint8_t nIC, //!< The number of ICs being written
+                   cell_asic *ic //!< A two dimensional array of the configuration data that will be written
+                  );
+
+/*!
+ Reads configuration registers of a LTC6810 daisy chain
+ @return int8_t, PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC
+ */
+int8_t LTC6810_rdcfg(uint8_t nIC, //!< Number of ICs in the daisy chain
+                     cell_asic *ic //!< A two dimensional array that the function stores the read configuration data
+                    );							
     
-//! Starts the Mux Decoder diagnostic self test
-//! Running this command will start the Mux Decoder Diagnostic Self Test.
-//! This test takes roughly 1ms to complete. The MUXFAIL bit will be updated.
-//! The bit will be set to 1 for a failure and 0 if the test has been passed.
-//!@return void
-void LTC6810_diagn();
-
-
-//! Sends the poll ADC command
-//! @returns 1 byte read back after a pladc command. If the byte is not 0xFF ADC conversion has completed
-uint8_t LTC6810_pladc();
-
-
-//! This function will block operation until the ADC has finished it's conversion
-//! @returns the approximate time it took for the ADC function to complete.
-uint32_t LTC6810_pollAdc();
-
-//! Starts cell voltage conversion
-//!@return void
+/*!
+ Starts cell voltage conversion
+ @return void 
+ */
 void LTC6810_adcv(uint8_t MD, //!< ADC Conversion Mode
                   uint8_t DCP, //!< Controls if Discharge is permitted during conversion
                   uint8_t CH //!< Sets which Cell channels are converted
                  );
 
-//!  Starts cell voltage, Cell 0 and GPIO 1 conversion
-//!@return void
-void LTC6810_adcvax(
-  uint8_t MD, //!< ADC Conversion Mode
-  uint8_t DCP //!< Controls if Discharge is permitted during conversion
-);
+/*!
+ Start a GPIO, cell 0 and Vref2 Conversion
+ @return void 
+ */
+void LTC6810_adax(uint8_t MD, //!< ADC Conversion Mode
+				  uint8_t CHG //!< Sets which GPIO channels are converted
+				 );
+				
+/*!
+ Start a Status ADC Conversion
+ @return void 
+ */
+void LTC6810_adstat(uint8_t MD, //!< ADC Conversion Mode
+					uint8_t CHST //!< Sets which Stat channels are converted
+				   );
 
+/*!
+ Starts cell voltage, Cell 0 and GPIO 1 conversion
+ @return void */
+void LTC6810_adcvax(uint8_t MD, //!< ADC Conversion Mode
+					uint8_t DCP //!< Controls if Discharge is permitted during conversion
+				   );
 
-//!  Starts cell voltage self test conversion
-//!@return void
-void LTC6810_cvst(
-  uint8_t MD, //!< ADC Conversion Mode
-  uint8_t ST //!< Self Test Mode
-);
+/*!
+ Starts cell voltage and SOC conversion
+ @return void 
+ */
+void LTC6810_adcvsc(uint8_t MD, //!< ADC Conversion Mode
+					uint8_t DCP //!< Controls if Discharge is permitted during conversion
+				   );				   
 
-//!  Starts cell voltage and SOC conversion
-//!@return void
-void LTC6810_adcvsc(
-  uint8_t MD, //!< ADC Conversion Mode
-  uint8_t DCP //!< Controls if Discharge is permitted during conversion
-);
-
-//!  Starts cell voltage overlap conversion
-//!@return void
-void LTC6810_adol(
-  uint8_t MD, //!< ADC Conversion Mode
-  uint8_t DCP //!< Discharge permitted during conversion
-);
-
-//!  Start an open wire Conversion
-//!@return void
-void LTC6810_adow(
- uint8_t MD, //!<  ADC Conversion Mode
- uint8_t PUP, //!<  Controls if Discharge is permitted during conversion
- uint8_t CH, //!< Channels
- uint8_t DCP//!< Discharge Permit
-);
-
-
-//!  Start a GPIO and Vref2 Conversion
-//!@return void
-void LTC6810_adax(
-  uint8_t MD, //!< ADC Conversion Mode
-  uint8_t CHG //!< Sets which GPIO channels are converted
-);
-
-//!  Start an GPIO Redundancy test
-//!@return void
-void LTC6810_adaxd(
-  uint8_t MD, //!< ADC Conversion Mode
-  uint8_t CHG //!< Sets which GPIO channels are converted
-);
-
-//!  Start an Auxiliary Register Self Test Conversion
-//!@return void
-void LTC6810_axst(
-  uint8_t MD, //!< ADC Conversion Mode
-  uint8_t ST //!< Sets if self test 1 or 2 is run
-);
-
-//!  Start a Status ADC Conversion
-//!@return void
-void LTC6810_adstat(
-  uint8_t MD, //!< ADC Conversion Mode
-  uint8_t CHST //!< Sets which Stat channels are converted
-);
-
-//!   Start a Status register redundancy test Conversion
-//!@return void
-void LTC6810_adstatd(
-  uint8_t MD, //!< ADC Mode
-  uint8_t CHST //!< Sets which Status channels are converted
-);
-
-
-//!  Start a Status Register Self Test Conversion
-//!@return void
-void LTC6810_statst(
-  uint8_t MD, //!< ADC Conversion Mode
-  uint8_t ST //!< Sets if self test 1 or 2 is run
-);
-
-/*!  Reads and parses the LTC6810 cell voltage registers.
-  @return int8_t, PEC Status.
-    0: No PEC error detected
-    -1: PEC error detected, retry read
-*/
-uint8_t LTC6810_rdcv(uint8_t reg, //!< controls which cell voltage register is read back.
-                     uint8_t total_ic, //!< the number of ICs in the daisy chain(-1 only)
-                     cell_asic *ic //!< array of the parsed cell codes from lowest to highest.
+/*!
+ Reads and parses the LTC6810 cell voltage registers.
+  @return uint8_t, pec_error PEC Status.
+  0: No PEC error detected
+ -1: PEC error detected, retry read 
+ */
+uint8_t LTC6810_rdcv(uint8_t reg, //!< Determines which cell voltage register is read back.
+                     uint8_t total_ic, //!< The number of ICs in the daisy chain
+                     cell_asic *ic //!< Array of the parsed cell codes
                     );
 
-
-/*!  Reads and parses the LTC6810 auxiliary registers.
-@return  int8_t, PEC Status
+/*!
+ Reads and parses the LTC6810 auxiliary registers.
+  @return  int8_t, pec_error PEC Status.
   0: No PEC error detected
- -1: PEC error detected, retry read
-*/
-int8_t LTC6810_rdaux(uint8_t reg,        //!< controls which GPIO voltage register is read back
-                     uint8_t nIC,        //!< the number of ICs in the daisy chain
+ -1: PEC error detected, retry read 
+   */
+int8_t LTC6810_rdaux(uint8_t reg, //!< Determines which GPIO voltage register is read back
+                     uint8_t nIC, //!< The number of ICs in the daisy chain
                      cell_asic *ic //!< A two dimensional array of the parsed gpio voltage codes
                     );
-
-/*!  Reads and parses the LTC6810 stat registers.
-@return  int8_t, PEC Status
-  0: No PEC error detected
- -1: PEC error detected, retry read
-*/
-int8_t LTC6810_rdstat(uint8_t reg, //!< Determines which Stat  register is read back.
-                        uint8_t total_ic, //!< The number of ICs in the system
-                        cell_asic *ic //!< A two dimensional array of the parsed gpio voltage codes
-                       );
 					
-//!  Clears the LTC6812 cell voltage registers
-//!@return void
+/*!
+ Reads and parses the LTC6810 stat registers.
+  @return  int8_t, pec_error PEC Status.
+  0: No PEC error detected
+ -1: PEC error detected, retry read 
+ */
+int8_t LTC6810_rdstat(uint8_t reg, //!< Determines which Stat register is read back.
+                      uint8_t total_ic, //!< The number of ICs in the system
+                      cell_asic *ic //!< A two dimensional array of the parsed stat codes
+                       );
+					   
+/*!
+ Reads and parses the LTC6810 S voltage registers
+ @return uint8_t, pec_error PEC Status.
+  0: No PEC error detected
+ -1: PEC error detected, retry read 
+ */
+uint8_t LTC6810_rds(uint8_t reg, //!< Determines which S voltage registers is read back.
+                     uint8_t total_ic, //!< The number of ICs in the system
+                     cell_asic *ic //!< Array of the parsed cell codes
+                    );
+					
+/*!
+ Reads the raw S voltage register data
+ @return void 
+ */
+void LTC6810_rds_reg(uint8_t reg, //!< Determines which s voltage register is read back
+                      uint8_t total_ic, //!< The number of ICs in the daisy-chain
+                      uint8_t *data //!< An array of the unparsed cell codes
+                     );
+
+/*!
+ Sends the poll ADC command
+  @returns 1 byte read back after a pladc command. If the byte is not 0xFF ADC conversion has completed 
+  */
+uint8_t LTC6810_pladc();
+
+/*!
+ This function will block operation until the ADC has finished it's conversion
+  @returns the approximate time it took for the ADC function to complete. 
+  */
+uint32_t LTC6810_pollAdc();					   
+					
+/*! Clears the LTC6810 cell voltage registers
+ @return void 
+ */
 void LTC6810_clrcell();
 
-/*! Clears the LTC6810 Auxiliary registers
-@return void
+/*!
+ Clears the LTC6810 Auxiliary registers
+ @return void 
 */
 void LTC6810_clraux();
 
-/*!  Clears the LTC6810 Stat registers
-@return void
-*/
+/*!
+ Clears the LTC6810 Stat registers
+  @return void */
 void LTC6810_clrstat();
 
-/*!  Clears the LTC6810 Sctrl registers
-@return void
-*/
-void LTC6810_clrsctrl();
+/*!
+ Starts the Mux Decoder diagnostic self test.
+ Running this command will start the Mux Decoder Diagnostic Self Test.
+ This test takes roughly 1ms to complete. The MUXFAIL bit will be updated.
+ The bit will be set to 1 for a failure and 0 if the test has been passed.
+ @return void
+ */
+void LTC6810_diagn();					
+				   
+/*!
+ Starts Cell voltage self test conversion
+ @return void 
+ */
+void LTC6810_cvst(uint8_t MD, //!< ADC Conversion Mode
+				  uint8_t ST //!< Sets if self test 1 or 2 is run
+				 );
 
-/*!  Write the LTC6810 configuration register
-@return void
-*/
-void LTC6810_wrcfg(uint8_t nIC, //!< The number of ICs being written
-                   cell_asic *ic //!< a two dimensional array of the configuration data that will be written
-                  );
+/*!
+ Start an Auxiliary Register Self Test Conversion
+ @return void 
+ */
+void LTC6810_axst(uint8_t MD, //!< ADC Conversion Mode
+				  uint8_t ST //!< Sets if self test 1 or 2 is run
+				 );
 
-/*!  Reads configuration registers of a LTC6810 daisy chain
-@return int8_t, PEC Status.
-  0: Data read back has matching PEC
-   -1: Data read back has incorrect PEC
-*/
-int8_t LTC6810_rdcfg(uint8_t nIC, //!< number of ICs in the daisy chain
-                     cell_asic *ic //!< a two dimensional array that the function stores the read configuration data
-                    );
+/*!
+ Start a Status Register Self Test Conversion
+ @return void 
+ */
+void LTC6810_statst(uint8_t MD, //!< ADC Conversion Mode
+					uint8_t ST //!< Sets if self test 1 or 2 is run
+				   );				 
+				 
+/*!
+ Start an GPIO Redundancy test
+ @return void 
+ */
+void LTC6810_adaxd(uint8_t MD, //!< ADC Conversion Mode
+				   uint8_t CHG //!< Sets which GPIO channels are converted
+				  );
 
-/*!  Write the LTC6810 PWM register
-@return void
-*/
-void LTC6810_wrpwm(uint8_t nIC, //!< number of ICs in the daisy chain
-                   uint8_t pwmReg, //!< Select register
-                   cell_asic *ic //!< A two dimensional array of the parsed gpio voltage codes
-                  );
+/*!
+ Start a Status register redundancy test Conversion
+ @return void 
+ */
+void LTC6810_adstatd(uint8_t MD, //!< ADC Mode
+				     uint8_t CHST //!< Sets which Status channels are converted
+				    );
 
-/*!  Reads pwm registers of a LTC6810 daisy chain
-@return void 
-*/
-int8_t LTC6810_rdpwm(uint8_t nIC, //!< number of ICs in the daisy chain
-                     uint8_t pwmReg, //!< Select register
-                     cell_asic *ic //!< a two dimensional array that the function stores the read pwm data
-                    );
-
-/*!  Write the LTC6810 Sctrl register
-@return void
-*/
-void LTC6810_wrsctrl(uint8_t nIC, //!< number of ICs in the daisy chain
-                     uint8_t sctrl_reg, //!< Select register
-                     cell_asic *ic //!< A two dimensional array of the parsed gpio voltage codes
-                    );
-
-
-/*!  Reads sctrl registers of a LTC6810 daisy chain
-@return int8_t, PEC Status.
-  0: Data read back has matching PEC
-  -1: Data read back has incorrect PEC
-*/
-int8_t LTC6810_rdsctrl(uint8_t nIC, //!< number of ICs in the daisy chain
-                       uint8_t sctrl_reg, //!< Select register
-                       cell_asic *ic //!< a two dimensional array that the function stores the read pwm data
-                      );
-
-
-/*!  Start Sctrl data communication
-This command will start the sctrl pulse communication over the spins
-@return void
-*/
-void LTC6810_stsctrl();
-
-
-/*!  Write the LTC6810 COMM register
-@return void
-*/
-void LTC6810_wrcomm(uint8_t total_ic, //!< Number of ICs in the daisy chain
-                    cell_asic *ic //!< A two dimensional array of the comm data that will be written
-                   );
-
-/*!  Reads comm registers of a LTC6810 daisy chain
-@return int8_t, PEC Status.
-
-  0: Data read back has matching PEC
-
-  -1: Data read back has incorrect PEC
-
-*/
-int8_t LTC6810_rdcomm(uint8_t total_ic, //!< number of ICs in the daisy chain
-                      cell_asic *ic //!< Two dimensional array that the function stores the read comm data.
-                     );
-
-/*!  issues a stcomm command and clocks data out of the COMM register 
-@return void
-*/
-void LTC6810_stcomm();
-
-
-/*! Looks up the result pattern for digital filter self test 
-@returns returns the register data pattern for a given ADC MD and Self test 
-*/
-uint16_t LTC6810_st_lookup(
-  uint8_t MD, //!< ADC Conversion Mode
-  uint8_t ST //!< Self test number
-);
-  
-//! Helper function to set discharge bit in CFG register
-//!@return void    
-void LTC6810_set_discharge(int Cell, //!< The cell to be discharged
-                           uint8_t total_ic, //!< number of ICs in the system
-                           cell_asic *ic //!< a two dimensional array that will store the data
-						   );
-                   
-/*! Helper function that runs the ADC Self Tests*/
-//!@return int16_t, error
-//! Number of errors detected.
+/*! 
+Helper function that runs the ADC Self Tests
+ @return int16_t, error Number of errors detected.
+ */
 int16_t LTC6810_run_cell_adc_st(uint8_t adc_reg, //!<  Type of register
-                                uint8_t total_ic, //!< number of ICs in the daisy chain
+                                uint8_t total_ic, //!< Number of ICs in the daisy chain
                                 cell_asic *ic, //!< A two dimensional array that will store the data 
 								uint8_t md, //!< ADC Mode
 								bool adcopt //!< the adcopt bit in the configuration register
 								);
 
-/*! Helper function that runs the ADC Digital Redundancy commands and checks output for errors*/
-//!@return int16_t, error
+/*!
+ Helper function that runs the ADC Digital Redundancy commands and checks output for errors
+ @return int16_t, error Number of errors detected. 
+ */
 int16_t LTC6810_run_adc_redundancy_st(uint8_t adc_mode, //!< ADC Mode
-                                      uint8_t adc_reg,  //!<  Type of register
-                                      uint8_t total_ic, //!< number of ICs in the daisy chain
+                                      uint8_t adc_reg,  //!< Type of register
+                                      uint8_t total_ic, //!< Number of ICs in the daisy chain
                                       cell_asic *ic //!< A two dimensional array that will store the data 
 									  );
 									  
-/*! Runs open wire for GPIOs*/
-//!@return void
-void LTC6810_run_gpio_openwire(uint8_t total_ic, //!< number of ICs in the daisy chain
-								cell_asic *ic //!< A two dimensional array that will store the data 
-								);
+/*!
+ Start an open wire Conversion
+ @return void 
+ */
+void LTC6810_adow(uint8_t MD, //!<  ADC Conversion Mode
+				  uint8_t PUP, //!<  Pull up/Pull down current
+				  uint8_t CH, //!< Channels
+				  uint8_t DCP//!< Discharge Permit
+				 );
 
-/*! Helper function that runs the data sheet open wire algorithm*/
-//!@return void
-void LTC6810_run_openwire_single(uint8_t total_ic,  //!< number of ICs in the daisy chain
-                          cell_asic *ic //!< A two dimensional array that will store the data 
-						  );
+/*!
+ Start GPIOs open wire ADC conversion
+ @return void 
+ */
+void LTC6810_axow(uint8_t MD, //!< ADC Mode
+				  uint8_t PUP //!< Pull up/Pull down current
+				 );
+				 
+/*!
+ Helper function that runs the data sheet open wire algorithm for single cell detection
+ @return void 
+ */
+void LTC6810_run_openwire_single(uint8_t total_ic,  //!< Number of ICs in the daisy chain
+								  cell_asic *ic //!< A two dimensional array that will store the data 
+								  );
 
-/*! Runs the data sheet algorithm for open wire for multiple cell and two consecutive cells detection*/
-//!@return void
-void LTC6810_run_openwire_multi(uint8_t total_ic, //!< number of ICs in the daisy chain 
+/*!
+ Runs the data sheet algorithm for open wire for multiple cell and two consecutive cells detection
+ @return void 
+ */
+void LTC6810_run_openwire_multi(uint8_t total_ic, //!< Number of ICs in the daisy chain 
 						         cell_asic *ic   //!< A two dimensional array that will store the data 
 						        );
+
+/*!
+ Runs open wire for GPIOs
+ @return void 
+ */
+void LTC6810_run_gpio_openwire(uint8_t total_ic, //!< Number of ICs in the daisy chain
+								cell_asic *ic //!< A two dimensional array that will store the data 
+								);
 								
-/*!Clears all of the DCC bits in the configuration registers*/
-//!@return void
-void LTC6810_clear_discharge(uint8_t total_ic, //!< number of ICs in the daisy chain 
+/*!
+ Helper function to set discharge bit in CFG register
+ @return void 
+ */
+void LTC6810_set_discharge(int Cell, //!< The cell to be discharged
+                           uint8_t total_ic, //!< Number of ICs in the system
+                           cell_asic *ic //!< A two dimensional array that will store the data
+						   );
+                   								
+/*!
+ Clears all of the DCC bits in the configuration registers
+ @return void 
+ */
+void LTC6810_clear_discharge(uint8_t total_ic, //!< Number of ICs in the daisy chain 
                              cell_asic *ic //!< A two dimensional array that will store the data 
 							 );
+
+/*!
+ Writes to the LTC6810 PWM register of LTC6810 
+ @return void 
+ */
+void LTC6810_wrpwm(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                   uint8_t pwmReg, //!< Select register
+                   cell_asic *ic //!< A two dimensional array that will store the data to be written
+                  );
+
+/*!
+ Reads pwm registers of the LTC6810 in daisy chain
+ @return void 
+ */
+int8_t LTC6810_rdpwm(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                     uint8_t pwmReg, //!< Select register
+                     cell_asic *ic //!< A two dimensional array that the function stores the read pwm data
+                    );
+
+/*!
+ Write the LTC6810 COMM register
+ @return void 
+ */
+void LTC6810_wrcomm(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                    cell_asic *ic //!< A two dimensional array of the comm data that will be written
+                   );
+
+/*!
+ Reads comm registers of a LTC6810 in daisy chain
+ @return int8_t, pec_error PEC Status.
+   0: Data read back has matching PEC
+   -1: Data read back has incorrect PEC 
+   */
+int8_t LTC6810_rdcomm(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                      cell_asic *ic //!< Two dimensional array that the function stores the read comm data.
+                     );
+
+/*!
+ Issues a stcomm command and clocks data out of the COMM register 
+ @return void 
+ */
+void LTC6810_stcomm(uint8_t len //!< Length of data to be transmitted 
+					);
+                         			 					 
+/*!
+ Reads Serial ID registers group
+ @return uint8_t, pec_error PEC Status.
+   0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC 
+ */
+uint8_t LTC6810_rdsid(uint8_t total_ic, //!< The number of ICs in the system
+                     cell_asic *ic //!< A two dimensional array that will store the read data 
+                    );
+					
+/*!
+ Mutes the LTC6810 discharge transistors
+  @return void 
+  */
+void LTC6810_mute();
+
+/*!
+ Clears the LTC6810 Mute Discharge
+  @return void 
+  */
+void LTC6810_unmute();
                                  
-/*! Helper Function that counts overall PEC errors and register/IC PEC errors*/
-//!@return void
-void LTC6810_check_pec(uint8_t total_ic, //!< number of ICs in the daisy chain 
+/*!
+ Helper Function that counts overall PEC errors and register/IC PEC errors
+  @return void 
+  */
+void LTC6810_check_pec(uint8_t total_ic, //!< Number of ICs in the daisy chain 
                        uint8_t reg, //!<  Type of register
                        cell_asic *ic //!< A two dimensional array that will store the data 
 					   );
 
-/*! Helper Function that resets the PEC error counters */
-//!@return void
-void LTC6810_reset_crc_count(uint8_t total_ic, //!< number of ICs in the daisy chain 
+/*!
+ Helper Function that resets the PEC error counters 
+  @return void 
+  */
+void LTC6810_reset_crc_count(uint8_t total_ic, //!< Number of ICs in the daisy chain 
                              cell_asic *ic//!< A two dimensional array that will store the data 
 							 );
 
-/*! Helper Function to initialize the CFGR data structures*/
-//!@return void
-void LTC6810_init_cfg(uint8_t total_ic, //!< number of ICs in the daisy chain 
+/*!
+ Helper Function to initialize the CFGR data structures
+  @return void 
+  */
+void LTC6810_init_cfg(uint8_t total_ic, //!< Number of ICs in the daisy chain 
                       cell_asic *ic //!< A two dimensional array that will store the data 
 					  );
 
-/*! Helper function to set appropriate bits in CFGR register based on bit function*/
-//!@return void
+/*!
+ Helper function to set appropriate bits in CFGR register based on bit function
+  @return void
+  */
 void LTC6810_set_cfgr(uint8_t nIC, //!< Current IC
 					  cell_asic *ic, //!< A two dimensional array that will store the data 
-					  bool refon, //!< the REFON bit
-					  bool adcopt, //!< the ADCOPT bit
-					  bool gpio[4], //!< the GPIO bits
-					  bool dcc[6],  //!< the DCC bits 
-					  bool dcc_0,  //!< the DCC bit 
+					  bool refon, //!< The REFON bit
+					  bool adcopt, //!< The ADCOPT bit
+					  bool gpio[4], //!< The GPIO bits
+					  bool dcc[6],  //!< The DCC bits 
+					  bool dcc_0,  //!< The DCC bit 
 					  bool mcal, //!< Enable Multi-Calibration
 					  bool en_dtmen, //!< Enable Discharge timer monitor
 					  bool dis_red, //!< Disable Digital Redundancy Check
 					  bool fdrf, //!< Force digital Redundancy Failure
 					  bool sconv, //!< Enable Cell Measurement Redundancy using S Pin
-					  bool dcto[4], //!<  Discharge Time Out Value
-					  uint16_t uv, //!< the UV value
-					  uint16_t  ov //!< the OV value
+					  bool dcto[4], //!< Discharge Time Out Value
+					  uint16_t uv, //!< The UV value
+					  uint16_t ov //!< The OV value
 					  );
 
-/*! Helper function to turn the refon bit HIGH or LOW*/
-//!@return void
+/*!
+ Helper function to turn the REFON bit HIGH or LOW
+  @return void 
+  */
 void LTC6810_set_cfgr_refon(uint8_t nIC, //!< Current IC
                             cell_asic *ic, //!< A two dimensional array that will store the data 
-                            bool refon //!< the REFON bit
+                            bool refon //!< The REFON bit
 							);
                             
-/*! Helper function to turn the ADCOPT bit HIGH or LOW*/
-//!@return void
+/*!
+ Helper function to turn the ADCOPT bit HIGH or LOW
+ @return void 
+ */
 void LTC6810_set_cfgr_adcopt(uint8_t nIC, //!< Current IC
                              cell_asic *ic, //!< A two dimensional array that will store the data 
-                             bool adcopt //!< the ADCOPT bit
+                             bool adcopt //!< The ADCOPT bit
 							 );
 
-/*! Helper function to turn the GPIO bits HIGH or LOW*/
-//!@return void
+/*!
+ Helper function to turn the GPIO bits HIGH or LOW
+  @return void 
+  */
 void LTC6810_set_cfgr_gpio(uint8_t nIC, //!< Current IC
                            cell_asic *ic, //!< A two dimensional array that will store the data 
-                           bool gpio[] //!< the GPIO bits
+                           bool gpio[] //!< The GPIO bits
 						   );
-						   
-/*! Helper function to turn the DCC bits HIGH or LOW*/
-//!@return void
+/*!
+ Helper function to turn the DCC bits HIGH or LOW
+  @return void 
+  */
 void LTC6810_set_cfgr_dis(uint8_t nIC, //!< Current IC
                           cell_asic *ic, //!< A two dimensional array that will store the data 
-                          bool dcc[] //!< the DCC bits
+                          bool dcc[] //!< The DCC bits
 						  ); 
 						  
-/*!  Helper function to set uv field in CFGRA register*/
-//!@return void
+/*!
+ Helper function to set uv field in CFGRA register
+  @return void 
+  */
 void LTC6810_set_cfgr_uv(uint8_t nIC, //!< Current IC
                          cell_asic *ic, //!< A two dimensional array that will store the data 
-                         uint16_t uv //!< the UV value
+                         uint16_t uv //!< The UV value
 						 );
                          
-/*!  Helper function to set ov field in CFGRA register*/
-//!@return void
+/*!
+ Helper function to set ov field in CFGRA register
+  @return void 
+  */
 void LTC6810_set_cfgr_ov(uint8_t nIC, //!< Current IC
                          cell_asic *ic, //!< A two dimensional array that will store the data 
-                         uint16_t ov //!< the OV value
+                         uint16_t ov //!< The OV value
 						 );
 						 
-/*!  Helper function to set the REFON bit*/
-//!@return void
+/*!
+ Helper function to set the MCAL bit
+  @return void 
+  */
 void LTC6810_set_cfgr_mcal(uint8_t nIC, //!< Current IC
 						   cell_asic *ic, //!< A two dimensional array that will store the data  
 						   bool mcal //!< Enable Multi-Calibration
 						   );
 
-/*!  Helper function to set the REFON bit*/
-//!@return void
+/*!
+ Helper function to set the DCC_0 bit
+  @return void 
+  */
 void LTC6810_set_cfgr_dcc_0(uint8_t nIC, //!< Current IC
 							cell_asic *ic, //!< A two dimensional array that will store the data 
-							bool dcc_0 //!< the DCC bit
+							bool dcc_0 //!< The DCC bit
 							);
 
-/*!  Helper function to set the REFON bit*/
-//!@return void
+/*!
+ Helper function to set the EN_DTMEN bit
+  @return void 
+  */
 void LTC6810_set_cfgr_en_dtmen(uint8_t nIC, //!< Current IC
 								cell_asic *ic, //!< A two dimensional array that will store the data 
 								bool en_dtmen //!< Enable Discharge timer monitor
 								);
 
-/*!  Helper function to set the REFON bit*/
-//!@return void
+/*!
+ Helper function to set the DIS_RED bit
+  @return void 
+  */
 void LTC6810_set_cfgr_dis_red(uint8_t nIC, //!< Current IC
 							  cell_asic *ic, //!< A two dimensional array that will store the data 
 							  bool dis_red //!< Disable Digital Redundancy Check
 							  );
 
-/*!  Helper function to set the REFON bit*/
-//!@return void
+/*!
+ Helper function to set the FDRF bit
+  @return void 
+  */
 void LTC6810_set_cfgr_fdrf(uint8_t nIC, //!< Current IC
 						   cell_asic *ic, //!< A two dimensional array that will store the data 
 						   bool fdrf //!< Force digital Redundancy Failure
 						   );
 
-/*!  Helper function to set the REFON bit*/
-//!@return void
+/*!
+ Helper function to set the SCONV bit
+  @return void 
+  */
 void LTC6810_set_cfgr_sconv(uint8_t nIC, //!< Current IC
 							cell_asic *ic, //!< A two dimensional array that will store the data 
 							bool sconv //!< Enable Cell Measurement Redundancy using S Pin
 							);
 
-/*!  Helper function to set the REFON bit*/
-//!@return void
+/*!
+ Helper function to set the DCTO bit
+  @return void 
+  */
 void LTC6810_set_cfgr_dcto(uint8_t nIC, //!< Current IC
 						   cell_asic *ic, //!< A two dimensional array that will store the data 
 						   bool dcto[] //!<  Discharge Time Out Value
-						   );
-                         
-void LTC6810_init_max_min(uint8_t total_ic, //!< number of ICs in the daisy chain  
-                          cell_asic *ic, //!< A two dimensional array that will store the data 
-                          cell_asic ic_max[],
-                          cell_asic ic_min[]);
-
-void LTC6810_max_min(uint8_t total_ic, 
-			cell_asic ic_cells[],
-             cell_asic ic_min[],
-             cell_asic ic_max[],
-             cell_asic ic_delta[]);
+						   );		 			 
 			 
-/*!  Reads and parses the LTC681x S voltage registers*/
-//!@return uint16_t, pec_error
-uint8_t LTC6810_rds(uint8_t reg, //!< Controls which cell voltage register is read back.
-                     uint8_t total_ic, //!< the number of ICs in the system
-                     cell_asic *ic //!< Array of the parsed cell codes
-                    );
-					
-/*!  Reads the raw S voltage register data*/
-//!@return void
-void LTC6810_rds_reg(uint8_t reg, //!< Determines which cell voltage register is read back
-                      uint8_t total_ic, //!< The number of ICs in the
-                      uint8_t *data //!< An array of the unparsed cell codes
-                     );
-					 
-/*!  Reads Serial ID registers group*/
-//!@return uint16_t, pec_error
-uint8_t LTC6810_rdsid(uint8_t total_ic, //!< the number of ICs in the system
-                     cell_asic *ic //!< Array of the parsed cell codes
-                    );		 			 
-			 
-/*!  Mutes the LTC6813 discharge transistors*/
-//!@return void
-void LTC6810_mute();
-
-/*! Clears the LTC6813 Mute Discharge*/
-//!@return void
-void LTC6810_unmute();
-
 #endif

--- a/LTSketchbook/libraries/LTC6811/LTC6811.cpp
+++ b/LTSketchbook/libraries/LTC6811/LTC6811.cpp
@@ -1,7 +1,7 @@
 /*! LTC6811: Multicell Battery Monitors
 *
 *@verbatim
-*The LTC6811 is multicell battery stack monitor that measures up to 12 series 
+*The LTC6811 is multi-cell battery stack monitor that measures up to 12 series 
 *connected battery cells with a total measurement error of less than 1.2mV. 
 *The cell measurement range of 0V to 5V makes the LTC6811 suitable for most 
 *battery chemistries. All 12 cell voltages can be captured in 290uS, and lower 
@@ -62,8 +62,8 @@
 #include "LTC681x.h"
 #include "LTC6811.h"
 
-//Initialize the Register limits
-void LTC6811_init_reg_limits(uint8_t total_ic, //the number of ICs in the system
+/* Initialize the Register limits */
+void LTC6811_init_reg_limits(uint8_t total_ic, //The number of ICs in the system
 							cell_asic *ic  //A two dimensional array where data will be written
 							)
 {
@@ -76,71 +76,12 @@ void LTC6811_init_reg_limits(uint8_t total_ic, //the number of ICs in the system
     ic[cic].ic_reg.num_gpio_reg=2;
     ic[cic].ic_reg.num_stat_reg=3;
   }
-
-}
-
-//Helper function to initialize CFG variables.
-void LTC6811_init_cfg(uint8_t total_ic, //Number of ICs in the system
-					  cell_asic *ic //a two dimensional array that will store the data
-					  )
-{
-  LTC681x_init_cfg(total_ic,ic);
-}
-
-//Helper function to set CFGR variable
-void LTC6811_set_cfgr(uint8_t nIC, //Current IC
-                      cell_asic *ic,//A two dimensional array that will store the data 
-					  bool refon, // the REFON bit
-					  bool adcopt, // the ADCOPT bit
-					  bool gpio[5],// the GPIO bit
-					  bool dcc[12],// the DCC bit 
-					  bool dcto[4],// the Dcto bit 
-					  uint16_t uv, // the UV bit
-					  uint16_t  ov // the OV bit
-					  )
-{
-  LTC681x_set_cfgr(nIC ,ic,refon,adcopt,gpio,dcc,dcto, uv, ov);
-}
-//Helper function to set the REFON bit
-void LTC6811_set_cfgr_refon(uint8_t nIC, cell_asic *ic, bool refon)
-{
-  LTC681x_set_cfgr_refon(nIC,ic,refon);
-}
-//Helper function to set the adcopt bit
-void LTC6811_set_cfgr_adcopt(uint8_t nIC, cell_asic *ic, bool adcopt)
-{
-  LTC681x_set_cfgr_adcopt(nIC,ic,adcopt);
-}
-//Helper function to set GPIO bits
-void LTC6811_set_cfgr_gpio(uint8_t nIC, cell_asic *ic,bool gpio[5])
-{
-  LTC681x_set_cfgr_gpio(nIC,ic,gpio);
-}
-//Helper function to control discharge
-void LTC6811_set_cfgr_dis(uint8_t nIC, cell_asic *ic,bool dcc[12])
-{
-  LTC681x_set_cfgr_dis(nIC,ic,dcc);
-}
-//Helper function to control discharge
-void LTC6811_set_cfgr_dcto(uint8_t nIC, cell_asic *ic,bool dcto[4])
-{
-  LTC681x_set_cfgr_dcto(nIC, ic,dcto);
-}
-//Helper Function to set uv value in CFG register
-void LTC6811_set_cfgr_uv(uint8_t nIC, cell_asic *ic,uint16_t uv)
-{
-  LTC681x_set_cfgr_uv(nIC, ic, uv);
-}
-//Helper function to set OV value in CFG register
-void LTC6811_set_cfgr_ov(uint8_t nIC, cell_asic *ic,uint16_t ov)
-{
-  LTC681x_set_cfgr_ov( nIC, ic, ov);
 }
 
 /*
- This command will write the configuration registers of the LTC6811-1s
- connected. The configuration is written in descending
- order so the last device's configuration is written first.
+This command will write the configuration registers of the LTC6811-1s
+connected. The configuration is written in descending
+order so the last device's configuration is written first.
 */
 void LTC6811_wrcfg(uint8_t total_ic, //The number of ICs being written to
                    cell_asic *ic //A two dimensional array of the configuration data that will be written
@@ -149,7 +90,7 @@ void LTC6811_wrcfg(uint8_t total_ic, //The number of ICs being written to
   LTC681x_wrcfg(total_ic,ic);
 }
 
-//Reads configuration registers of a LTC6811 
+/* Reads configuration registers of a LTC6811 */
 int8_t LTC6811_rdcfg(uint8_t total_ic, //Number of ICs in the system
                      cell_asic *ic //A two dimensional array that the function stores the read configuration data.
                     )
@@ -159,7 +100,7 @@ int8_t LTC6811_rdcfg(uint8_t total_ic, //Number of ICs in the system
   return(pec_error);
 }
 
-//Starts cell voltage conversion
+/* Starts cell voltage conversion */
 void LTC6811_adcv(uint8_t MD, //ADC Mode
 				  uint8_t DCP, //Discharge Permit
 				  uint8_t CH //Cell Channels to be measured
@@ -168,9 +109,45 @@ void LTC6811_adcv(uint8_t MD, //ADC Mode
   LTC681x_adcv(MD,DCP,CH);
 }
 
-// Reads and parses the LTC6811 cell voltage registers.
+/* Start a GPIO and Vref2 Conversion */
+void LTC6811_adax(uint8_t MD, //ADC Mode
+				  uint8_t CHG //GPIO Channels to be measured
+				  )
+{
+  LTC681x_adax(MD,CHG);
+}
+
+/* Start a Status ADC Conversion */
+void LTC6811_adstat(uint8_t MD, //ADC Mode
+				    uint8_t CHST //Stat Channels to be measured
+				   )
+{
+  LTC681x_adstat(MD,CHST);
+}
+
+/*  Starts cell voltage  and GPIO 1 &  2 conversion */
+void LTC6811_adcvax(uint8_t MD, //ADC Mode
+				    uint8_t DCP //Discharge Permit
+				    )
+{
+  LTC681x_adcvax(MD,DCP);
+}
+
+/* Starts cell voltage and Sum of cells conversion */
+void LTC6811_adcvsc(uint8_t MD, //ADC Mode
+				    uint8_t DCP //Discharge Permit
+				    )
+{
+  LTC681x_adcvsc(MD,DCP);
+}
+
+/*
+The function is used to read the  parsed cell voltage codes of the LTC6811. 
+This function will send the requested read commands parse the data and 
+store the cell voltages in c_codes variable
+*/
 uint8_t LTC6811_rdcv(uint8_t reg, // Controls which cell voltage register is read back.
-                     uint8_t total_ic, // the number of ICs in the system
+                     uint8_t total_ic, // The number of ICs in the system
                      cell_asic *ic // Array of the parsed cell codes
                     )
 {
@@ -179,21 +156,13 @@ uint8_t LTC6811_rdcv(uint8_t reg, // Controls which cell voltage register is rea
   return(pec_error);
 }
 
-//Start a GPIO and Vref2 Conversion
-void LTC6811_adax(uint8_t MD, //ADC Mode
-				  uint8_t CHG //GPIO Channels to be measured)
-				  )
-{
-  LTC681x_adax(MD,CHG);
-}
-
 /*
- The function is used to read the  parsed GPIO codes of the LTC6811. 
- This function will send the requested
- read commands parse the data and store the gpio voltages in aux_codes variable
+The function is used to read the  parsed GPIO codes of the LTC6811. 
+This function will send the requested read commands parse the data 
+and store the gpio voltages in a_codes variable
 */
 int8_t LTC6811_rdaux(uint8_t reg, //Determines which GPIO voltage register is read back.
-                     uint8_t total_ic,//the number of ICs in the system
+                     uint8_t total_ic,//The number of ICs in the system
                      cell_asic *ic//A two dimensional array of the gpio voltage codes.
                      )
 {
@@ -202,23 +171,15 @@ int8_t LTC6811_rdaux(uint8_t reg, //Determines which GPIO voltage register is re
   return (pec_error);
 }
 
-//Start a Status ADC Conversion
-void LTC6811_adstat(uint8_t MD, //ADC Mode
-				    uint8_t CHST //GPIO Channels to be measured
-				   )
-{
-  LTC681x_adstat(MD,CHST);
-}
-
 /*
- Reads and parses the LTC6811 stat registers.
- The function is used to read the  parsed stat codes of the LTC6811. 
- This function will send the requested
- read commands parse the data and store the stat voltages in stat_codes variable
+Reads and parses the LTC6811 stat registers.
+The function is used to read the  parsed stat codes of the LTC6811. 
+This function will send the requested read commands parse the data 
+and store the stat voltages in stat_codes variable
 */
-int8_t LTC6811_rdstat(uint8_t reg, //Determines which Stat  register is read back.
-                      uint8_t total_ic,//the number of ICs in the system
-                      cell_asic *ic // Array of the parsed cell codes
+int8_t LTC6811_rdstat(uint8_t reg, //Determines which Stat register is read back.
+                      uint8_t total_ic,//The number of ICs in the system
+                      cell_asic *ic //Array of the parsed stat codes
                      )
 {
   int8_t pec_error = 0;
@@ -226,29 +187,52 @@ int8_t LTC6811_rdstat(uint8_t reg, //Determines which Stat  register is read bac
   return (pec_error);
 }
 
-// Starts cell voltage  and GPIO 1&2 conversion
-void LTC6811_adcvax(uint8_t MD, //ADC Mode
-				    uint8_t DCP //Discharge Permit
-				    )
+/* Sends the poll ADC command */
+uint8_t LTC6811_pladc()
 {
-  LTC681x_adcvax(MD,DCP);
+  return(LTC681x_pladc());
 }
 
-//Starts cell voltage and SOC conversion
-void LTC6811_adcvsc(uint8_t MD, //ADC Mode
-				    uint8_t DCP //Discharge Permit
-				    )
+//This function will block operation until the ADC has finished it's conversion */
+uint32_t LTC6811_pollAdc()
 {
-  LTC681x_adcvsc(MD,DCP);
+  return(LTC681x_pollAdc());
 }
 
-//Starts the Mux Decoder diagnostic self test
+/*
+The command clears the cell voltage registers and initializes all values to 1. 
+The register will read back hexadecimal 0xFF after the command is sent.
+*/
+void LTC6811_clrcell()
+{
+  LTC681x_clrcell();
+}
+
+/*
+The command clears the Auxiliary registers and initializes all values to 1. 
+The register will read back hexadecimal 0xFF after the command is sent.
+*/
+void LTC6811_clraux()
+{
+  LTC681x_clraux();
+}
+
+/*
+The command clears the Stat registers and initializes all values to 1. 
+The register will read back hexadecimal 0xFF after the command is sent.
+*/
+void LTC6811_clrstat()
+{
+  LTC681x_clrstat();
+}
+
+/* Starts the Mux Decoder diagnostic self test */
 void LTC6811_diagn()
 {
   LTC681x_diagn();
 }
 
-//Starts cell voltage self test conversion
+/* Starts cell voltage self test conversion */
 void LTC6811_cvst(uint8_t MD, //ADC Mode
 				  uint8_t ST //Self Test
 				  )
@@ -256,7 +240,7 @@ void LTC6811_cvst(uint8_t MD, //ADC Mode
   LTC681x_cvst(MD,ST);
 }
 
-//Start an Auxiliary Register Self Test Conversion
+/* Start an Auxiliary Register Self Test Conversion */
 void LTC6811_axst(uint8_t MD, //ADC Mode
 				  uint8_t ST //Self Test
 				  )
@@ -264,7 +248,7 @@ void LTC6811_axst(uint8_t MD, //ADC Mode
   LTC681x_axst(MD,ST);
 }
 
-//Start a Status Register Self Test Conversion
+/* Start a Status Register Self Test Conversion */
 void LTC6811_statst(uint8_t MD, //ADC Mode
 				    uint8_t ST //Self Test
 				    )
@@ -272,20 +256,7 @@ void LTC6811_statst(uint8_t MD, //ADC Mode
   LTC681x_statst(MD,ST);
 }
 
-// Runs the Digital Filter Self Test
-int16_t LTC6811_run_cell_adc_st(uint8_t adc_reg, // Type of register
-								uint8_t total_ic,//Number of ICs in the system 
-								cell_asic *ic, //a two dimensional array that will store the data
-								uint8_t md, //ADC Mode
-								bool adcopt // the adcopt bit in the configuration register
-								)
-{
-  int16_t error = 0;
-  error = LTC681x_run_cell_adc_st(adc_reg,total_ic,ic,md,adcopt);
-  return(error);
-}
-
-//Starts cell voltage overlap conversion
+/* Starts cell voltage overlap conversion */
 void LTC6811_adol(uint8_t MD, //ADC Mode
 				  uint8_t DCP //Discharge Permit
 				  )
@@ -293,9 +264,38 @@ void LTC6811_adol(uint8_t MD, //ADC Mode
   LTC681x_adol(MD,DCP);
 }
 
-// Runs the ADC overlap test for the IC
+/* Start an GPIO Redundancy test */
+void LTC6811_adaxd(uint8_t MD, //ADC Mode
+				   uint8_t CHG //GPIO Channels to be measured
+				   )
+{
+  LTC681x_adaxd(MD,CHG);
+}
+
+/* Start a Status register redundancy test Conversion */
+void LTC6811_adstatd(uint8_t MD, //ADC Mode
+				     uint8_t CHST //Stat Channels to be measured
+				    )
+{
+  LTC681x_adstatd(MD,CHST);
+}
+
+/* Runs the Digital Filter Self Test */
+int16_t LTC6811_run_cell_adc_st(uint8_t adc_reg, // Type of register
+								uint8_t total_ic,//Number of ICs in the system 
+								cell_asic *ic, //A two dimensional array that will store the data
+								uint8_t md, //ADC Mode
+								bool adcopt //The adcopt bit in the configuration register
+								)
+{
+  int16_t error = 0;
+  error = LTC681x_run_cell_adc_st(adc_reg,total_ic,ic,md,adcopt);
+  return(error);
+}
+
+/* Runs the ADC overlap test for the IC */
 uint16_t LTC6811_run_adc_overlap(uint8_t total_ic,//Number of ICs in the system  
-								 cell_asic *ic
+								 cell_asic *ic //A two dimensional array that will store the data
 								 )
 {
   uint16_t error = 0;
@@ -303,7 +303,19 @@ uint16_t LTC6811_run_adc_overlap(uint8_t total_ic,//Number of ICs in the system
   return(error);
 }
 
-// Start an open wire Conversion
+/* Runs the redundancy self test */
+int16_t LTC6811_run_adc_redundancy_st(uint8_t adc_mode, //ADC Mode 
+									  uint8_t adc_reg, // Type of register
+									  uint8_t total_ic,//Number of ICs in the system  
+									  cell_asic *ic //A two dimensional array that will store the data
+									  )
+{
+  int16_t error = 0;
+  LTC681x_run_adc_redundancy_st(adc_mode,adc_reg,total_ic,ic);
+  return(error);
+}
+
+/* Start an open wire Conversion */
 void LTC6811_adow(uint8_t MD, //ADC Mode
 				  uint8_t PUP,//Pull up/ Pull down
 				  uint8_t CH, //Cell selection 
@@ -313,179 +325,26 @@ void LTC6811_adow(uint8_t MD, //ADC Mode
   LTC681x_adow(MD,PUP,CH,DCP);
 }
 
-//Runs the data sheet algorithm for open wire for single cell detection
+/* Runs the data sheet algorithm for open wire for single cell detection */
 void LTC6811_run_openwire_single(uint8_t total_ic,//Number of ICs in the system  
-						         cell_asic *ic   
+						         cell_asic *ic //A two dimensional array that will store the data  
 						        )
 {
   LTC681x_run_openwire_single(total_ic,ic);
 }
 
-//Runs the data sheet algorithm for open wire for multiple cell and two consecutive cells detection
+/* Runs the data sheet algorithm for open wire for multiple cell and two consecutive cells detection */
 void LTC6811_run_openwire_multi(uint8_t total_ic,//Number of ICs in the system  
-						         cell_asic *ic   
+						         cell_asic *ic //A two dimensional array that will store the data  
 						        )
 {
   LTC681x_run_openwire_multi(total_ic,ic);
 }
 
-//Start an GPIO Redundancy test
-void LTC6811_adaxd(uint8_t MD, //ADC Mode
-				   uint8_t CHG //GPIO Channels to be measured)
-				   )
-{
-  LTC681x_adaxd(MD,CHG);
-}
-
-// Start a Status register redundancy test Conversion
-void LTC6811_adstatd(uint8_t MD, //ADC Mode
-				     uint8_t CHST //GPIO Channels to be measured
-				    )
-{
-  LTC681x_adstatd(MD,CHST);
-}
-
-//runs the redundancy self test
-int16_t LTC6811_run_adc_redundancy_st(uint8_t adc_mode, //ADC Mode 
-									  uint8_t adc_reg, // Type of register
-									  uint8_t total_ic,//Number of ICs in the system  
-									  cell_asic *ic   //a two dimensional array that will store the data
-									  )
-{
-  int16_t error = 0;
-  LTC681x_run_adc_redundancy_st(adc_mode,adc_reg,total_ic,ic);
-  return(error);
-}
-
-//Sends the poll adc command
-uint8_t LTC6811_pladc()
-{
-  return(LTC681x_pladc());
-}
-
-//This function will block operation until the ADC has finished it's conversion
-uint32_t LTC6811_pollAdc()
-{
-  return(LTC681x_pollAdc());
-}
-
-/*
- The command clears the cell voltage registers and initializes all values to 1. 
- The register will read back hexadecimal 0xFF after the command is sent.
-*/
-void LTC6811_clrcell()
-{
-  LTC681x_clrcell();
-}
-
-/*
- The command clears the Auxiliary registers and initializes
- all values to 1. The register will read back hexadecimal 0xFF
- after the command is sent.
-*/
-void LTC6811_clraux()
-{
-  LTC681x_clraux();
-}
-
-/*
- The command clears the Stat registers and initializes
- all values to 1. The register will read back hexadecimal 0xFF
- after the command is sent.
-*/
-void LTC6811_clrstat()
-{
-  LTC681x_clrstat();
-}
-
-//Writes the pwm registers of a LTC6811
-void LTC6811_wrpwm(uint8_t total_ic, //Number of ICs in the system
-                   uint8_t pwmReg,  //The number of registers being written to
-                   cell_asic *ic //A two dimensional array that the function stores the data in.
-                  )
-{
-  LTC681x_wrpwm(total_ic,pwmReg,ic);
-}
-
-
-//Reads pwm registers of a LTC6811 
-int8_t LTC6811_rdpwm(uint8_t total_ic, //Number of ICs in the system
-                     uint8_t pwmReg,  //The number of registers being written to
-                     cell_asic *ic //A two dimensional array that the function stores the read pwm data.
-                    )
-{
-  int8_t pec_error =0;
-  pec_error = LTC681x_rdpwm(total_ic,pwmReg,ic);
-  return(pec_error);
-}
-
-//Writes data in S control register the LTC6811-1s connected  
-void LTC6811_wrsctrl(uint8_t total_ic, //Number of ICs in the system
-                     uint8_t sctrl_reg, //The number of registers being written to
-                     cell_asic *ic //A two dimensional array of the data that will be written
-                    )
-{
-	LTC681x_wrsctrl(total_ic, sctrl_reg, ic);
-  }
-  
-//Reads sctrl registers of a LTC6811  
-int8_t LTC6811_rdsctrl(uint8_t total_ic, //number of ICs in the system
-                       uint8_t sctrl_reg,//The number of registers being written to
-                       cell_asic *ic //a two dimensional array that the function stores the read pwm data
-                      )
-{
-	int8_t pec_error =0;
-    pec_error =  LTC681x_rdsctrl(total_ic, sctrl_reg,ic );
-    return(pec_error);
-	
-  }
-
-/* Start Sctrl data communication              
-This command will start the sctrl pulse communication over the spins
-*/
-void LTC6811_stsctrl()
-{
-LTC681x_stsctrl();
-  }
-  
-/*
- The command clears the Sctrl registers and initializes
- all values to 0. The register will read back hexadecimal 0x00
- after the command is sent.
- */
-void LTC6811_clrsctrl()
-{
-  LTC681x_clrsctrl();
-}
-
-//Writes the COMM registers of a LTC6811 
-void LTC6811_wrcomm(uint8_t total_ic, //The number of ICs being written to
-                    cell_asic *ic //A two dimensional array of the comm data that will be written
-                   )
-{
-  LTC681x_wrcomm(total_ic,ic);
-}
-
-//Reads COMM registers of a LTC6811 
-int8_t LTC6811_rdcomm(uint8_t total_ic, //Number of ICs in the system
-                      cell_asic *ic //A two dimensional array that the function stores the read comm data.
-                     )
-{
-  int8_t pec_error = 0;
-  LTC681x_rdcomm(total_ic, ic);
-  return(pec_error);
-}
-
-//Shifts data in COMM register out over LTC6811 SPI/I2C port
-void LTC6811_stcomm()
-{
-  LTC681x_stcomm();
-}
-
-//Helper function to set discharge bit in CFG register
+/* Helper function to set discharge bit in CFG register */
 void LTC6811_set_discharge(int Cell, //The cell to be discharged
-						   uint8_t total_ic, //number of ICs in the system
-						   cell_asic *ic //a two dimensional array that will store the data
+						   uint8_t total_ic, //Number of ICs in the system
+						   cell_asic *ic //A two dimensional array that will store the data
 						   )
 {
   for (int i=0; i<total_ic; i++)
@@ -505,27 +364,174 @@ void LTC6811_set_discharge(int Cell, //The cell to be discharged
   }
 }
 
-//Clears all of the DCC bits in the configuration registers
+/* Clears all of the DCC bits in the configuration registers */
 void LTC6811_clear_discharge(uint8_t total_ic, cell_asic *ic)
 {
-	LTC681x_clear_discharge(total_ic,ic);
+  LTC681x_clear_discharge(total_ic,ic);
 }
 
-//Helper function that increments PEC counters
+/* Writes the pwm registers of a LTC6811 */
+void LTC6811_wrpwm(uint8_t total_ic, //Number of ICs in the system
+                   uint8_t pwmReg,  //The number of registers being written to
+                   cell_asic *ic //A two dimensional array that the function stores the data in.
+                  )
+{
+  LTC681x_wrpwm(total_ic,pwmReg,ic);
+}
+
+
+/* Reads pwm registers of a LTC6811 */
+int8_t LTC6811_rdpwm(uint8_t total_ic, //Number of ICs in the system
+                     uint8_t pwmReg,  //The number of registers being written to
+                     cell_asic *ic //A two dimensional array that the function stores the read pwm data.
+                    )
+{
+  int8_t pec_error =0;
+  pec_error = LTC681x_rdpwm(total_ic,pwmReg,ic);
+  return(pec_error);
+}
+
+/* Writes data in S control register the LTC6811-1s connected */  
+void LTC6811_wrsctrl(uint8_t total_ic, //Number of ICs in the system
+                     uint8_t sctrl_reg, //The number of registers being written to
+                     cell_asic *ic //A two dimensional array of the data that will be written
+                    )
+{
+  LTC681x_wrsctrl(total_ic, sctrl_reg, ic);
+}
+  
+/* Reads sctrl registers of a LTC6811 */  
+int8_t LTC6811_rdsctrl(uint8_t total_ic, //Number of ICs in the system
+                       uint8_t sctrl_reg,//The number of registers being written to
+                       cell_asic *ic //A two dimensional array that the function stores the read data
+                      )
+{
+  int8_t pec_error =0;
+  pec_error =  LTC681x_rdsctrl(total_ic, sctrl_reg,ic );
+  return(pec_error);	
+}
+
+/* 
+Start Sctrl data communication              
+This command will start the sctrl pulse communication over the spins
+*/
+void LTC6811_stsctrl()
+{
+  LTC681x_stsctrl();
+}
+  
+/*
+The command clears the Sctrl registers and initializes
+all values to 0. The register will read back hexadecimal 0x00
+after the command is sent.
+ */
+void LTC6811_clrsctrl()
+{
+  LTC681x_clrsctrl();
+}
+
+/* Writes the COMM registers of a LTC6811 */ 
+void LTC6811_wrcomm(uint8_t total_ic, //The number of ICs being written to
+                    cell_asic *ic //A two dimensional array of the comm data that will be written
+                   )
+{
+  LTC681x_wrcomm(total_ic,ic);
+}
+
+/* Reads COMM registers of a LTC6811 */
+int8_t LTC6811_rdcomm(uint8_t total_ic, //Number of ICs in the system
+                      cell_asic *ic //A two dimensional array that the function stores the read comm data.
+                     )
+{
+  int8_t pec_error = 0;
+  LTC681x_rdcomm(total_ic, ic);
+  return(pec_error);
+}
+
+/* Shifts data in COMM register out over LTC6811 SPI/I2C port */
+void LTC6811_stcomm(uint8_t len)
+{
+  LTC681x_stcomm(len); // length of data to be transmitted 
+}
+
+/* Helper function that increments PEC counters */
 void LTC6811_check_pec(uint8_t total_ic,//Number of ICs in the system  
 					   uint8_t reg, // Type of register
-					   cell_asic *ic//a two dimensional array that will store the data
+					   cell_asic *ic//A two dimensional array that will store the data
 					   )
 {
   LTC681x_check_pec(total_ic,reg,ic);
 }
 
-//Helper Function to reset PEC counters
+/* Helper Function to reset PEC counters */
 void LTC6811_reset_crc_count(uint8_t total_ic, //Number of ICs in the system
-							 cell_asic *ic //a two dimensional array that will store the data
+							 cell_asic *ic //A two dimensional array that will store the data
 							 )
 {
   LTC681x_reset_crc_count(total_ic,ic);
 }
 
+/* Helper function to initialize CFG variables.*/
+void LTC6811_init_cfg(uint8_t total_ic, //Number of ICs in the system
+					  cell_asic *ic //A two dimensional array that will store the data
+					  )
+{
+  LTC681x_init_cfg(total_ic,ic);
+}
 
+/* Helper function to set CFGR variable */
+void LTC6811_set_cfgr(uint8_t nIC, //current IC
+                      cell_asic *ic,//a two dimensional array that will store the data 
+					  bool refon, // The REFON bit
+					  bool adcopt, // The ADCOPT bit
+					  bool gpio[5],// The GPIO bit
+					  bool dcc[12],// The DCC bit 
+					  bool dcto[4],// The Dcto bit 
+					  uint16_t uv, // The UV bit
+					  uint16_t  ov // The OV bit
+					  )
+{
+  LTC681x_set_cfgr(nIC ,ic,refon,adcopt,gpio,dcc,dcto, uv, ov);
+}
+
+/* Helper function to set the REFON bit */
+void LTC6811_set_cfgr_refon(uint8_t nIC, cell_asic *ic, bool refon)
+{
+  LTC681x_set_cfgr_refon(nIC,ic,refon);
+}
+
+/* Helper function to set the adcopt bit */
+void LTC6811_set_cfgr_adcopt(uint8_t nIC, cell_asic *ic, bool adcopt)
+{
+  LTC681x_set_cfgr_adcopt(nIC,ic,adcopt);
+}
+
+/* Helper function to set GPIO bits */
+void LTC6811_set_cfgr_gpio(uint8_t nIC, cell_asic *ic,bool gpio[5])
+{
+  LTC681x_set_cfgr_gpio(nIC,ic,gpio);
+}
+
+/* Helper function to control discharge */
+void LTC6811_set_cfgr_dis(uint8_t nIC, cell_asic *ic,bool dcc[12])
+{
+  LTC681x_set_cfgr_dis(nIC,ic,dcc);
+}
+
+/* Helper function to control discharge */
+void LTC6811_set_cfgr_dcto(uint8_t nIC, cell_asic *ic,bool dcto[4])
+{
+  LTC681x_set_cfgr_dcto(nIC, ic,dcto);
+}
+
+/* Helper Function to set uv value in CFG register */
+void LTC6811_set_cfgr_uv(uint8_t nIC, cell_asic *ic,uint16_t uv)
+{
+  LTC681x_set_cfgr_uv(nIC, ic, uv);
+}
+
+/* Helper function to set OV value in CFG register */
+void LTC6811_set_cfgr_ov(uint8_t nIC, cell_asic *ic,uint16_t ov)
+{
+  LTC681x_set_cfgr_ov( nIC, ic, ov);
+}

--- a/LTSketchbook/libraries/LTC6811/LTC6811.h
+++ b/LTSketchbook/libraries/LTC6811/LTC6811.h
@@ -1,7 +1,7 @@
 /*! LTC6811: Multicell Battery Monitors
 *
 *@verbatim
-*The LTC6811 is multicell battery stack monitor that measures up to 12 series 
+*The LTC6811 is multi-cell battery stack monitor that measures up to 12 series 
 *connected battery cells with a total measurement error of less than 1.2mV. 
 *The cell measurement range of 0V to 5V makes the LTC6811 suitable for most 
 *battery chemistries. All 12 cell voltages can be captured in 290uS, and lower 
@@ -63,343 +63,437 @@
 #define AUX 2
 #define STAT 3
 
-//! Initialize the Register limits
-//!@return void
+/*!
+ Initialize the Register limits
+ @return void 
+ */
 void LTC6811_init_reg_limits(uint8_t total_ic, //!< Number of ICs in the system
 							 cell_asic *ic //!< A two dimensional array that will store the data
 							 );
 
-//! Helper Function to initialize the CFGR data structures
-//!@return void						 
-void LTC6811_init_cfg(uint8_t total_ic, //!< Number of ICs in the system
-                      cell_asic *ic //!< A two dimensional array that will store the data
-					  );
-
-//! Helper function to set appropriate bits in CFGR register based on bit function
-//!@return void
-void LTC6811_set_cfgr(uint8_t nIC, //!< Current IC
-                      cell_asic *ic,//!< A two dimensional array that will store the data 
-					  bool refon, //!< the REFON bit
-					  bool adcopt, //!< the ADCOPT bit
-					  bool gpio[5],//!< the GPIO bits
-					  bool dcc[12],//!< the DCC bits 
-					  bool dcto[4],//!< the Dcto bits 
-					  uint16_t uv, //!< the UV value
-					  uint16_t  ov //!< the OV value
-					  );
-					  
-				  
-//! Helper function to turn the refon bit HIGH or LOW
-//!@return void
-void LTC6811_set_cfgr_refon(uint8_t nIC, //!< Current IC
-                            cell_asic *ic, //!< a two dimensional array that will store the data
-                            bool refon); //!< the REFON bit
-							
-							
-//! Helper function to turn the ADCOPT bit HIGH or LOW
-//!@return void
-void LTC6811_set_cfgr_adcopt(uint8_t nIC,  //!< Current IC
-                             cell_asic *ic, //!< a two dimensional array that will store the data 
-                             bool adcopt); //!< the ADCOPT bit
- 							 
-//! Helper function to turn the GPIO bits HIGH or LOW
-//!@return void
-void LTC6811_set_cfgr_gpio(uint8_t nIC, //!< Current IC
-                           cell_asic *ic, //!< a two dimensional array that will store the data 
-                           bool gpio[]); //!< the GPIO bits
-
-//! Helper function to turn the DCC bits HIGH or LOW
-//!@return void
-void LTC6811_set_cfgr_dis(uint8_t nIC, //!< Current IC
-                          cell_asic *ic, //!< a two dimensional array that will store the data 
-                          bool dcc[]); //!< the DCC bits
-						  
-//! Helper function to set uv field in CFGRA register
-//!@return void
-void LTC6811_set_cfgr_uv(uint8_t nIC, //!< Current IC
-                         cell_asic *ic, //!< a two dimensional array that will store the data 
-                         uint16_t uv);  //!< the UV value
-
-//! Helper function to set ov field in CFGRA register
-//!@return void
-void LTC6811_set_cfgr_ov(uint8_t nIC, //!< Current IC
-                         cell_asic *ic, //!< a two dimensional array that will store the data 
-                         uint16_t ov); //!< the OV value
-
-//! Write the LTC6811 configuration register
-//!@return void
-void LTC6811_wrcfg(uint8_t nIC, //!< The number of ICs being written
-                   cell_asic *ic //!<  a two dimensional array of the configuration data that will be written
+/*!
+ Write the LTC6811 configuration register
+ @return void 
+ */
+void LTC6811_wrcfg(uint8_t total_ic, //!< The number of ICs being written
+                   cell_asic *ic //!< A two dimensional array of the configuration data that will be written
                   );
 
-//! Reads configuration registers of a LTC6811 
-//!@return int8_t, PEC Status.
-//! 0: Data read back has matching PEC
-//!-1: Data read back has incorrect PEC
-int8_t LTC6811_rdcfg(uint8_t nIC, //!<  number of ICs 
-                     cell_asic *ic //!<  a two dimensional array that the function stores the read configuration data
+/*!
+ Reads configuration registers of a LTC6811 
+ @return int8_t, PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC 
+ */
+int8_t LTC6811_rdcfg(uint8_t total_ic, //!< Number of ICs 
+                     cell_asic *ic //!< A two dimensional array that the function stores the read configuration data
                     );
 
-//! Starts cell voltage conversion
-//!@return void
+/*!
+ Starts cell voltage conversion
+ @return void
+ */
 void LTC6811_adcv(uint8_t MD, //!< ADC Conversion Mode
-                  uint8_t DCP, //!<  Controls if Discharge is permitted during conversion
-                  uint8_t CH //!<  Sets which Cell channels are converted
+                  uint8_t DCP, //!< Controls if Discharge is permitted during conversion
+                  uint8_t CH //!< Sets which Cell channels are converted
                  );	
 
-//! Reads and parses the LTC6811 cell voltage registers.
-//!@return int8_t, PEC Status.
-//! 0: No PEC error detected
-//!-1: PEC error detected, retry read
-uint8_t LTC6811_rdcv(uint8_t reg, //!<  controls which cell voltage register is read back.
-                     uint8_t total_ic, //!<  the number of ICs in the daisy chain(-1 only)
-                     cell_asic *ic //!<  array of the parsed cell codes from lowest to highest.
-                    );	
-
-//! Start a GPIO and Vref2 Conversion
-//!@return void
+/*!
+ Start a GPIO and Vref2 Conversion
+ @return void
+ */
 void LTC6811_adax(uint8_t MD, //!< ADC Conversion Mode
 				  uint8_t CHG //!< Sets which GPIO channels are converted
 				  );
 
-//! Reads and parses the LTC6811 auxiliary registers.
-//!@return  int8_t, PEC Status
-//!  0: No PEC error detected
-//! -1: PEC error detected, retry read
-int8_t LTC6811_rdaux(uint8_t reg, //!< controls which GPIO voltage register is read back
-                     uint8_t nIC,  //!<  the number of ICs in the daisy chain
-                     cell_asic *ic //!<  A two dimensional array of the parsed gpio voltage codes
-                    );
-
-//! Start a Status ADC Conversion
-//!@return void
-void LTC6811_adstat(uint8_t MD, //!<  ADC Conversion Mode
-				    uint8_t CHST //!<  Sets which Stat channels are converted
+/*!
+ Start a Status ADC Conversion
+ @return void 
+ */
+void LTC6811_adstat(uint8_t MD, //!< ADC Conversion Mode
+				    uint8_t CHST //!< Sets which Stat channels are converted
 				    );
 					
-//! Reads and parses the LTC6811 stat registers.
-//!@return  int8_t, PEC Status
-//! 0: No PEC error detected
-//!-1: PEC error detected, retry read
-int8_t LTC6811_rdstat(uint8_t reg, //!< Determines which Stat  register is read back.
-                      uint8_t total_ic,//!< the number of ICs in the system
-                      cell_asic *ic//!<  Array of the parsed cell codes
-                     );
-
-
-//! Starts cell voltage  and GPIO 1&2 conversion
-//!@return void
-void LTC6811_adcvax(uint8_t MD, //!<  ADC Conversion Mode
-				    uint8_t DCP //!<  Controls if Discharge is permitted during conversion
+/*!
+ Starts cell voltage  and GPIO 1&2 conversion
+ @return void 
+ */
+void LTC6811_adcvax(uint8_t MD, //!< ADC Conversion Mode
+				    uint8_t DCP //!< Controls if Discharge is permitted during conversion
 				   );
 
-//! Starts cell voltage and SOC conversion
-//!@return void
-void LTC6811_adcvsc(uint8_t MD, //!<  ADC Conversion Mode
-				    uint8_t DCP //!<  Controls if Discharge is permitted during conversion
-				   );				   
+/*!
+ Starts cell voltage and SOC conversion
+ @return void 
+ */
+void LTC6811_adcvsc(uint8_t MD, //!< ADC Conversion Mode
+				    uint8_t DCP //!< Controls if Discharge is permitted during conversion
+				   );						
+
+/*!
+ Reads and parses the LTC6811 cell voltage registers.
+ @return uint8_t, PEC Status.
+  0: No PEC error detected
+ -1: PEC error detected, retry read 
+ */
+uint8_t LTC6811_rdcv(uint8_t reg, //!< Controls which cell voltage register is read back.
+                     uint8_t total_ic, //!< The number of ICs in the daisy chain
+                     cell_asic *ic //!< Array of the parsed cell codes from lowest to highest.
+                    );				  
+				  
+/*!
+ Reads and parses the LTC6811 auxiliary registers.
+ @return  int8_t, PEC Status
+   0: No PEC error detected
+  -1: PEC error detected, retry read 
+  */
+int8_t LTC6811_rdaux(uint8_t reg, //!< Controls which GPIO voltage register is read back
+                     uint8_t nIC,  //!< The number of ICs in the daisy chain
+                     cell_asic *ic //!< A two dimensional array of the parsed gpio voltage codes
+                    );
 					
-//! Starts the Mux Decoder diagnostic self test
-//! Running this command will start the Mux Decoder Diagnostic Self Test.
-//! This test takes roughly 1ms to complete. The MUXFAIL bit will be updated.
-//! The bit will be set to 1 for a failure and 0 if the test has been passed.
-//!@return void
+/*!
+ Reads and parses the LTC6811 stat registers.
+ @return  int8_t, PEC Status
+  0: No PEC error detected
+ -1: PEC error detected, retry read 
+ */
+int8_t LTC6811_rdstat(uint8_t reg, //!< Determines which Stat register is read back.
+                      uint8_t total_ic,//!< The number of ICs in the system
+                      cell_asic *ic//!< Array of the parsed Stat codes
+                     );
+
+/*!
+ Sends the poll ADC command
+ @returns uint8_t, 1 byte read back after a pladc command. If the byte is not 0xFF ADC conversion has completed  
+*/
+uint8_t LTC6811_pladc();
+
+/*!
+ This function will block operation until the ADC has finished it's conversion
+  @returns uint32_t, the approximate time it took for the ADC function to complete. 
+  */
+uint32_t LTC6811_pollAdc();						 
+	
+/*!
+ Clears the LTC6811 cell voltage registers
+ @return void 
+ */
+void LTC6811_clrcell();
+
+/*!
+ Clears the LTC6811 Auxiliary registers
+ @return void 
+ */
+void LTC6811_clraux();
+
+/*!
+ Clears the LTC6811 Stat registers
+ @return void 
+ */
+void LTC6811_clrstat();
+								
+/*!
+ Starts the Mux Decoder diagnostic self test
+  Running this command will start the Mux Decoder Diagnostic Self Test.
+  This test takes roughly 1ms to complete. The MUXFAIL bit will be updated.
+  The bit will be set to 1 for a failure and 0 if the test has been passed.
+ @return void 
+ */
 void LTC6811_diagn();
 
-//! Starts cell voltage self test conversion
-//!@return void
-void LTC6811_cvst( uint8_t MD, //!<  ADC Conversion Mode
-				  uint8_t ST //!<  Self Test Mode
+/*!
+ Starts cell voltage self test conversion
+ @return void 
+ */
+void LTC6811_cvst( uint8_t MD, //!< ADC Conversion Mode
+				  uint8_t ST //!< Sets if self test 1 or 2 is run
 				 );
 
-//! Start an Auxiliary Register Self Test Conversion
-//!@return void
-void LTC6811_axst(uint8_t MD, //!<  ADC Conversion Mode
-				  uint8_t ST //!<  Sets if self test 1 or 2 is run
+/*!
+ Start an Auxiliary Register Self Test Conversion
+  @return void 
+ */
+void LTC6811_axst(uint8_t MD, //!< ADC Conversion Mode
+				  uint8_t ST //!< Sets if self test 1 or 2 is run
 				 );				 
 
-//! Start a Status Register Self Test Conversion
-//!@return void
+/*!
+ Start a Status Register Self Test Conversion
+ @return void 
+ */
 void LTC6811_statst(uint8_t MD, //!< ADC Conversion Mode
 				    uint8_t ST //!<  Sets if self test 1 or 2 is run
 				   );
 
-//!  Helper function that runs the ADC Self Tests
-//!@return int16_t, error
-//! Number of errors detected.
-int16_t LTC6811_run_cell_adc_st(uint8_t adc_reg, //!<  Type of register
-                                uint8_t total_ic, //!< Number of ICs in the system 
-                                cell_asic *ic, //!< a two dimensional array that will store the 
-								uint8_t md, //!< ADC Mode
-								bool adcopt //!<  the adcopt bit in the configuration register
-								);
 								
-//! Starts cell voltage overlap conversion
-//!@return void
-void LTC6811_adol( uint8_t MD, //!<  ADC Conversion Mode
-				  uint8_t DCP //!<  Discharge permitted during conversion
-				  );								
+/*!
+ Starts cell voltage overlap conversion
+ @return void 
+ */
+void LTC6811_adol( uint8_t MD, //!< ADC Conversion Mode
+				  uint8_t DCP //!< Discharge permitted during conversion
+				  );
 
-//! Helper Function that runs the ADC Overlap test
-//!@return uint16_t, error
-//! 0: Pass
-//!-1: False, Error detected
+/*!
+ Start an GPIO Redundancy test
+ @return void 
+ */
+void LTC6811_adaxd(uint8_t MD, //!< ADC Conversion Mode
+				   uint8_t CHG //!< Sets which GPIO channels are converted
+				  );
+
+/*!
+ Start a Status register redundancy test Conversion
+ @return void 
+ */
+void LTC6811_adstatd(uint8_t MD, //!< ADC Conversion Mode
+				     uint8_t CHST //!< Sets which Status channels are converted
+				    );				  
+
+/*!
+  Helper function that runs the ADC Self Tests
+  @return int16_t, error
+  Number of errors detected 
+  */
+int16_t LTC6811_run_cell_adc_st(uint8_t adc_reg, //!< Type of register
+                                uint8_t total_ic, //!< Number of ICs in the system 
+                                cell_asic *ic, //!< A two dimensional array that will store the data
+								uint8_t md, //!< ADC Mode
+								bool adcopt //!< The adcopt bit in the configuration register
+								);				  
+				  
+/*!
+ Helper Function that runs the ADC Overlap test
+  @return uint16_t, error
+  0: Pass
+ -1: False, Error detected 
+ */
 uint16_t LTC6811_run_adc_overlap(uint8_t total_ic,//!< Number of ICs in the system  
-                                 cell_asic *ic //!< a two dimensional array that will store the 
+                                 cell_asic *ic //!< A two dimensional array that will store the data
 								 );
+								 
+/*!
+ Helper function that runs the ADC Digital Redundancy commands and checks output for errors
+ @return int16_t, error 
+ */
+int16_t LTC6811_run_adc_redundancy_st(uint8_t adc_mode, //!< ADC Mode
+                                      uint8_t adc_reg,  //!< Type of register
+                                      uint8_t total_ic, //!< Number of ICs in the system
+                                      cell_asic *ic    //!< A two dimensional array that will store the data
+									  );								 
 
-//! Start an open wire Conversion
-//!@return void
+/*!
+ Start an open wire Conversion
+ @return void  
+ */
 void LTC6811_adow(uint8_t MD, //!< ADC Mode
 				  uint8_t PUP, //!< Discharge Permit
 				  uint8_t CH, //!< Cell selection
 				  uint8_t DCP //!< Discharge Permit  
 				 );
 
-//! Helper function that runs the data sheet open wire algorithm for single cell detection
-//!@return void
+/*!
+ Helper function that runs the data sheet open wire algorithm for single cell detection
+ @return void  
+ */
 void LTC6811_run_openwire_single(uint8_t total_ic,//!< Number of ICs in the system  
-						         cell_asic *ic  //!< a two dimensional array that will store the  
+						         cell_asic *ic  //!< A two dimensional array that will store the  data
 						        );
 								
-//! Helper function that runs open wire for multiple cell and two consecutive cells detection
-//!@return void
+/*!
+ Helper function that runs open wire for multiple cell and two consecutive cells detection
+ @return void  
+ */
 void LTC6811_run_openwire_multi(uint8_t total_ic,//!< Number of ICs in the system  
-						        cell_asic *ic  //!< a two dimensional array that will store the  
+						        cell_asic *ic  //!< A two dimensional array that will store the  data
 						        );
 
-//! Start an GPIO Redundancy test
-//!@return void
-void LTC6811_adaxd(uint8_t MD, //!<  ADC Conversion Mode
-				   uint8_t CHG //!< Sets which GPIO channels are converted
-				  );
+/*!
+ Helper function to set discharge bit in CFG register
+ @return void  */
+void LTC6811_set_discharge(int Cell, //!< The cell to be discharged
+                           uint8_t total_ic, //!< Number of ICs in the system
+                           cell_asic *ic //!< A two dimensional array that will store the data
+						   );
 
-//! Start a Status register redundancy test Conversion
-//!@return void
-void LTC6811_adstatd(uint8_t MD, //!<  ADC Mode
-				     uint8_t CHST //!<  Sets which Status channels are converted
-				    );
-
-//! Helper function that runs the ADC Digital Redundancy commands and checks output for errors
-//!@return int16_t, error
-int16_t LTC6811_run_adc_redundancy_st(uint8_t adc_mode, //!< ADC Mode
-                                      uint8_t adc_reg,  //!<  Type of register
-                                      uint8_t total_ic, //!< Number of ICs in the system
-                                      cell_asic *ic    //!< a two dimensional array that will store the data
-									  );				  
-						 
-//! Sends the poll ADC command
-//!@returns uint8_t, 1 byte read back after a pladc command. If the byte is not 0xFF ADC conversion has completed 
-uint8_t LTC6811_pladc();
-
-
-//! This function will block operation until the ADC has finished it's conversion
-//! @returns uint32_t, the approximate time it took for the ADC function to complete. 
-uint32_t LTC6811_pollAdc();						 
-	
-//! Clears the LTC6811 cell voltage registers
-//!@return void
-void LTC6811_clrcell();
-
-//! Clears the LTC6811 Auxiliary registers
-//!@return void
-void LTC6811_clraux();
-
-//! Clears the LTC6811 Stat registers
-//!@return void
-void LTC6811_clrstat();
-
-//! Write the LTC6811 PWM register
-//!@return void
-void LTC6811_wrpwm(uint8_t nIC, //!<  number of ICs 
+/*!
+ Clears all of the DCC bits in the configuration registers
+ @return void	
+ */					 
+void LTC6811_clear_discharge(uint8_t total_ic, //!< Number of ICs in the daisy chain
+							 cell_asic *ic //!< A two dimensional array that will store the data
+					        );								
+								
+/*!
+ Write the LTC6811 PWM register
+ @return void  
+ */
+void LTC6811_wrpwm(uint8_t total_ic, //!< Number of ICs 
                    uint8_t pwmReg, //!< Select register
                    cell_asic *ic//!< A two dimensional array that the function stores the data in.
                   );
 
-//! Reads pwm registers of a LTC6811 daisy chain
-//!   @return int8_t, PEC Status.
-//!  0: Data read back has matching PEC
-//! -1: Data read back has incorrect PEC
-int8_t LTC6811_rdpwm(uint8_t nIC, //!<  number of ICs 
+/*!
+ Reads pwm registers of a LTC6811 daisy chain
+ @return int8_t, PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC 
+ */
+int8_t LTC6811_rdpwm(uint8_t total_ic, //!< Number of ICs 
                      uint8_t pwmReg, //!< Select register
-                     cell_asic *ic //!< a two dimensional array that the function stores the read pwm data
+                     cell_asic *ic //!< A two dimensional array that the function stores the read pwm data
                     );
 
-//! Write the LTC6811 Sctrl register
-//!@return void
-void LTC6811_wrsctrl(uint8_t nIC, //!<  number of ICs in the daisy chain
+/*!
+ Write the LTC6811 Sctrl register
+ @return void 
+ */
+void LTC6811_wrsctrl(uint8_t total_ic, //!< Number of ICs in the daisy chain
                      uint8_t sctrl_reg, //!< Select register
                      cell_asic *ic //!< A two dimensional array of the data that will be written
                     );
 
-
-//! Reads sctrl registers of a LTC6811 daisy chain
-//!   @return int8_t, PEC Status.
-//!  0: Data read back has matching PEC
-//! -1: Data read back has incorrect PEC
-int8_t LTC6811_rdsctrl(uint8_t nIC, //!< number of ICs in the daisy chain
+/*!
+ Reads sctrl registers of a LTC6811 daisy chain
+  @return int8_t, PEC Status.
+   0: Data read back has matching PEC
+  -1: Data read back has incorrect PEC 
+  */
+int8_t LTC6811_rdsctrl(uint8_t total_ic, //!< Number of ICs in the daisy chain
                        uint8_t sctrl_reg, //!< Select register
-                       cell_asic *ic //!<  a two dimensional array that the function stores the read pwm data
+                       cell_asic *ic //!< A two dimensional array that the function stores the read data
                       );
 					  
-//! Start Sctrl data communication
-//! This command will start the sctrl pulse communication over the spins
-//!@return void
+/*!
+ Start Sctrl data communication
+  This command will start the sctrl pulse communication over the spins
+ @return void 
+ */
 void LTC6811_stsctrl();
 					  
-//! Clears the LTC6811 Sctrl registers
-//!@return void
+/*!
+ Clears the LTC6811 Sctrl registers
+ @return void 
+ */
 void LTC6811_clrsctrl();
 
-//! Write the LTC6811 COMM register
+/*!
+ Writes to the LTC6811 COMM register 
+ @return void 
+ */
 void LTC6811_wrcomm(uint8_t total_ic, //!<  Number of ICs in the daisy chain
                     cell_asic *ic //!<  A two dimensional array of the comm data that will be written
                    );
 
-//! Reads comm registers of a LTC6811 daisy chain
-//! @return int8_t, PEC Status.
-//! 0: Data read back has matching PEC
-//!-1: Data read back has incorrect PEC
-int8_t LTC6811_rdcomm(uint8_t total_ic, //!<  number of ICs in the daisy chain
-                      cell_asic *ic //!<  Two dimensional array that the function stores the read comm data.
+/*!
+ Reads comm registers of a LTC6811 daisy chain
+  @return int8_t, PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC 
+ */
+int8_t LTC6811_rdcomm(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                      cell_asic *ic //!< Two dimensional array that the function stores the read comm data.
                      );
 
-//! Issues a stcomm command and clocks data out of the COMM register 
-//!@return void
-void LTC6811_stcomm();
-
-//! Helper function to set discharge bit in CFG register
-//!@return void
-void LTC6811_set_discharge(int Cell, //!< The cell to be discharged
-                           uint8_t total_ic, //!< number of ICs in the system
-                           cell_asic *ic //!< a two dimensional array that will store the data
-						   );
-
-//! Clears all of the DCC bits in the configuration registers
-//!@return void						 
-void LTC6811_clear_discharge(uint8_t total_ic, //!<  Number of ICs in the daisy chain
-							 cell_asic *ic //!< a two dimensional array that will store the data
-					        );
-
-//! Looks up the result pattern for digital filter self test							
-//! @returns returns the register data pattern for a given ADC MD and Self test
-uint16_t LTC6811_st_lookup(uint8_t MD, //!<  ADC Conversion Mode
-						  uint8_t ST //!<  Self test number
-						  );
+/*!
+ Issues a stcomm command and clocks data out of the COMM register 
+ @return void 
+ */
+void LTC6811_stcomm(uint8_t len //!< Length of data to be transmitted 
+					);
 						  
-//!  Helper Function that counts overall PEC errors and register/IC PEC errors
-//!@return void	
+/*!
+ Helper Function that counts overall PEC errors and register/IC PEC errors
+ @return void	
+ */
 void LTC6811_check_pec(uint8_t total_ic,//!< Number of ICs in the system  
-                       uint8_t reg, //!<  Type of register
-                       cell_asic *ic //!< a two dimensional array that will store the data
+                       uint8_t reg, //!< Type of register
+                       cell_asic *ic //!< A two dimensional array that will store the data
 					   );
 
-//!  Helper Function that resets the PEC error counters
-//!@return void	
+/*!
+ Helper Function that resets the PEC error counters
+ @return void 
+ */
 void LTC6811_reset_crc_count(uint8_t total_ic, //!< Number of ICs in the system
-                             cell_asic *ic //!< a two dimensional array that will store the data
+                             cell_asic *ic //!< A two dimensional array that will store the data
 							 );
 
+/*!
+ Helper Function to initialize the CFGR data structures
+ @return void 
+ */						 
+void LTC6811_init_cfg(uint8_t total_ic, //!< Number of ICs in the system
+                      cell_asic *ic //!< A two dimensional array that will store the data
+					  );
 
-
+/*!
+ Helper function to set appropriate bits in CFGR register based on bit function
+ @return void 
+ */
+void LTC6811_set_cfgr(uint8_t nIC, //!< Current IC
+                      cell_asic *ic,//!< A two dimensional array that will store the data 
+					  bool refon, //!< The REFON bit
+					  bool adcopt, //!< The ADCOPT bit
+					  bool gpio[5],//!< The GPIO bits
+					  bool dcc[12],//!< The DCC bits 
+					  bool dcto[4],//!< The Dcto bits 
+					  uint16_t uv, //!< The UV value
+					  uint16_t  ov //!< The OV value
+					  );
+					  			  
+/*!
+ Helper function to turn the refon bit HIGH or LOW
+ @return void 
+ */
+void LTC6811_set_cfgr_refon(uint8_t nIC, //!< Current IC
+                            cell_asic *ic, //!< A two dimensional array that will store the data
+                            bool refon //!< The REFON bit
+							);
+							
+/*!
+ Helper function to turn the ADCOPT bit HIGH or LOW
+ @return void 
+ */
+void LTC6811_set_cfgr_adcopt(uint8_t nIC,  //!< Current IC
+                             cell_asic *ic, //!< A two dimensional array that will store the data 
+                             bool adcopt //!< The ADCOPT bit
+ 							 );
+							 
+/*!
+ Helper function to turn the GPIO bits HIGH or LOW
+ @return void
+ */
+void LTC6811_set_cfgr_gpio(uint8_t nIC, //!< Current IC
+                           cell_asic *ic, //!< A two dimensional array that will store the data 
+                           bool gpio[] //!< The GPIO bits
+						  );
+						  
+/*!
+ Helper function to turn the DCC bits HIGH or LOW
+ @return void
+ */
+void LTC6811_set_cfgr_dis(uint8_t nIC, //!< Current IC
+                          cell_asic *ic, //!< A two dimensional array that will store the data 
+                          bool dcc[] //!< The DCC bits
+						  );
+						  
+/*!
+ Helper function to set uv field in CFGRA register
+ @return void 
+ */
+void LTC6811_set_cfgr_uv(uint8_t nIC, //!< Current IC
+                         cell_asic *ic, //!< A two dimensional array that will store the data 
+                         uint16_t uv  //!< The UV value
+						);
+/*!
+ Helper function to set ov field in CFGRA register
+ @return void 
+ */
+void LTC6811_set_cfgr_ov(uint8_t nIC, //!< Current IC
+                         cell_asic *ic, //!< A two dimensional array that will store the data 
+                         uint16_t ov //!< The OV value
+						);
+						 
 #endif					 

--- a/LTSketchbook/libraries/LTC6812/LTC6812.cpp
+++ b/LTSketchbook/libraries/LTC6812/LTC6812.cpp
@@ -1,7 +1,7 @@
 /*! LTC6812: Multicell Battery Monitors
 *
 *@verbatim
-*The LTC6812 is multicell battery stack monitor that measures up to 15 series 
+*The LTC6812 is multi-cell battery stack monitor that measures up to 15 series 
 *connected battery cells with a total measurement error of less than 2.2mV. 
 *The cell measurement range of 0V to 5V makes the LTC6812 suitable for most 
 *battery chemistries. All 15 cell voltages can be captured in 245uS, and lower 
@@ -64,8 +64,10 @@
 #include "LTC681x.h"
 #include "LTC6812.h"
 
-//Helper function to initialize register limits.
-void LTC6812_init_reg_limits(uint8_t total_ic, cell_asic *ic)
+/* Helper function to initialize register limits. */
+void LTC6812_init_reg_limits(uint8_t total_ic, //Number of ICs in the system
+							cell_asic *ic //A two dimensional array that the function stores data
+							)
 {
     for(uint8_t cic=0; cic<total_ic; cic++)
     {
@@ -78,218 +80,6 @@ void LTC6812_init_reg_limits(uint8_t total_ic, cell_asic *ic)
     } 
 }
 
-//Starts cell voltage conversion
-void LTC6812_adcv(
-  uint8_t MD, //ADC Mode
-  uint8_t DCP, //Discharge Permit
-  uint8_t CH //Cell Channels to be measured
-)
-{
-    LTC681x_adcv(MD,DCP,CH);
-}
-
-//Starts cell voltage and SOC conversion
-void LTC6812_adcvsc(
-  uint8_t MD, //ADC Mode
-  uint8_t DCP //Discharge Permit
-)
-{
-    LTC681x_adcvsc(MD,DCP);
-}
-
-// Starts cell voltage  and GPIO 1&2 conversion
-void LTC6812_adcvax(
-  uint8_t MD, //ADC Mode
-  uint8_t DCP //Discharge Permit
-)
-{
-    LTC681x_adcvax(MD,DCP);
-}
-
-//Starts cell voltage overlap conversion
-void LTC6812_adol(
-  uint8_t MD, //ADC Mode
-  uint8_t DCP //Discharge Permit
-)
-{
-  LTC681x_adol(MD,DCP);
-}
-
-//Starts cell voltage self test conversion
-void LTC6812_cvst(
-  uint8_t MD, //ADC Mode
-  uint8_t ST //Self Test
-)
-{
-    LTC681x_cvst(MD,ST);
-}
-
-//Start an Auxiliary Register Self Test Conversion
-void LTC6812_axst(
-  uint8_t MD, //ADC Mode
-  uint8_t ST //Self Test
-)
-{
-  LTC681x_axst(MD,ST);
-}
-
-//Start a Status Register Self Test Conversion
-void LTC6812_statst(
-  uint8_t MD, //ADC Mode
-  uint8_t ST //Self Test
-)
-{
-    LTC681x_statst(MD,ST);
-}
-
-//Sends the poll ADC command
-uint8_t LTC6812_pladc()
-{
-  return(LTC681x_pladc());
-}
-
-//This function will block operation until the ADC has finished it's conversion
-uint32_t LTC6812_pollAdc()
-{
-  return(LTC681x_pollAdc());
-}
-
-//Start a GPIO and Vref2 Conversion
-void LTC6812_adax(
-  uint8_t MD, //ADC Mode
-  uint8_t CHG //GPIO Channels to be measured)
-)
-{
-  LTC681x_adax(MD,CHG);
-}
-
-//Start an GPIO Redundancy test
-void LTC6812_adaxd(
-  uint8_t MD, //ADC Mode
-  uint8_t CHG //GPIO Channels to be measured)
-)
-{
-  LTC681x_adaxd(MD,CHG);
-}
-
-//Start a Status ADC Conversion
-void LTC6812_adstat(
-  uint8_t MD, //ADC Mode
-  uint8_t CHST //GPIO Channels to be measured
-)
-{
-  LTC681x_adstat(MD,CHST);
-}
-
-// Start a Status register redundancy test Conversion
-void LTC6812_adstatd(
-  uint8_t MD, //ADC Mode
-  uint8_t CHST //GPIO Channels to be measured
-)
-{
- LTC681x_adstatd(MD,CHST);
-}
-
-// Start an open wire Conversion
-void LTC6812_adow(uint8_t MD, // ADC Conversion Mode
-				 uint8_t PUP, // Controls if Discharge is permitted during conversion
-				 uint8_t CH,  // Sets which Cell channels are converted
-				 uint8_t DCP  // Discharge permitted during conversion
-				 )
-{
-    LTC681x_adow(MD,PUP,CH,DCP);
-}
-
-// Reads and parses the LTC6812 cell voltage registers.
-uint8_t LTC6812_rdcv(uint8_t reg, // Controls which cell voltage register is read back.
-                     uint8_t total_ic, // the number of ICs in the system
-                     cell_asic *ic // Array of the parsed cell codes
-                    )
-{
- 
-  int8_t pec_error = 0;
-  pec_error = LTC681x_rdcv(reg,total_ic,ic);
-  return(pec_error);
-}
-
-/*
-The function is used
-to read the  parsed GPIO codes of the LTC6812. This function will send the requested
-read commands parse the data and store the gpio voltages in aux_codes variable
-*/
-int8_t LTC6812_rdaux(uint8_t reg, //Determines which GPIO voltage register is read back.
-                       uint8_t total_ic,//the number of ICs in the system
-                       cell_asic *ic//A two dimensional array of the gpio voltage codes.
-                      )
-  {
-    int8_t pec_error = 0;
-    LTC681x_rdaux(reg,total_ic,ic);
-    return (pec_error);
-  }
-
-/*
-Reads and parses the LTC6812 stat registers.
-The function is used
-to read the  parsed stat codes of the LTC6812. This function will send the requested
-read commands parse the data and store the stat voltages in stat_codes variable
-*/
-int8_t LTC6812_rdstat(uint8_t reg, //Determines which Stat  register is read back.
-                        uint8_t total_ic,//the number of ICs in the system
-                        cell_asic *ic
-                       )
-  {
-    int8_t pec_error = 0;
-    pec_error = LTC681x_rdstat(reg,total_ic,ic);
-    return (pec_error);
-  }
-
-/*
-The command clears the cell voltage registers and initializes
-all values to 1. The register will read back hexadecimal 0xFF
-after the command is sent.
-*/
-void LTC6812_clrcell()
-  {
-    LTC681x_clrcell();
-  }
-
-/*
-The command clears the Auxiliary registers and initializes
-all values to 1. The register will read back hexadecimal 0xFF
-after the command is sent.
-*/
-void LTC6812_clraux()
-  {
-    LTC681x_clraux();
-  }
-
-/*
-The command clears the Stat registers and initializes
-all values to 1. The register will read back hexadecimal 0xFF
-after the command is sent.
-
-*/
-void LTC6812_clrstat()
-  {
-   LTC681x_clrstat();
-  }
-
-/*
-The command clears the Sctrl registers and initializes
-all values to 0. The register will read back hexadecimal 0x00
-after the command is sent.
-*/
-void LTC6812_clrsctrl()
-  {
-     LTC681x_clrsctrl();
-  }
-
-//Starts the Mux Decoder diagnostic self test
-void LTC6812_diagn()
-  {
-     LTC681x_diagn();
-  }
-
 /*
 This command will write the configuration registers of the LTC6812-1s
 connected in a daisy chain stack. The configuration is written in descending
@@ -298,9 +88,9 @@ order so the last device's configuration is written first.
 void LTC6812_wrcfg(uint8_t total_ic, //The number of ICs being written to
                      cell_asic *ic //A two dimensional array of the configuration data that will be written
                     )
-  {
-    LTC681x_wrcfg(total_ic,ic);
-  }
+{
+	LTC681x_wrcfg(total_ic,ic);
+}
 
 /*
 This command will write the configuration b registers of the LTC6812-1s
@@ -314,17 +104,17 @@ void LTC6812_wrcfgb(uint8_t total_ic, //The number of ICs being written to
     LTC681x_wrcfgb(total_ic,ic);
 }
 
-// Reads configuration registers of a LTC6812 daisy chain
+/* Reads configuration registers of a LTC6812 daisy chain */
 int8_t LTC6812_rdcfg(uint8_t total_ic, //Number of ICs in the system
                        cell_asic *ic //A two dimensional array that the function stores the read configuration data.
                       )
-  {
-    int8_t pec_error = 0;
-    pec_error = LTC681x_rdcfg(total_ic,ic);
-    return(pec_error);
-  }
+{
+	int8_t pec_error = 0;
+	pec_error = LTC681x_rdcfg(total_ic,ic);
+	return(pec_error);
+}
 
-// Reads configuration b registers of a LTC6812 daisy chain
+/* Reads configuration registers B of a LTC6812 daisy chain */
 int8_t LTC6812_rdcfgb(uint8_t total_ic, //Number of ICs in the system
                    cell_asic *ic //A two dimensional array that the function stores the read configuration data.
                   )
@@ -334,124 +124,205 @@ int8_t LTC6812_rdcfgb(uint8_t total_ic, //Number of ICs in the system
     return(pec_error);
 }
 
- // Writes the pwm registers of a LTC6812 daisy chain
-void LTC6812_wrpwm(uint8_t total_ic,
-                     uint8_t pwmReg,  //The number of ICs being written to
-                     cell_asic *ic //A two dimensional array of the configuration data that will be written
+/* Starts cell voltage conversion */
+void LTC6812_adcv(uint8_t MD, //ADC Mode
+				  uint8_t DCP, //Discharge Permit
+				  uint8_t CH //Cell Channels to be measured
+				)
+{
+    LTC681x_adcv(MD,DCP,CH);
+}
+
+/* Start a GPIO and Vref2 Conversion */
+void LTC6812_adax(uint8_t MD, //ADC Mode
+				  uint8_t CHG //GPIO Channels to be measured)
+				)
+{
+	LTC681x_adax(MD,CHG);
+}
+
+/* Start a Status ADC Conversion */
+void LTC6812_adstat(uint8_t MD, //ADC Mode
+				    uint8_t CHST //Stat Channels to be measured
+				  )
+{
+	LTC681x_adstat(MD,CHST);
+}
+
+/* Starts cell voltage and SOC conversion */
+void LTC6812_adcvsc(uint8_t MD, //ADC Mode
+					uint8_t DCP //Discharge Permit
+					)
+{
+    LTC681x_adcvsc(MD,DCP);
+}
+
+/* Starts cell voltage  and GPIO 1 & 2 conversion */
+void LTC6812_adcvax(uint8_t MD, //ADC Mode
+					uint8_t DCP //Discharge Permit
+					)
+{
+    LTC681x_adcvax(MD,DCP);
+}
+
+/*
+Reads and parses the LTC6812 cell voltage registers of the LTC6812. This function will send the requested
+read commands parse the data and store the cell voltages in c_codes variable.
+*/
+uint8_t LTC6812_rdcv(uint8_t reg, // Controls which cell voltage register is read back.
+                     uint8_t total_ic, // the number of ICs in the system
+                     cell_asic *ic // Array of the parsed cell codes
                     )
-  {
-      LTC681x_wrpwm(total_ic,pwmReg,ic);
-  }
+{
+	int8_t pec_error = 0;
+	pec_error = LTC681x_rdcv(reg,total_ic,ic);
+	return(pec_error);
+}
 
-// Reads pwm registers of a LTC6812 daisy chain
-int8_t LTC6812_rdpwm(uint8_t total_ic, //Number of ICs in the system
-                       uint8_t pwmReg,
-                       cell_asic *ic //A two dimensional array that the function stores the read configuration data.
+/*
+The function is used to read the  parsed GPIO codes of the LTC6812. This function will send the requested
+read commands parse the data and store the gpio voltages in a_codes variable
+*/
+int8_t LTC6812_rdaux(uint8_t reg, //Determines which GPIO voltage register is read back.
+                       uint8_t total_ic,//The number of ICs in the system
+                       cell_asic *ic//A two dimensional array of the gpio voltage codes.
                       )
-  {
-    int8_t pec_error =0;
-    pec_error = LTC681x_rdpwm(total_ic,pwmReg,ic);
-    return(pec_error);
-  }
+{
+	int8_t pec_error = 0;
+	LTC681x_rdaux(reg,total_ic,ic);
+	return (pec_error);
+}
 
-// Writes the COMM registers of a LTC6812 daisy chain
-void LTC6812_wrcomm(uint8_t total_ic, //The number of ICs being written to
-                      cell_asic *ic //A two dimensional array of the comm data that will be written
-                     )
-  {
-      LTC681x_wrcomm(total_ic,ic);
-  }
-
-// Reads COMM registers of a LTC6812 daisy chain
-int8_t LTC6812_rdcomm(uint8_t total_ic, //Number of ICs in the system
-                        cell_asic *ic //A two dimensional array that the function stores the read configuration data.
+/*
+Reads and parses the LTC6812 stat registers.
+The function is used to read the  parsed stat codes of the LTC6812. 
+This function will send the requested read commands parse the data 
+and store the stat voltages in stat_codes variable
+*/
+int8_t LTC6812_rdstat(uint8_t reg, //Determines which Stat  register is read back.
+                        uint8_t total_ic,//The number of ICs in the system
+                        cell_asic *ic //A two dimensional array of the stat codes.
                        )
-  {
-    int8_t pec_error = 0;
-    LTC681x_rdcomm(total_ic, ic);
-    return(pec_error);
-  }
-
-//Shifts data in COMM register out over LTC6812 SPI/I2C port
-void LTC6812_stcomm()
 {
-    LTC681x_stcomm();
+	int8_t pec_error = 0;
+	pec_error = LTC681x_rdstat(reg,total_ic,ic);
+	return (pec_error);
 }
 
-//Helper function to set discharge bit in CFG register
-void LTC6812_set_discharge(int Cell, uint8_t total_ic, cell_asic *ic)
+/* Sends the poll ADC command */
+uint8_t LTC6812_pladc()
 {
-  for (int i=0; i<total_ic; i++)
-  {
-	if (Cell==0)
-	{
-		ic[i].configb.tx_data[1] = ic[i].configb.tx_data[1] |(0x04);
-	}
-    else if (Cell<9)
-    {
-      ic[i].config.tx_data[4] = ic[i].config.tx_data[4] | (1<<(Cell-1));
-    }
-    else if (Cell < 13)
-    {
-      ic[i].config.tx_data[5] = ic[i].config.tx_data[5] | (1<<(Cell-9));
-    }
-    else if (Cell<16)
-    {
-      ic[i].configb.tx_data[0] = ic[i].configb.tx_data[0] | (1<<(Cell-9));
-    }
-    else
-	{
-		break;
-	}
-  }
+	return(LTC681x_pladc());
 }
 
-//Clears all of the DCC bits in the configuration registers
-void LTC6812_clear_discharge(uint8_t total_ic,
-                             cell_asic *ic)
+/* This function will block operation until the ADC has finished it's conversion */
+uint32_t LTC6812_pollAdc()
 {
-    LTC681x_clear_discharge(total_ic,ic);
-
+	return(LTC681x_pollAdc());
 }
 
-// Runs the Digital Filter Self Test
-int16_t LTC6812_run_cell_adc_st(uint8_t adc_reg,uint8_t total_ic, cell_asic *ic,uint8_t md,bool adcopt)
+/*
+The command clears the cell voltage registers and initializes
+all values to 1. The register will read back hexadecimal 0xFF
+after the command is sent.
+*/
+void LTC6812_clrcell()
 {
-  int16_t error = 0;
-  error = LTC681x_run_cell_adc_st(adc_reg,total_ic,ic,md,adcopt);
-  return(error);
+	LTC681x_clrcell();
 }
 
-//Runs the redundancy self test
-int16_t LTC6812_run_adc_redundancy_st(uint8_t adc_mode, uint8_t adc_reg, uint8_t total_ic, cell_asic *ic)
+/*
+The command clears the Auxiliary registers and initializes
+all values to 1. The register will read back hexadecimal 0xFF
+after the command is sent.
+*/
+void LTC6812_clraux()
 {
-  int16_t error = 0;
-  LTC681x_run_adc_redundancy_st(adc_mode,adc_reg,total_ic,ic);
-  return(error);
+	LTC681x_clraux();
 }
 
-//Runs open wire for GPIOs
-void LTC6812_run_gpio_openwire(uint8_t total_ic, 
-								cell_asic *ic
+/*
+The command clears the Stat registers and initializes
+all values to 1. The register will read back hexadecimal 0xFF
+after the command is sent.
+
+*/
+void LTC6812_clrstat()
+{
+	LTC681x_clrstat();
+}
+  
+/* Starts the Mux Decoder diagnostic self test */
+void LTC6812_diagn()
+{
+	LTC681x_diagn();
+}  
+
+/* Starts cell voltage self test conversion */
+void LTC6812_cvst(uint8_t MD, //ADC Mode
+				  uint8_t ST //Self Test
+				)
+{
+    LTC681x_cvst(MD,ST);
+}
+
+/* Start an Auxiliary Register Self Test Conversion */
+void LTC6812_axst(uint8_t MD, //ADC Mode
+				  uint8_t ST //Self Test
+				)
+{
+	LTC681x_axst(MD,ST);
+}
+
+/* Start a Status Register Self Test Conversion */
+void LTC6812_statst(uint8_t MD, //ADC Mode
+					uint8_t ST //Self Test
+					)
+{
+    LTC681x_statst(MD,ST);
+}
+
+/* Starts cell voltage overlap conversion */
+void LTC6812_adol(uint8_t MD, //ADC Mode
+				  uint8_t DCP //Discharge Permit
+				)
+{
+	LTC681x_adol(MD,DCP);
+}
+
+/* Start an GPIO Redundancy test */
+void LTC6812_adaxd(uint8_t MD, //ADC Mode
+				   uint8_t CHG //GPIO Channels to be measured
+				 )
+{
+	LTC681x_adaxd(MD,CHG);
+}
+
+/* Start a Status register redundancy test Conversion */
+void LTC6812_adstatd(uint8_t MD, //ADC Mode
+					 uint8_t CHST //Stat Channels to be measured
+					)
+{
+	LTC681x_adstatd(MD,CHST);
+}
+
+/* Runs the Digital Filter Self Test */
+int16_t LTC6812_run_cell_adc_st(uint8_t adc_reg, // Type of register
+								uint8_t total_ic, // Number of ICs in the daisy chain
+								cell_asic *ic, // A two dimensional array that will store the data 
+								uint8_t md, //ADC Mode
+								bool adcopt // The ADCOPT bit in the configuration register
 								)
 {
-	LTC681x_run_gpio_openwire(total_ic, ic);
+	int16_t error = 0;
+	error = LTC681x_run_cell_adc_st(adc_reg,total_ic,ic,md,adcopt);
+	return(error);
 }
 
-//Runs the data sheet algorithm for open wire for single cell detection
-void LTC6812_run_openwire_single(uint8_t total_ic, cell_asic *ic)
-{
-	LTC681x_run_openwire_single(total_ic, ic);
-}
-
-//Runs the data sheet algorithm for open wire for multiple cell and two consecutive cells detection
-void LTC6812_run_openwire_multi(uint8_t total_ic, cell_asic *ic)
-{
-	LTC681x_run_openwire_multi(total_ic, ic);
-}
-
-// Runs the ADC overlap test for the IC
-uint16_t LTC6812_run_adc_overlap(uint8_t total_ic, cell_asic *ic)
+/* Runs the ADC overlap test for the IC */
+uint16_t LTC6812_run_adc_overlap(uint8_t total_ic, // Number of ICs in the daisy chain
+							     cell_asic *ic // A two dimensional array that will store the data 
+								 )
 {
     uint16_t error = 0;
 	int32_t measure_delta =0;
@@ -482,215 +353,178 @@ uint16_t LTC6812_run_adc_overlap(uint8_t total_ic, cell_asic *ic)
 	return(error);
 }
 
-//Helper function that increments PEC counters
-void LTC6812_check_pec(uint8_t total_ic,uint8_t reg, cell_asic *ic)
+/* Runs the redundancy self test */
+int16_t LTC6812_run_adc_redundancy_st(uint8_t adc_mode, //ADC Mode
+									  uint8_t adc_reg, // Type of register
+									  uint8_t total_ic, // Number of ICs in the daisy chain
+									  cell_asic *ic // A two dimensional array that will store the data 
+									  )
 {
-    LTC681x_check_pec(total_ic,reg,ic);
+	int16_t error = 0;
+	LTC681x_run_adc_redundancy_st(adc_mode,adc_reg,total_ic,ic);
+	return(error);
 }
 
-//Helper Function to reset PEC counters
-void LTC6812_reset_crc_count(uint8_t total_ic, cell_asic *ic)
+/* Start an open wire Conversion */
+void LTC6812_adow(uint8_t MD, // ADC Conversion Mode
+				 uint8_t PUP, //Pull up/Pull down current
+				 uint8_t CH,  // Sets which Cell channels are converted
+				 uint8_t DCP  // Discharge permitted during conversion
+				 )
 {
-     LTC681x_reset_crc_count(total_ic,ic);
+    LTC681x_adow(MD,PUP,CH,DCP);
 }
 
-//Helper function to initialize CFG variables.
-void LTC6812_init_cfg(uint8_t total_ic, cell_asic *ic)
-{
-   LTC681x_init_cfg(total_ic,ic);
-}
-//Helper function to set CFGR variable
-void LTC6812_set_cfgr(uint8_t nIC, cell_asic *ic, bool refon, bool adcopt, bool gpio[5],bool dcc[12],bool dcto[4], uint16_t uv, uint16_t  ov)
-{
-    LTC681x_set_cfgr_refon(nIC,ic,refon);
-    LTC681x_set_cfgr_adcopt(nIC,ic,adcopt);
-    LTC681x_set_cfgr_gpio(nIC,ic,gpio);
-    LTC681x_set_cfgr_dis(nIC,ic,dcc);
-	LTC681x_set_cfgr_dcto(nIC,ic,dcto);
-	LTC681x_set_cfgr_uv(nIC, ic, uv);
-    LTC681x_set_cfgr_ov(nIC, ic, ov);
-}
-//Helper function to set the REFON bit
-void LTC6812_set_cfgr_refon(uint8_t nIC, cell_asic *ic, bool refon) 
-{
-  LTC681x_set_cfgr_refon(nIC,ic,refon);
-}
-//Helper function to set the adcopt bit
-void LTC6812_set_cfgr_adcopt(uint8_t nIC, cell_asic *ic, bool adcopt)
-{
-  LTC681x_set_cfgr_adcopt(nIC,ic,adcopt);
-}
-//Helper function to set GPIO bits
-void LTC6812_set_cfgr_gpio(uint8_t nIC, cell_asic *ic,bool gpio[5])
-{  
-  LTC681x_set_cfgr_gpio(nIC,ic,gpio);
-}
-//Helper function to control discharge
-void LTC6812_set_cfgr_dis(uint8_t nIC, cell_asic *ic,bool dcc[12])
-{  
-  LTC681x_set_cfgr_dis(nIC,ic,dcc);
-}
-//Helper Function to set dcto value in CFG register
-void LTC6812_set_cfgr_dcto(uint8_t nIC, cell_asic *ic,bool dcto[4])
-{
-    LTC681x_set_cfgr_dcto(nIC, ic, dcto);
-}
-//Helper Function to set uv value in CFG register
-void LTC6812_set_cfgr_uv(uint8_t nIC, cell_asic *ic,uint16_t uv)
-{
-    LTC681x_set_cfgr_uv(nIC, ic, uv);
-}
-//Helper function to set OV value in CFG register
-void LTC6812_set_cfgr_ov(uint8_t nIC, cell_asic *ic,uint16_t ov)
-{
-    LTC681x_set_cfgr_ov( nIC, ic, ov);
-}
-
-//Start GPIOs open wire adc conversion
-void LTC6812_axow(
-  uint8_t MD, //ADC Mode
-  uint8_t PUP //Discharge Permit
-)
+/* Start GPIOs open wire ADC conversion */
+void LTC6812_axow( uint8_t MD, //ADC Mode
+				  uint8_t PUP //Pull up/Pull down current
+				)
 {
 	LTC681x_axow(MD, PUP);
 }
 
-// Helper Function to initialize the CFGRB data structures
-void LTC6812_init_cfgb(
-  uint8_t total_ic, 
-  cell_asic *ic
- )
+/* Runs the data sheet algorithm for open wire for single cell detection */
+void LTC6812_run_openwire_single(uint8_t total_ic, cell_asic *ic)
 {
-	 for (uint8_t current_ic = 0; current_ic<total_ic;current_ic++)
-    {
-        for(int j =0; j<6;j++)
-        {
-            ic[current_ic].configb.tx_data[j] = 0;
-        }
-    }
+	LTC681x_run_openwire_single(total_ic, ic);
 }
 
-// Helper Function to set the configuration register B 
-void LTC6812_set_cfgrb(uint8_t nIC, cell_asic *ic,bool fdrf,bool dtmen,bool ps[2],bool gpiobits[4],bool dccbits[4])
+/* Runs the data sheet algorithm for open wire for multiple cell and two consecutive cells detection */
+void LTC6812_run_openwire_multi(uint8_t total_ic, cell_asic *ic)
 {
-	LTC6812_set_cfgrb_fdrf(nIC,ic,fdrf);
-    LTC6812_set_cfgrb_dtmen(nIC,ic,dtmen);
-    LTC6812_set_cfgrb_ps(nIC,ic,ps);
-    LTC6812_set_cfgrb_gpio_b(nIC,ic,gpiobits);
-	LTC6812_set_cfgrb_dcc_b(nIC,ic,dccbits);
-	
+	LTC681x_run_openwire_multi(total_ic, ic);
 }
 
-//Helper function to set the FDRF bit
-void LTC6812_set_cfgrb_fdrf(uint8_t nIC, cell_asic *ic, bool fdrf) 
+/* Runs open wire for GPIOs */
+void LTC6812_run_gpio_openwire(uint8_t total_ic, 
+								cell_asic *ic
+								)
 {
-  if(fdrf) ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|0x40;
-  else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&0xBF;
+	LTC681x_run_gpio_openwire(total_ic, ic);
 }
 
-//Helper function to set the DTMEN bit
-void LTC6812_set_cfgrb_dtmen(uint8_t nIC, cell_asic *ic, bool dtmen) 
+/* Helper function to set discharge bit in CFG register */
+void LTC6812_set_discharge(int Cell, uint8_t total_ic, cell_asic *ic)
 {
-  if(dtmen) ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|0x08;
-  else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&0xF7;
-}
-	
-//Helper function to set the PATH SELECT bit
-void LTC6812_set_cfgrb_ps(uint8_t nIC, cell_asic *ic, bool ps[]) 
-{
-  for(int i =0;i<2;i++)
-  {
-      if(ps[i])ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|(0x01<<(i+4));
-      else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&(~(0x01<<(i+4)));
-  }
-}
-
-// Helper function to set the gpio bits in config b register
-void LTC6812_set_cfgrb_gpio_b(uint8_t nIC, cell_asic *ic, bool gpiobits[]) 
-{
-	for(int i =0;i<4;i++)
-  {
-      if(gpiobits[i])ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]|(0x01<<i);
-      else ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]&(~(0x01<<i));
-  }
-}
-
-// Helper function to set the dcc bits in config b register
-void LTC6812_set_cfgrb_dcc_b(uint8_t nIC, cell_asic *ic, bool dccbits[]) 
-{
-	
-	for(int i =0;i<4;i++)
-  { 
-		if(i==0)
+	for (int i=0; i<total_ic; i++)
+	{
+		if (Cell==0)
 		{
-			if(dccbits[i])ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|0x04;
-			else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&0xFB;
+			ic[i].configb.tx_data[1] = ic[i].configb.tx_data[1] |(0x04);
+		}
+		else if (Cell<9)
+		{
+		  ic[i].config.tx_data[4] = ic[i].config.tx_data[4] | (1<<(Cell-1));
+		}
+		else if (Cell < 13)
+		{
+		  ic[i].config.tx_data[5] = ic[i].config.tx_data[5] | (1<<(Cell-9));
+		}
+		else if (Cell<16)
+		{
+		  ic[i].configb.tx_data[0] = ic[i].configb.tx_data[0] | (1<<(Cell-9));
 		}
 		else
-		{	
-			if(dccbits[i])ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]|(0x01<<(i+3));
-			else ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]&(~(0x01<<(i+3)));
+		{
+			break;
 		}
-		
-  }
+	}
 }
 
-//Writes data in S control register the LTC6812-1s connected in a daisy chain stack. 
-void LTC6812_wrsctrl(uint8_t total_ic, //number of ICs in the daisy chain
-                     uint8_t sctrl_reg,
-                     cell_asic *ic
+/* Clears all of the DCC bits in the configuration registers */
+void LTC6812_clear_discharge(uint8_t total_ic, //Number of ICs in the system
+                             cell_asic *ic //A two dimensional array of the data
+							 )
+{
+    LTC681x_clear_discharge(total_ic,ic);
+
+}
+
+/* Writes the pwm registers of a LTC6812 daisy chain */
+void LTC6812_wrpwm(uint8_t total_ic, //The number of ICs being written to
+                     uint8_t pwmReg, // Register Select 
+                     cell_asic *ic //A two dimensional array of the data that will be written
+                    )
+{
+	LTC681x_wrpwm(total_ic,pwmReg,ic);
+}
+
+/* Reads pwm registers of a LTC6812 daisy chain */
+int8_t LTC6812_rdpwm(uint8_t total_ic, //Number of ICs in the system
+                       uint8_t pwmReg, //Register Select 
+                       cell_asic *ic //A two dimensional array that the function stores the read data.
+                      )
+{
+	int8_t pec_error =0;
+	pec_error = LTC681x_rdpwm(total_ic,pwmReg,ic);
+	return(pec_error);
+}
+  
+/* Writes data in S control register the LTC6812-1s connected in a daisy chain stack. */ 
+void LTC6812_wrsctrl(uint8_t total_ic, //Number of ICs in the daisy chain
+                     uint8_t sctrl_reg, //Register Select 
+                     cell_asic *ic //A two dimensional array of the data that will be written
                     )
 {
 	LTC681x_wrsctrl(total_ic, sctrl_reg, ic);
-  }
+}
   
-//  Reads sctrl registers of a LTC6812 daisy chain   
-int8_t LTC6812_rdsctrl(uint8_t total_ic, //number of ICs in the daisy chain
-                       uint8_t sctrl_reg,
-                       cell_asic *ic //a two dimensional array that the function stores the read pwm data
+/* Reads sctrl registers of a LTC6812 daisy chain */   
+int8_t LTC6812_rdsctrl(uint8_t total_ic, //Number of ICs in the daisy chain
+                       uint8_t sctrl_reg, //Register Select 
+                       cell_asic *ic //A two dimensional array that the function stores the read data
                       )
 {
- LTC681x_rdsctrl( total_ic, sctrl_reg,ic )	;
-
-  }
+	LTC681x_rdsctrl( total_ic, sctrl_reg,ic )	;
+ }
 
 /* Start Sctrl data communication               
 This command will start the sctrl pulse communication over the spins
 */
 void LTC6812_stsctrl()
 {
-LTC681x_stsctrl();
-
-  }
+	LTC681x_stsctrl();
+ }
   
-// Write the 6812 PWM/S ctrl Register B 
-void LTC6812_wrpsb(uint8_t total_ic,cell_asic *ic)
+/*
+The command clears the Sctrl registers and initializes
+all values to 0. The register will read back hexadecimal 0x00
+after the command is sent.
+*/
+void LTC6812_clrsctrl()
 {
-		uint8_t cmd[2];
-		uint8_t write_buffer[256];
-		uint8_t c_ic = 0;
+	LTC681x_clrsctrl();
+}
+  
+/* Write the 6812 PWM/Sctrl Register B */
+void LTC6812_wrpsb(uint8_t total_ic, //Number of ICs in the daisy chain
+					cell_asic *ic //A two dimensional array of the data that will be written
+					)
+{
+	uint8_t cmd[2];
+	uint8_t write_buffer[256];
+	uint8_t c_ic = 0;
+	
+	cmd[0] = 0x00;
+	cmd[1] = 0x1C;
+	for(uint8_t current_ic = 0; current_ic<total_ic;current_ic++)
+	{
+		if(ic->isospi_reverse == true){c_ic = current_ic;}
+		else{c_ic = total_ic - current_ic - 1;}
 		
-		cmd[0] = 0x00;
-		cmd[1] = 0x1C;
-		for(uint8_t current_ic = 0; current_ic<total_ic;current_ic++)
-		{
-			if(ic->isospi_reverse == true){c_ic = current_ic;}
-			else{c_ic = total_ic - current_ic - 1;}
-			
-			write_buffer[0] = ic[c_ic].pwmb.tx_data[0];
-            write_buffer[1] = ic[c_ic].pwmb.tx_data[1]&(0x0F);
-     		write_buffer[2]= 0x00;
-        	write_buffer[3] = ic[c_ic].sctrlb.tx_data[3];
-		    write_buffer[4] = ic[c_ic].sctrlb.tx_data[4]&(0x0F);
-		    write_buffer[5]= 0x00;
-		}
-		write_68(total_ic, cmd, write_buffer);
-		
+		write_buffer[0] = ic[c_ic].pwmb.tx_data[0];
+		write_buffer[1] = ic[c_ic].pwmb.tx_data[1]&(0x0F);
+		write_buffer[2]= 0x00;
+		write_buffer[3] = ic[c_ic].sctrlb.tx_data[3];
+		write_buffer[4] = ic[c_ic].sctrlb.tx_data[4]&(0x0F);
+		write_buffer[5]= 0x00;
+	}
+	write_68(total_ic, cmd, write_buffer);		
 }
 
-// Reading pwm/s control register b
-int8_t LTC6812_rdpsb(uint8_t total_ic, //!< number of ICs in the daisy chain
-                       cell_asic *ic //!< a two dimensional array that the function stores the read pwm data
+/* Reading 6812 PWM/Sctrl Register B */
+int8_t LTC6812_rdpsb(uint8_t total_ic, //Number of ICs in the daisy chain
+                       cell_asic *ic //A two dimensional array that the function stores the read data
                       )	
 {
 	uint8_t cmd[4];
@@ -740,29 +574,188 @@ int8_t LTC6812_rdpsb(uint8_t total_ic, //!< number of ICs in the daisy chain
 		}
     }
     return(pec_error);
+}  
+  
+/*  Writes the COMM registers of a LTC6812 daisy chain */
+void LTC6812_wrcomm(uint8_t total_ic, //The number of ICs being written to
+                      cell_asic *ic //A two dimensional array of the comm data that will be written
+                     )
+{
+	LTC681x_wrcomm(total_ic,ic);
 }
 
-//Mutes the LTC6812discharge transistors
+/*  Reads COMM registers of a LTC6812 daisy chain */
+int8_t LTC6812_rdcomm(uint8_t total_ic, //Number of ICs in the system
+                        cell_asic *ic //A two dimensional array that the function stores the read data.
+                       )
+{
+	int8_t pec_error = 0;
+	LTC681x_rdcomm(total_ic, ic);
+	return(pec_error);
+}
+
+/* Shifts data in COMM register out over LTC6812 SPI/I2C port */
+void LTC6812_stcomm(uint8_t len) //Length of data to be transmitted 
+{
+    LTC681x_stcomm(len);
+}
+
+/* Mutes the LTC6812 discharge transistors */
 void LTC6812_mute()
 {
-  uint8_t cmd[2];
+	uint8_t cmd[2];
 
-  cmd[0] = 0x00;
-  cmd[1] = 0x28;
-  
-  cmd_68(cmd);
+	cmd[0] = 0x00;
+	cmd[1] = 0x28;	
+	cmd_68(cmd);
 }
 
-//Clears the LTC6812Mute Discharge
+/* Clears the LTC6812 Mute Discharge */
 void LTC6812_unmute()
 {
-  uint8_t cmd[4];
-  uint16_t cmd_pec;
+	uint8_t cmd[2];
 
-  cmd[0] = 0x00;
-  cmd[1] = 0x29;
-  cmd_68(cmd);
+	cmd[0] = 0x00;
+	cmd[1] = 0x29;
+	cmd_68(cmd);
 }
 
+/* Helper function that increments PEC counters */
+void LTC6812_check_pec(uint8_t total_ic,uint8_t reg, cell_asic *ic)
+{
+    LTC681x_check_pec(total_ic,reg,ic);
+}
 
+/* Helper Function to reset PEC counters */
+void LTC6812_reset_crc_count(uint8_t total_ic, cell_asic *ic)
+{
+	LTC681x_reset_crc_count(total_ic,ic);
+}
 
+/* Helper function to initialize CFG variables */
+void LTC6812_init_cfg(uint8_t total_ic, cell_asic *ic)
+{
+	LTC681x_init_cfg(total_ic,ic);
+}
+/* Helper function to set CFGR variable */
+void LTC6812_set_cfgr(uint8_t nIC, cell_asic *ic, bool refon, bool adcopt, bool gpio[5],bool dcc[12],bool dcto[4], uint16_t uv, uint16_t  ov)
+{
+    LTC681x_set_cfgr_refon(nIC,ic,refon);
+    LTC681x_set_cfgr_adcopt(nIC,ic,adcopt);
+    LTC681x_set_cfgr_gpio(nIC,ic,gpio);
+    LTC681x_set_cfgr_dis(nIC,ic,dcc);
+	LTC681x_set_cfgr_dcto(nIC,ic,dcto);
+	LTC681x_set_cfgr_uv(nIC, ic, uv);
+    LTC681x_set_cfgr_ov(nIC, ic, ov);
+}
+/* Helper function to set the REFON bit */
+void LTC6812_set_cfgr_refon(uint8_t nIC, cell_asic *ic, bool refon) 
+{
+	LTC681x_set_cfgr_refon(nIC,ic,refon);
+}
+/* Helper function to set the adcopt bit */
+void LTC6812_set_cfgr_adcopt(uint8_t nIC, cell_asic *ic, bool adcopt)
+{
+	LTC681x_set_cfgr_adcopt(nIC,ic,adcopt);
+}
+/* Helper function to set GPIO bits */
+void LTC6812_set_cfgr_gpio(uint8_t nIC, cell_asic *ic,bool gpio[5])
+{  
+	LTC681x_set_cfgr_gpio(nIC,ic,gpio);
+}
+/* Helper function to control discharge */
+void LTC6812_set_cfgr_dis(uint8_t nIC, cell_asic *ic,bool dcc[12])
+{  
+	LTC681x_set_cfgr_dis(nIC,ic,dcc);
+}
+/* Helper Function to set dcto value in CFG register */
+void LTC6812_set_cfgr_dcto(uint8_t nIC, cell_asic *ic,bool dcto[4])
+{
+    LTC681x_set_cfgr_dcto(nIC, ic, dcto);
+}
+/* Helper Function to set uv value in CFG register */
+void LTC6812_set_cfgr_uv(uint8_t nIC, cell_asic *ic,uint16_t uv)
+{
+    LTC681x_set_cfgr_uv(nIC, ic, uv);
+}
+/* Helper function to set OV value in CFG register */
+void LTC6812_set_cfgr_ov(uint8_t nIC, cell_asic *ic,uint16_t ov)
+{
+    LTC681x_set_cfgr_ov( nIC, ic, ov);
+}
+
+/*  Helper Function to initialize the CFGRB data structures */
+void LTC6812_init_cfgb(uint8_t total_ic, cell_asic *ic)
+{
+	 for (uint8_t current_ic = 0; current_ic<total_ic;current_ic++)
+    {
+        for(int j =0; j<6;j++)
+        {
+            ic[current_ic].configb.tx_data[j] = 0;
+        }
+    }
+}
+
+/*  Helper Function to set the configuration register B */ 
+void LTC6812_set_cfgrb(uint8_t nIC, cell_asic *ic,bool fdrf,bool dtmen,bool ps[2],bool gpiobits[4],bool dccbits[4])
+{
+	LTC6812_set_cfgrb_fdrf(nIC,ic,fdrf);
+    LTC6812_set_cfgrb_dtmen(nIC,ic,dtmen);
+    LTC6812_set_cfgrb_ps(nIC,ic,ps);
+    LTC6812_set_cfgrb_gpio_b(nIC,ic,gpiobits);
+	LTC6812_set_cfgrb_dcc_b(nIC,ic,dccbits);	
+}
+
+/* Helper function to set the FDRF bit */
+void LTC6812_set_cfgrb_fdrf(uint8_t nIC, cell_asic *ic, bool fdrf) 
+{
+	if(fdrf) ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|0x40;
+	else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&0xBF;
+}
+
+/* Helper function to set the DTMEN bit */
+void LTC6812_set_cfgrb_dtmen(uint8_t nIC, cell_asic *ic, bool dtmen) 
+{
+	if(dtmen) ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|0x08;
+	else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&0xF7;
+}
+	
+/* Helper function to set the PATH SELECT bit */
+void LTC6812_set_cfgrb_ps(uint8_t nIC, cell_asic *ic, bool ps[]) 
+{
+	for(int i =0;i<2;i++)
+	{
+      if(ps[i])ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|(0x01<<(i+4));
+      else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&(~(0x01<<(i+4)));
+	}
+}
+
+/*  Helper function to set the gpio bits in config b register */
+void LTC6812_set_cfgrb_gpio_b(uint8_t nIC, cell_asic *ic, bool gpiobits[]) 
+{
+	for(int i =0;i<4;i++)
+	{
+      if(gpiobits[i])ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]|(0x01<<i);
+      else ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]&(~(0x01<<i));
+	}
+}
+
+/*  Helper function to set the dcc bits in config b register */
+void LTC6812_set_cfgrb_dcc_b(uint8_t nIC, cell_asic *ic, bool dccbits[]) 
+{
+	
+	for(int i =0;i<4;i++)
+   { 
+		if(i==0)
+		{
+			if(dccbits[i])ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|0x04;
+			else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&0xFB;
+		}
+		else
+		{	
+			if(dccbits[i])ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]|(0x01<<(i+3));
+			else ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]&(~(0x01<<(i+3)));
+		}
+		
+   }
+}

--- a/LTSketchbook/libraries/LTC6812/LTC6812.h
+++ b/LTSketchbook/libraries/LTC6812/LTC6812.h
@@ -59,470 +59,581 @@
 #define LTC6812_H
 
 #include "stdint.h"
-#include "ltc681x.h"
+#include "LTC681x.h"
 
 #define CELL 1
 #define AUX 2
 #define STAT 3
 
-//! Initialize the Register limits
-//!@return void
+/*!
+ Initialize the Register limits
+ @return void 
+ */
 void LTC6812_init_reg_limits(uint8_t total_ic, //!< Number of ICs in the system
 							 cell_asic *ic //!< A two dimensional array that will store the data
 							 );
+
+/*!
+ Write the LTC6812 configuration register
+ @return void 
+ */
+void LTC6812_wrcfg(uint8_t total_ic, //!< The number of ICs being written
+                   cell_asic *ic //!< A two dimensional array of the configuration data that will be written
+                  );
+
+/*! 
+ Write the LTC6812 configuration register B
+ @return void	
+ */			  
+void LTC6812_wrcfgb(uint8_t total_ic, //!< The number of ICs being written
+                   cell_asic *ic //!< A two dimensional array of the configuration data that will be written
+                  );
+				  
+/*!
+ Reads configuration registers of a LTC6812 daisy chain
+ @return int8_t, pec_error PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC 
+  */
+int8_t LTC6812_rdcfg(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                     cell_asic *ic //!< A two dimensional array that the function stores the read configuration data
+                    );
+
+/*!
+ Reads configuration registers of a LTC6812 daisy chain
+ @return int8_t, pec_error PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC 
+  */					
+int8_t LTC6812_rdcfgb(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                     cell_asic *ic //!< A two dimensional array that the function stores the read configuration data
+                    );
 							 
-//! Starts the Mux Decoder diagnostic self test
-//! Running this command will start the Mux Decoder Diagnostic Self Test.
-//! This test takes roughly 1ms to complete. The MUXFAIL bit will be updated.
-//! The bit will be set to 1 for a failure and 0 if the test has been passed.
-//!@return void
-void LTC6812_diagn();
-
-
-//! Sends the poll ADC command
-//! @returns 1 byte read back after a pladc command. If the byte is not 0xFF ADC conversion has completed
-uint8_t LTC6812_pladc();
-
-//! This function will block operation until the ADC has finished it's conversion
-//! @returns the approximate time it took for the ADC function to complete.
-uint32_t LTC6812_pollAdc();
-
-//! Starts cell voltage conversion
-//!@return void
+/*!
+ Starts cell voltage conversion
+ @return void 
+ */
 void LTC6812_adcv(uint8_t MD, //!< ADC Conversion Mode
                   uint8_t DCP, //!< Controls if Discharge is permitted during conversion
                   uint8_t CH //!< Sets which Cell channels are converted
                  );
 
-//!  Starts cell voltage  and GPIO 1&2 conversion
-//!@return void
-void LTC6812_adcvax(uint8_t MD, //!< ADC Conversion Mode
-					uint8_t DCP //!< Controls if Discharge is permitted during conversion
-					);
-
-
-//!  Starts cell voltage self test conversion
-//!@return void
-void LTC6812_cvst(uint8_t MD, //!< ADC Conversion Mode
-				uint8_t ST //!< Self Test Mode
-				);
-
-//!  Starts cell voltage and SOC conversion
-//!@return void
-void LTC6812_adcvsc(uint8_t MD, //!< ADC Conversion Mode
-					uint8_t DCP //!< Controls if Discharge is permitted during conversion
-					);
-					
-//!  Starts cell voltage overlap conversion
-//!@return void
-void LTC6812_adol(uint8_t MD, //!< ADC Conversion Mode
-					uint8_t DCP //!< Discharge permitted during conversion
-					);
-
-//!  Start an open wire Conversion
-//!@return void
-void LTC6812_adow(uint8_t MD, //!< ADC Conversion Mode
-				 uint8_t PUP, //!< Controls if Discharge is permitted during conversion
-				 uint8_t CH,  //!< Sets which Cell channels are converted
-				 uint8_t DCP  //!< Discharge permitted during conversion
-				 );
-
-//!  Start a GPIO and Vref2 Conversion
-//!@return void
+/*!
+ Start a GPIO and Vref2 Conversion
+ @return void 
+ */
 void LTC6812_adax(uint8_t MD, //!< ADC Conversion Mode
 				  uint8_t CHG //!< Sets which GPIO channels are converted
 				  );
 
-//!  Start an GPIO Redundancy test
-//!@return void
-void LTC6812_adaxd(uint8_t MD, //!< ADC Conversion Mode
-					uint8_t CHG //!< Sets which GPIO channels are converted
+/*!
+ Start a Status ADC Conversion
+ @return void 
+ */
+void LTC6812_adstat(uint8_t MD, //!< ADC Conversion Mode
+					uint8_t CHST //!< Sets which Stat channels are converted
+					);				  
+				 
+/*!
+ Starts cell voltage  and GPIO 1&2 conversion
+ @return void 
+ */
+void LTC6812_adcvax(uint8_t MD, //!< ADC Conversion Mode
+					uint8_t DCP //!< Controls if Discharge is permitted during conversion
 					);
 
-//!  Start an Auxiliary Register Self Test Conversion
-//!@return void
+/*!
+ Starts cell voltage and SOC conversion
+ @return void 
+ */
+void LTC6812_adcvsc(uint8_t MD, //!< ADC Conversion Mode
+					uint8_t DCP //!< Controls if Discharge is permitted during conversion
+					);					
+
+/*!
+ Reads and parses the LTC6812 cell voltage registers.
+ @return uint8_t, pec_error PEC Status.
+   0: No PEC error detected
+  -1: PEC error detected, retry read 
+  */
+uint8_t LTC6812_rdcv(uint8_t reg, //!< Controls which cell voltage register is read back
+                     uint8_t total_ic, //!< The number of ICs in the daisy chain
+                     cell_asic *ic //!< Array of the parsed cell codes from lowest to highest
+                    );
+
+/*!
+ Reads and parses the LTC6812 auxiliary registers.
+ @return  int8_t, pec_error PEC Status
+   0: No PEC error detected
+  -1: PEC error detected, retry read 
+  */
+int8_t LTC6812_rdaux(uint8_t reg,  //!< Controls which GPIO voltage register is read back
+                     uint8_t total_ic,  //!< The number of ICs in the daisy chain
+                     cell_asic *ic //!< A two dimensional array of the parsed gpio voltage codes
+                    );
+
+/*!
+ Reads and parses the LTC6812 stat registers.
+ @return  int8_t, pec_error PEC Status
+   0: No PEC error detected
+  -1: PEC error detected, retry read 
+  */
+int8_t LTC6812_rdstat(uint8_t reg, //!<Determines which Stat  register is read back
+                        uint8_t total_ic,//!<The number of ICs in the system
+                        cell_asic *ic  //!< A two dimensional array that will store the data 
+                       );	
+					   
+/*! 
+ Sends the poll ADC command
+ @returns 1 byte read back after a pladc command. If the byte is not 0xFF ADC conversion has completed 
+  */
+uint8_t LTC6812_pladc();
+
+/*!
+ This function will block operation until the ADC has finished it's conversion.
+ @returns uint32_t, counter The approximate time it took for the ADC function to complete
+  */
+uint32_t LTC6812_pollAdc();
+					   			   
+/*!
+ Clears the LTC6812 cell voltage registers
+ @return void 
+ */
+void LTC6812_clrcell();
+
+/*!
+ Clears the LTC6812 Auxiliary registers
+ @return void 
+ */
+void LTC6812_clraux();
+
+/*!
+  Clears the LTC6812 Stat registers
+ @return void 
+ */
+void LTC6812_clrstat();
+
+/*!
+ Starts the Mux Decoder diagnostic self test
+ Running this command will start the Mux Decoder Diagnostic Self Test.
+ This test takes roughly 1ms to complete. The MUXFAIL bit will be updated.
+ The bit will be set to 1 for a failure and 0 if the test has been passed.
+ @return void 
+ */
+void LTC6812_diagn();
+					   
+/*!
+ Starts cell voltage self test conversion
+ @return void  
+ */
+void LTC6812_cvst(uint8_t MD, //!< ADC Conversion Mode
+				uint8_t ST //!< Sets if self test 1 or 2 is run
+				);
+
+/*!
+ Start an Auxiliary Register Self Test Conversion
+ @return void 
+ */
 void LTC6812_axst(uint8_t MD, //!< ADC Conversion Mode
 					uint8_t ST //!< Sets if self test 1 or 2 is run
 					);
 
-//!  Start a Status ADC Conversion
-//!@return void
-void LTC6812_adstat(uint8_t MD, //!< ADC Conversion Mode
-					uint8_t CHST //!< Sets which Stat channels are converted
-					);
-
-//!   Start a Status register redundancy test Conversion
-//!@return void
-void LTC6812_adstatd(uint8_t MD, //!< ADC Mode
-					uint8_t CHST //!< Sets which Status channels are converted
-					);
-
-
-//!  Start a Status Register Self Test Conversion
-//!@return void
+/*!
+ Start a Status Register Self Test Conversion
+ @return void 
+ */
 void LTC6812_statst(uint8_t MD, //!< ADC Conversion Mode
 					uint8_t ST //!< Sets if self test 1 or 2 is run
+					);					
+								
+/*!
+ Starts Cell voltage overlap conversion
+ @return void 
+ */
+void LTC6812_adol(uint8_t MD, //!< ADC Conversion Mode
+					uint8_t DCP //!< Discharge permitted during conversion
 					);
 
-/*!  Reads and parses the LTC6812 cell voltage registers.
-  @return int8_t, PEC Status.
-    0: No PEC error detected
-    -1: PEC error detected, retry read
-*/
-uint8_t LTC6812_rdcv(uint8_t reg, //!< controls which cell voltage register is read back.
-                     uint8_t total_ic, //!< the number of ICs in the daisy chain(-1 only)
-                     cell_asic *ic //!< array of the parsed cell codes from lowest to highest.
-                    );
+/*!
+ Start an GPIO Redundancy test
+ @return void 
+ */
+void LTC6812_adaxd(uint8_t MD, //!< ADC Conversion Mode
+					uint8_t CHG //!< Sets which GPIO channels are converted
+					);
 
-/*!  Reads and parses the LTC6812 auxiliary registers.
-@return  int8_t, PEC Status
-  0: No PEC error detected
- -1: PEC error detected, retry read
-*/
-int8_t LTC6812_rdaux(uint8_t reg,  //!< controls which GPIO voltage register is read back
-                     uint8_t nIC,  //!< the number of ICs in the daisy chain
-                     cell_asic *ic //!< A two dimensional array of the parsed gpio voltage codes
-                    );
+/*!
+ Start a Status register redundancy test Conversion
+ @return void 
+ */
+void LTC6812_adstatd(uint8_t MD, //!< ADC Mode
+					uint8_t CHST //!< Sets which Status channels are converted
+					);					
 
-/*!  Reads and parses the LTC6812 stat registers.
-@return  int8_t, PEC Status
-  0: No PEC error detected
- -1: PEC error detected, retry read
-*/
-int8_t LTC6812_rdstat(uint8_t reg, //!<Determines which Stat  register is read back.
-                        uint8_t total_ic,//!<the number of ICs in the system
-                        cell_asic *ic  //!< a two dimensional array that will store the data 
-                       );
+/*!
+ Helper function that runs the ADC Self Tests
+ @return int16_t, error   Number of errors detected. 
+ */
+int16_t LTC6812_run_cell_adc_st(uint8_t adc_reg,  //!<  Type of register
+								uint8_t total_ic, //!< Number of ICs in the daisy chain
+								cell_asic *ic, //!< A two dimensional array that will store the data 
+								uint8_t md, //!< ADC Mode
+								bool adcopt //!< The ADCOPT bit in the configuration register
+								);
 
-//!  Clears the LTC6812 cell voltage registers
-//!@return void
-void LTC6812_clrcell();
-
-//! Clears the LTC6812 Auxiliary registers
-//!@return void
-void LTC6812_clraux();
-
-//!  Clears the LTC6812 Stat registers
-//!@return void
-void LTC6812_clrstat();
-
-//!  Clears the LTC6812 Sctrl registers
-//!@return void
-void LTC6812_clrsctrl();
-
-//!  Write the LTC6812 configuration register
-//!@return void
-void LTC6812_wrcfg(uint8_t nIC, //!< The number of ICs being written
-                   cell_asic *ic //!< a two dimensional array of the configuration data that will be written
-                  );
-
-//!  Write the LTC6812 configuration register B
-//!@return void				  
-void LTC6812_wrcfgb(uint8_t nIC, //!< The number of ICs being written
-                   cell_asic *ic //!< a two dimensional array of the configuration data that will be written
-                  );
-				  
-/*!  Reads configuration registers of a LTC6812 daisy chain
-@return int8_t, PEC Status.
-  0: Data read back has matching PEC
-   -1: Data read back has incorrect PEC
-*/
-int8_t LTC6812_rdcfg(uint8_t nIC, //!< number of ICs in the daisy chain
-                     cell_asic *ic //!< a two dimensional array that the function stores the read configuration data
-                    );
-
-/*!  Reads configuration registers of a LTC6812 daisy chain
-@return int8_t, PEC Status.
-  0: Data read back has matching PEC
-   -1: Data read back has incorrect PEC
-*/					
-int8_t LTC6812_rdcfgb(uint8_t nIC, //!< number of ICs in the daisy chain
-                     cell_asic *ic //!< a two dimensional array that the function stores the read configuration data
-                    );
+/*!
+ Helper Function that runs the ADC Overlap test
+ @return uint16_t, error
+  0: Pass
+ -1: False, Error detected 
+ */
+uint16_t LTC6812_run_adc_overlap(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                                 cell_asic *ic //!< A two dimensional array that will store the data 
+                                 );								
+								
+/*!
+ Helper function that runs the ADC Digital Redundancy commands and checks output for errors
+ @return int16_t, error   Number of errors detected. 
+ */
+int16_t LTC6812_run_adc_redundancy_st(uint8_t adc_mode, //!< ADC Mode
+                                      uint8_t adc_reg,  //!< Type of register
+                                      uint8_t total_ic, //!< Number of ICs in the daisy chain
+                                      cell_asic *ic //!< A two dimensional array that will store the data 
+									 );
 					
-//!  Write the LTC6812 PWM register
-//!@return void
-void LTC6812_wrpwm(uint8_t nIC, //!< number of ICs in the daisy chain
+/*!
+ Start an open wire Conversion
+ @return void 
+ */
+void LTC6812_adow(uint8_t MD, //!< ADC Conversion Mode
+				 uint8_t PUP, //!< Pull up/Pull down current
+				 uint8_t CH,  //!< Sets which Cell channels are converted
+				 uint8_t DCP  //!< Discharge permitted during conversion
+				 );
+				 
+/*!
+ Start GPIOs open wire ADC conversion
+ @return void 
+ */
+void LTC6812_axow( uint8_t MD, //!< ADC Mode
+				  uint8_t PUP  //!< Pull up/Pull down current
+				);				 
+
+/*!
+ Runs the data sheet algorithm for open wire for single cell detection 
+ @return void 
+ */
+void LTC6812_run_openwire_single(uint8_t total_ic, //!< Number of ICs in the daisy chain
+								 cell_asic *ic //!< A two dimensional array that will store the data 
+								 );
+								 
+/*!
+ Runs the data sheet algorithm for open wire for multiple cell and two consecutive cells detection 
+ @return void 
+ */ 
+void LTC6812_run_openwire_multi(uint8_t total_ic, //!< Number of ICs in the daisy chain
+								cell_asic *ic //!< A two dimensional array that will store the data 
+								);				 
+
+/*!
+ Runs open wire for GPIOs
+ @return void 
+ */
+void LTC6812_run_gpio_openwire(uint8_t total_ic, //!< Number of ICs in the daisy chain
+								cell_asic *ic //!< A two dimensional array that will store the data 
+								);		
+
+/*!
+ Helper function to set discharge bit in CFG register
+ @return void 
+ */                   
+void LTC6812_set_discharge(int Cell, //!< The cell to be discharged
+                           uint8_t total_ic, //!< Number of ICs in the system
+                           cell_asic *ic//!< A two dimensional array that will store the data
+							);
+							
+/*!
+ Clears all of the DCC bits in the configuration registers
+ @return void 
+ */							   
+void LTC6812_clear_discharge(uint8_t total_ic, //!< Number of ICs in the system
+                             cell_asic *ic //!< A two dimensional array that will store the data
+							 );
+					
+/*!
+ Write the LTC6812 PWM register
+ @return void 
+ */
+void LTC6812_wrpwm(uint8_t total_ic, //!< Number of ICs in the daisy chain
                    uint8_t pwmReg, //!< Select register
                    cell_asic *ic //!< a two dimensional array that will store the data 
                   );
 
-/*! Reads pwm registers of a LTC6811 daisy chain
-@return int8_t, PEC Status.
-  0: Data read back has matching PEC
- -1: Data read back has incorrect PEC
-*/
-int8_t LTC6812_rdpwm(uint8_t nIC, //!< number of ICs in the daisy chain
+/*!
+ Reads pwm registers of a LTC6811 daisy chain
+ @return int8_t, pec_error PEC Status.
+   0: Data read back has matching PEC
+  -1: Data read back has incorrect PEC 
+  */
+int8_t LTC6812_rdpwm(uint8_t total_ic, //!< Number of ICs in the daisy chain
                      uint8_t pwmReg, //!< Select register
-                     cell_asic *ic //!< a two dimensional array that the function stores the read pwm data
+                     cell_asic *ic //!< A two dimensional array that the function stores the read pwm data
                     );
 
-//!  Write the LTC6812 Sctrl register
-//!@return void
-void LTC6812_wrsctrl(uint8_t nIC, //!< number of ICs in the daisy chain
+/*!
+  Write the LTC6812 Sctrl register
+ @return void 
+ */
+void LTC6812_wrsctrl(uint8_t total_ic, //!< Number of ICs in the daisy chain
                      uint8_t sctrl_reg, //!< Select register
-                     cell_asic *ic //!< a two dimensional array that will store the data 
+                     cell_asic *ic  //!< A two dimensional array that will store the data 
                     );
 
-/*!  Reads sctrl registers of a LTC6812 daisy chain
-@return int8_t, PEC Status.
-  0: Data read back has matching PEC
-  -1: Data read back has incorrect PEC
-*/
-int8_t LTC6812_rdsctrl(uint8_t nIC, //!< number of ICs in the daisy chain
+/*!
+ Reads sctrl registers of a LTC6812 daisy chain
+ @return int8_t, pec_error PEC Status.
+   0: Data read back has matching PEC
+  -1: Data read back has incorrect PEC 
+   */
+int8_t LTC6812_rdsctrl(uint8_t total_ic, //!< Number of ICs in the daisy chain
                        uint8_t sctrl_reg, //!< Select register
-                       cell_asic *ic //!< a two dimensional array that the function stores the read pwm data
+                       cell_asic *ic //!< A two dimensional array that the function stores the read data
                       );
 
-/*!  Start Sctrl data communication
-This command will start the sctrl pulse communication over the spins
-*/
-//!@return void
+/*!
+ Start Sctrl data communication
+ This command will start the sctrl pulse communication over the spins
+ @return void 
+ */
 void LTC6812_stsctrl();
 
-/*!  Write the LTC6812 COMM register
-*/
-//!@return void
+/*!
+ Clears the LTC6812 Sctrl registers
+ @return void 
+ */
+void LTC6812_clrsctrl();
+
+/*!
+ Write the 6812 PWM/Sctrl Register B 
+ @return void 
+ */
+void LTC6812_wrpsb(uint8_t total_ic, //!< Number of ICs in the daisy chain
+					cell_asic *ic //!< A two dimensional array that will store the data 
+					
+					);
+					
+/*!
+ Reading pwm/s control register b
+ @return int8_t, pec_error PEC Status.
+   0: Data read back has matching PEC
+  -1: Data read back has incorrect PEC 
+  */
+int8_t LTC6812_rdpsb(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                       cell_asic *ic //!< A two dimensional array that the function stores the read data
+                      );
+
+/*!
+ Write the LTC6812 COMM register
+ @return void 
+ */
 void LTC6812_wrcomm(uint8_t total_ic, //!< Number of ICs in the daisy chain
-                    cell_asic *ic //!< a two dimensional array of the comm data that will be written
+                    cell_asic *ic //!< A two dimensional array of the comm data that will be written
                    );
 
-/*!  Reads comm registers of a LTC6812 daisy chain
-@return int8_t, PEC Status.
-  0: Data read back has matching PEC
-  -1: Data read back has incorrect PEC
-*/
-int8_t LTC6812_rdcomm(uint8_t total_ic, //!< number of ICs in the daisy chain
-                      cell_asic *ic //!< Two dimensional array that the function stores the read comm data.
+/*!
+ Reads comm registers of a LTC6812 daisy chain
+ @return int8_t, pec_error PEC Status.
+   0: Data read back has matching PEC
+  -1: Data read back has incorrect PEC 
+ */
+int8_t LTC6812_rdcomm(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                      cell_asic *ic //!< Two dimensional array that the function stores the read comm data
                      );
 
-/*!  Issues a stcomm command and clocks data out of the COMM register */
-//!@return void
-void LTC6812_stcomm();
+/*!
+ Issues a stcomm command and clocks data out of the COMM register 
+ @return void 
+ */
+void LTC6812_stcomm(uint8_t len);
+				   									 
+/*!
+ Mutes the LTC6812 discharge transistors
+ @return void 
+ */
+void LTC6812_mute();
 
-//! Looks up the result pattern for digital filter self test
-/*! @returns returns the register data pattern for a given ADC MD and Self test */
-uint16_t LTC6812_st_lookup(uint8_t MD, //!< ADC Conversion Mode
-						   uint8_t ST //!< Self test number
-						   );
-
-//! Helper function to set discharge bit in CFG register
-//!@return void                   
-void LTC6812_set_discharge(int Cell, //!< The cell to be discharged
-                           uint8_t total_ic, //!< number of ICs in the system
-                           cell_asic *ic//!< a two dimensional array that will store the data
-							);
-//! Clears all of the DCC bits in the configuration registers
-//!@return void							   
-void LTC6812_clear_discharge(uint8_t total_ic, //!< number of ICs in the system
-                             cell_asic *ic //!< a two dimensional array that will store the data
-							 );
-				   
-/*! Helper function that runs the ADC Self Tests*/
-//!@return int16_t, error
-//! Number of errors detected.
-int16_t LTC6812_run_cell_adc_st(uint8_t adc_reg,  //!<  Type of register
-								uint8_t total_ic, //!< number of ICs in the daisy chain
-								cell_asic *ic, //!< A two dimensional array that will store the data 
-								uint8_t md, //!< ADC Mode
-								bool adcopt //!< the adcopt bit in the configuration register
-								);
-
-/*! Helper function that runs the ADC Digital Redundancy commands and checks output for errors*/
-//!@return int16_t, error
-int16_t LTC6812_run_adc_redundancy_st(uint8_t adc_mode, //!< ADC Mode
-                                      uint8_t adc_reg,  //!< Type of register
-                                      uint8_t total_ic, //!< number of ICs in the daisy chain
-                                      cell_asic *ic //!< A two dimensional array that will store the data 
-									 );
-									 
-/*! Runs open wire for GPIOs*/
-//!@return void
-void LTC6812_run_gpio_openwire(uint8_t total_ic, //!< number of ICs in the daisy chain
-								cell_asic *ic //!< a two dimensional array that will store the data 
-								);									  
-
-/*! Runs the data sheet algorithm for open wire for single cell detection */
-//!@return void
-void LTC6812_run_openwire_single(uint8_t total_ic, //!< number of ICs in the daisy chain
-								 cell_asic *ic //!< A two dimensional array that will store the data 
-								 );
+/*!
+ Clears the LTC6812 Mute Discharge
+ @return void 
+ */
+void LTC6812_unmute();							  
 								 
-/*! Runs the data sheet algorithm for open wire for multiple cell and two consecutive cells detection */
-//!@return void
-void LTC6812_run_openwire_multi(uint8_t total_ic, //!< number of ICs in the daisy chain
-								cell_asic *ic //!< A two dimensional array that will store the data 
-								);
-
-/*! Helper Function that runs the ADC Overlap test*/
-//!@return uint16_t, error
-//! 0: Pass
-//!-1: False, Error detected
-uint16_t LTC6812_run_adc_overlap(uint8_t total_ic, //!< number of ICs in the daisy chain
-                                 cell_asic *ic //!< A two dimensional array that will store the data 
-                                 );
-								 
-/*! Helper Function that counts overall PEC errors and register/IC PEC errors*/
-//!@return void
-void LTC6812_check_pec(uint8_t total_ic, //!< number of ICs in the daisy chain
-                       uint8_t reg, //!<  Type of register
+/*!
+ Helper Function that counts overall PEC errors and register/IC PEC errors 
+ @return void 
+ */
+void LTC6812_check_pec(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                       uint8_t reg, //!< Type of register
                        cell_asic *ic //!< A two dimensional array that will store the data 
 						);
 					   
-/*! Helper Function that resets the PEC error counters */
-//!@return void
-void LTC6812_reset_crc_count(uint8_t total_ic, //!< number of ICs in the daisy chain
+/*!
+ Helper Function that resets the PEC error counters  
+ @return void 
+ */
+void LTC6812_reset_crc_count(uint8_t total_ic, //!< Number of ICs in the daisy chain
                              cell_asic *ic //!< A two dimensional array that will store the data 
 							 );
 							 
-/*! Helper Function to initialize the CFGR data structures*/
-//!@return void
-void LTC6812_init_cfg(uint8_t total_ic, //!< number of ICs in the daisy chain
+/*!
+ Helper Function to initialize the CFGR data structures 
+ @return void 
+ */
+void LTC6812_init_cfg(uint8_t total_ic, //!< Number of ICs in the daisy chain
                       cell_asic *ic //!< A two dimensional array that will store the data 
 						);
 					  
-/*! Helper function to set appropriate bits in CFGR register based on bit function*/
-//!@return void
+/*!
+ Helper function to set appropriate bits in CFGR register based on bit function 
+ @return void 
+ */
 void LTC6812_set_cfgr(uint8_t nIC, //!< Current IC
                       cell_asic *ic, //!< A two dimensional array that will store the data 
-                      bool refon,  //!< the REFON bit
-                      bool adcopt,  //!< the ADCOPT bit
-                      bool gpio[5], //!< the GPIO bits
-                      bool dcc[12], //!< the DCC bits 
-					  bool dcto[4], //!< the Dcto bits
-					  uint16_t uv, //!< the UV value
-					  uint16_t  ov //!< the OV value
+                      bool refon,  //!< The REFON bit
+                      bool adcopt,  //!< The ADCOPT bit
+                      bool gpio[5], //!< The GPIO bits
+                      bool dcc[12], //!< The DCC bits 
+					  bool dcto[4], //!< The Dcto bits
+					  uint16_t uv, //!< The UV value
+					  uint16_t  ov //!< The OV value
 					  );
 
-/*! Helper function to turn the refon bit HIGH or LOW*/
-//!@return void
+/*!
+ Helper function to turn the refon bit HIGH or LOW 
+ @return void 
+ */
 void LTC6812_set_cfgr_refon(uint8_t nIC,//!< Current IC
                             cell_asic *ic, //!< A two dimensional array that will store the data 
-                            bool refon //!< the REFON bit
+                            bool refon //!< The REFON bit
 							);
                             
-/*! Helper function to turn the ADCOPT bit HIGH or LOW*/
-//!@return void
+/*!
+ Helper function to turn the ADCOPT bit HIGH or LOW 
+ @return void 
+ */
 void LTC6812_set_cfgr_adcopt(uint8_t nIC,//!< Current IC
                              cell_asic *ic, //!< A two dimensional array that will store the data  
-                             bool adcopt //!< the ADCOPT bit
+                             bool adcopt //!< The ADCOPT bit
 							 );
 
-/*! Helper function to turn the GPIO bits HIGH or LOW*/
-//!@return void
+/*!
+ Helper function to turn the GPIO bits HIGH or LOW 
+ @return void 
+ */
 void LTC6812_set_cfgr_gpio(uint8_t nIC, //!< Current IC
                            cell_asic *ic, //!< A two dimensional array that will store the data 
-                           bool gpio[] //!< the GPIO bits
+                           bool gpio[] //!< The GPIO bits
 						   );
 
-/*! Helper function to turn the DCC bits HIGH or LOW*/
-//!@return void
+/*!
+ Helper function to turn the DCC bits HIGH or LOW 
+ @return void 
+ */
 void LTC6812_set_cfgr_dis(uint8_t nIC, //!< Current IC
                           cell_asic *ic, //!< A two dimensional array that will store the data 
-                          bool dcc[] //!< the DCC bits 
+                          bool dcc[] //!< The DCC bits 
 						  );
 						  
-/*!Helper Function to set dcto value in CFG register*/
-//!@return void
+/*!
+ Helper Function to set dcto value in CFG register 
+ @return void 
+ */
 void LTC6812_set_cfgr_dcto(uint8_t nIC, //!< Current IC
 						   cell_asic *ic, //!< A two dimensional array that will store the data 
-						   bool dcto[4] //!< the Dcto bits
+						   bool dcto[4] //!< The Dcto bits
 						   );		
 						   
-/*!  Helper function to set uv field in CFGRA register*/
-//!@return void
+/*! Helper function to set uv field in CFGRA register 
+ @return void 
+ */
 void LTC6812_set_cfgr_uv(uint8_t nIC, //!< Current IC
                          cell_asic *ic, //!< A two dimensional array that will store the data 
-                         uint16_t uv //!< the UV value
+                         uint16_t uv //!< The UV value
 						 );
                          
-/*!  Helper function to set ov field in CFGRA register*/
-//!@return void
+/*!
+ Helper function to set OV field in CFGRA register 
+ @return void 
+ */
 void LTC6812_set_cfgr_ov(uint8_t nIC, //!< Current IC
                          cell_asic *ic, //!< A two dimensional array that will store the data 
-                         uint16_t ov //!< the OV value
+                         uint16_t ov //!< The OV value
 						 );
  
-/*! Start GPIOs open wire ADC conversion*/
-//!@return void
-void LTC6812_axow(uint8_t MD, //!< ADC Mode
-				  uint8_t PUP //!< Discharge Permit
-				);
-
-/*! Helper Function to initialize the CFGR B data structures*/
-//!@return void
-void LTC6812_init_cfgb(uint8_t total_ic, //!< number of ICs in the daisy chain
+/*!
+ Helper Function to initialize the CFGR B data structures 
+ @return void
+ */
+void LTC6812_init_cfgb(uint8_t total_ic, //!< Number of ICs in the daisy chain
                        cell_asic *ic//!< A two dimensional array that will store the data 
 					  );
 					  
-/*! Helper function to set appropriate bits in CFGR register based on bit function*/
-//!@return void
+/*!
+ Helper function to set appropriate bits in CFGR register based on bit function 
+ @return void 
+ */
 void LTC6812_set_cfgrb(uint8_t nIC, //!< Current IC
                       cell_asic *ic, //!< A two dimensional array that will store the data 
-					  bool fdrf, //!< the FDRF bit
-                      bool dtmen, //!< the DTMEN bit
+					  bool fdrf, //!< The FDRF bit
+                      bool dtmen, //!< The DTMEN bit
                       bool ps[2], //!< Path selection bits
-                      bool gpiobits[4], //!< the GPIO bits
-					  bool dccbits[4] //!< the DCC bits 
+                      bool gpiobits[4], //!< The GPIO bits
+					  bool dccbits[4] //!< The DCC bits 
 					  );
 
-/*! Helper function to turn the fdrf bit HIGH or LOW*/
-//!@return void
+/*!
+ Helper function to turn the FDRF bit HIGH or LOW 
+ @return void
+ */
 void LTC6812_set_cfgrb_fdrf(uint8_t nIC,//!< Current IC
                             cell_asic *ic, //!< A two dimensional array that will store the data 
-                            bool fdrf //!< the FDRF bit
+                            bool fdrf //!< The FDRF bit
 							);
 							
-/*! Helper function to turn the DTMEN bit HIGH or LOW*/
-//!@return void
+/*!
+ Helper function to turn the DTMEN bit HIGH or LOW 
+ @return void 
+ */
 void LTC6812_set_cfgrb_dtmen(uint8_t nIC,//!< Current IC
                             cell_asic *ic, //!< A two dimensional array that will store the data 
-                            bool dtmen //!< the DTMEN bit
+                            bool dtmen //!< The DTMEN bit
 							);
 							
-/*! Helper function to turn the Path Select bit HIGH or LOW*/
-//!@return void
+/*!
+ Helper function to turn the Path Select bit HIGH or LOW 
+ @return void 
+ */
 void LTC6812_set_cfgrb_ps(uint8_t nIC,//!< Current IC
                             cell_asic *ic, //!< A two dimensional array that will store the data 
                             bool ps[] //!< Path selection bits
 							);
 							
-/*! Helper function to turn the GPIO bit HIGH or LOW*/
-//!@return void
+/*!
+ Helper function to turn the GPIO bit HIGH or LOW 
+ @return void
+ */
 void LTC6812_set_cfgrb_gpio_b(uint8_t nIC,//!< Current IC
                             cell_asic *ic, //!< A two dimensional array that will store the data 
-                            bool gpiobits[] //!< the GPIO bits
+                            bool gpiobits[] //!< The GPIO bits
 							);
 							
-/*! Helper function to turn the dcc bit HIGH or LOW*/
-//!@return void
+/*!
+ Helper function to turn the DCC bit HIGH or LOW 
+ @return void 
+ */
 void LTC6812_set_cfgrb_dcc_b(uint8_t nIC,//!< Current IC
                             cell_asic *ic, //!< A two dimensional array that will store the data 
-                            bool dccbits[] //!< the DCC bits 
+                            bool dccbits[] //!< The DCC bits 
 							);
 							
-/*! Write the 6812 PWM/S ctrl Register B */
-//!@return void
-void LTC6812_wrpsb(uint8_t total_ic, //!< number of ICs in the daisy chain
-					cell_asic *ic //!< A two dimensional array that will store the data 
-					
-					);
-					
-/*! Reading pwm/s control register b
-@return int8_t, PEC Status.
-  0: Data read back has matching PEC
- -1: Data read back has incorrect PEC
- */
-int8_t LTC6812_rdpsb(uint8_t total_ic, //!< number of ICs in the daisy chain
-                       cell_asic *ic //!< a two dimensional array that the function stores the read pwm data
-                      );
-					  
-/*!Mutes the LTC6812 discharge transistors*/
-//!@return void
-void LTC6812_mute();
-
-/*!Clears the LTC6812 Mute Discharge*/
-//!@return void
-void LTC6812_unmute();
-
 #endif

--- a/LTSketchbook/libraries/LTC6813/LTC6813.cpp
+++ b/LTSketchbook/libraries/LTC6813/LTC6813.cpp
@@ -1,7 +1,7 @@
 /*! LTC6813: Multicell Battery Monitors
 *
 *@verbatim
-*The LTC6813 is multicell battery stack monitor that measures up to 18 series 
+*The LTC6813 is multi-cell battery stack monitor that measures up to 18 series 
 *connected battery cells with a total measurement error of less than 2.2mV. 
 *The cell measurement range of 0V to 5V makes the LTC6813 suitable for most 
 *battery chemistries. All 18 cell voltages can be captured in 290uS, and lower 
@@ -63,8 +63,10 @@
 #include "LTC681x.h"
 #include "LTC6813.h"
 
-//Helper function to initialize register limits.
-void LTC6813_init_reg_limits(uint8_t total_ic, cell_asic *ic)
+/* Helper function to initialize register limits. */
+void LTC6813_init_reg_limits(uint8_t total_ic, //Number of ICs in the system
+							 cell_asic *ic // A two dimensional array that will store the data
+							 )
 {
     for(uint8_t cic=0; cic<total_ic; cic++)
     {
@@ -77,163 +79,23 @@ void LTC6813_init_reg_limits(uint8_t total_ic, cell_asic *ic)
     } 
 }
 
-//Helper function to initialize CFG variables.
-void LTC6813_init_cfg(uint8_t total_ic, cell_asic *ic)
-{
-   LTC681x_init_cfg(total_ic,ic);
-}
-
-//Helper function to set CFGR variable
-void LTC6813_set_cfgr(uint8_t nIC, cell_asic *ic, bool refon, bool adcopt, bool gpio[5],bool dcc[12],bool dcto[4], uint16_t uv, uint16_t  ov)
-{
-    LTC681x_set_cfgr_refon(nIC,ic,refon);
-    LTC681x_set_cfgr_adcopt(nIC,ic,adcopt);
-    LTC681x_set_cfgr_gpio(nIC,ic,gpio);
-    LTC681x_set_cfgr_dis(nIC,ic,dcc);
-	LTC681x_set_cfgr_dcto(nIC,ic,dcto);
-	LTC681x_set_cfgr_uv(nIC, ic, uv);
-    LTC681x_set_cfgr_ov(nIC, ic, ov);
-}
-
-//Helper function to set the REFON bit
-void LTC6813_set_cfgr_refon(uint8_t nIC, cell_asic *ic, bool refon) 
-{
-  LTC681x_set_cfgr_refon(nIC,ic,refon);
-}
-
-//Helper function to set the adcopt bit
-void LTC6813_set_cfgr_adcopt(uint8_t nIC, cell_asic *ic, bool adcopt)
-{
-  LTC681x_set_cfgr_adcopt(nIC,ic,adcopt);
-}
-
-//Helper function to set GPIO bits
-void LTC6813_set_cfgr_gpio(uint8_t nIC, cell_asic *ic,bool gpio[5])
-{  
-  LTC681x_set_cfgr_gpio(nIC,ic,gpio);
-}
-
-//Helper function to control discharge
-void LTC6813_set_cfgr_dis(uint8_t nIC, cell_asic *ic,bool dcc[12])
-{  
-  LTC681x_set_cfgr_dis(nIC,ic,dcc);
-}
-
-//Helper Function to set uv value in CFG register
-void LTC6813_set_cfgr_uv(uint8_t nIC, cell_asic *ic,uint16_t uv)
-{
-    LTC681x_set_cfgr_uv(nIC, ic, uv);
-}
-
-//Helper Function to set dcto value in CFG register
-void LTC6813_set_cfgr_dcto(uint8_t nIC, cell_asic *ic,bool dcto[4])
-{
-    LTC681x_set_cfgr_dcto(nIC, ic, dcto);
-}
-
-//Helper function to set OV value in CFG register
-void LTC6813_set_cfgr_ov(uint8_t nIC, cell_asic *ic,uint16_t ov)
-{
-    LTC681x_set_cfgr_ov( nIC, ic, ov);
-}
-
-//Helper Function to initialize the CFGRB data structures
-void LTC6813_init_cfgb(uint8_t total_ic,cell_asic *ic)
-{
-	for (uint8_t current_ic = 0; current_ic<total_ic;current_ic++)
-    {
-		for(int j =0; j<6;j++)
-        {
-            ic[current_ic].configb.tx_data[j] = 0;
-        }  
-    }
-}
-
-//Helper Function to set the configuration register B 
-void LTC6813_set_cfgrb(uint8_t nIC, cell_asic *ic,bool fdrf,bool dtmen,bool ps[2],bool gpiobits[4],bool dccbits[7])
-{
-    LTC6813_set_cfgrb_fdrf(nIC,ic,fdrf);
-    LTC6813_set_cfgrb_dtmen(nIC,ic,dtmen);
-    LTC6813_set_cfgrb_ps(nIC,ic,ps);
-    LTC6813_set_cfgrb_gpio_b(nIC,ic,gpiobits);
-	LTC6813_set_cfgrb_dcc_b(nIC,ic,dccbits);
-}
-
-//Helper function to set the FDRF bit
-void LTC6813_set_cfgrb_fdrf(uint8_t nIC, cell_asic *ic, bool fdrf) 
-{
-  if(fdrf) ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|0x40;
-  else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&0xBF;
-}
-
-//Helper function to set the DTMEN bit
-void LTC6813_set_cfgrb_dtmen(uint8_t nIC, cell_asic *ic, bool dtmen) 
-{
-  if(dtmen) ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|0x08;
-  else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&0xF7;
-}
-	
-//Helper function to set the PATH SELECT bit
-void LTC6813_set_cfgrb_ps(uint8_t nIC, cell_asic *ic, bool ps[]) 
-{
-  for(int i =0;i<2;i++)
-  {
-      if(ps[i])ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|(0x01<<(i+4));
-      else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&(~(0x01<<(i+4)));
-  }
-}
-
-// Helper function to set the gpio bits in configb b register
-void LTC6813_set_cfgrb_gpio_b(uint8_t nIC, cell_asic *ic, bool gpiobits[]) 
-{
-	for(int i =0;i<4;i++)
-  {
-      if(gpiobits[i])ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]|(0x01<<i);
-      else ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]&(~(0x01<<i));
-  }
-}
-
-// Helper function to set the dcc bits in configb b register
-void LTC6813_set_cfgrb_dcc_b(uint8_t nIC, cell_asic *ic, bool dccbits[]) 
-{
-	for(int i =0;i<7;i++)
-	{ 
-		if(i==0)
-		{
-			if(dccbits[i])ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|0x04;
-			else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&0xFB;
-		}
-		if(i>0 and i<5)
-		{	
-			if(dccbits[i])ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]|(0x01<<(i+3));
-			else ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]&(~(0x01<<(i+3)));
-		}
-		if(i>4 and i<7)
-		{
-			if(dccbits[i])ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|(0x01<<(i-5));
-			else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&(~(0x01<<(i-5)));	
-		}
-	}
-}
-
  /*
-   This command will write the configuration registers of the LTC6813-1s
-   connected in a daisy chain stack. The configuration is written in descending
-   order so the last device's configuration is written first.
-  */
+This command will write the configuration registers of the LTC6813-1s
+connected in a daisy chain stack. The configuration is written in descending
+order so the last device's configuration is written first.
+*/
 void LTC6813_wrcfg(uint8_t total_ic, //The number of ICs being written to
                      cell_asic *ic //A two dimensional array of the configuration data that will be written
                     )
-  {
-    LTC681x_wrcfg(total_ic,ic);
-  }
-
+{
+	LTC681x_wrcfg(total_ic,ic);
+}
 
 /*
-   This command will write the configuration b registers of the LTC6813-1s
-   connected in a daisy chain stack. The configuration is written in descending
-   order so the last device's configuration is written first.
-  */
+This command will write the configuration b registers of the LTC6813-1s
+connected in a daisy chain stack. The configuration is written in descending
+order so the last device's configuration is written first.
+*/
 void LTC6813_wrcfgb(uint8_t total_ic, //The number of ICs being written to
                     cell_asic *ic //A two dimensional array of the configuration data that will be written
                    )
@@ -241,18 +103,17 @@ void LTC6813_wrcfgb(uint8_t total_ic, //The number of ICs being written to
     LTC681x_wrcfgb(total_ic,ic);
 }
 
- 
-// Reads configuration registers of a LTC6813 daisy chain
-  int8_t LTC6813_rdcfg(uint8_t total_ic, //Number of ICs in the system
-                       cell_asic *ic //A two dimensional array that the function stores the read configuration data.
-                      )
-  {
-    int8_t pec_error = 0;
-    pec_error = LTC681x_rdcfg(total_ic,ic);
-    return(pec_error);
-  }
+/* Reads configuration registers of a LTC6813 daisy chain */
+int8_t LTC6813_rdcfg(uint8_t total_ic, //Number of ICs in the system
+				   cell_asic *ic //A two dimensional array that the function stores the read configuration data.
+				  )
+{
+	int8_t pec_error = 0;
+	pec_error = LTC681x_rdcfg(total_ic,ic);
+	return(pec_error);
+}
 
-//Reads configuration b registers of a LTC6813 daisy chain
+/* Reads configuration b registers of a LTC6813 daisy chain */
 int8_t LTC6813_rdcfgb(uint8_t total_ic, //Number of ICs in the system
                    cell_asic *ic //A two dimensional array that the function stores the read configuration data.
                   )
@@ -262,8 +123,7 @@ int8_t LTC6813_rdcfgb(uint8_t total_ic, //Number of ICs in the system
     return(pec_error);
 }
 
-
-//Starts cell voltage conversion
+/* Starts cell voltage conversion */
 void LTC6813_adcv(uint8_t MD, //ADC Mode
 				  uint8_t DCP, //Discharge Permit
 				  uint8_t CH //Cell Channels to be measured
@@ -272,9 +132,41 @@ void LTC6813_adcv(uint8_t MD, //ADC Mode
     LTC681x_adcv(MD,DCP,CH);
 }
 
-// Reads and parses the LTC6813 cell voltage registers.
+/* Start a GPIO and Vref2 Conversion */
+void LTC6813_adax(uint8_t MD, //ADC Mode
+				  uint8_t CHG //GPIO Channels to be measured)
+                 ) 
+{
+	LTC681x_adax(MD,CHG);
+}
+
+/* Start a Status ADC Conversion */
+void LTC6813_adstat(uint8_t MD, //ADC Mode
+					uint8_t CHST //Stat Channels to be measured
+)
+{
+	LTC681x_adstat(MD,CHST);
+} 
+
+/* Starts cell voltage and GPIO 1&2 conversion */
+void LTC6813_adcvax(uint8_t MD, //ADC Mode
+					uint8_t DCP //Discharge Permit
+					)
+{
+    LTC681x_adcvax(MD,DCP);
+}  
+
+/* Starts cell voltage and SOC conversion */
+void LTC6813_adcvsc( uint8_t MD, //ADC Mode
+                     uint8_t DCP //Discharge Permit
+                   )
+{
+    LTC681x_adcvsc(MD,DCP);
+}
+
+/*  Reads and parses the LTC6813 cell voltage registers */
 uint8_t LTC6813_rdcv(uint8_t reg, // Controls which cell voltage register is read back.
-                     uint8_t total_ic, // the number of ICs in the system
+                     uint8_t total_ic, // The number of ICs in the system
                      cell_asic *ic // Array of the parsed cell codes
                     )
 {
@@ -283,21 +175,13 @@ uint8_t LTC6813_rdcv(uint8_t reg, // Controls which cell voltage register is rea
 	return(pec_error);
 }
 
-//Start a GPIO and Vref2 Conversion
-void LTC6813_adax(uint8_t MD, //ADC Mode
-				  uint8_t CHG //GPIO Channels to be measured)
-                 ) 
-{
-	LTC681x_adax(MD,CHG);
-}
-
 /*
 The function is used
 to read the  parsed GPIO codes of the LTC6813. This function will send the requested
 read commands parse the data and store the gpio voltages in aux_codes variable
 */
 int8_t LTC6813_rdaux(uint8_t reg, //Determines which GPIO voltage register is read back.
-				     uint8_t total_ic,//the number of ICs in the system
+				     uint8_t total_ic,//The number of ICs in the system
 				     cell_asic *ic//A two dimensional array of the gpio voltage codes.
 				    )
 {
@@ -306,14 +190,6 @@ int8_t LTC6813_rdaux(uint8_t reg, //Determines which GPIO voltage register is re
 	return (pec_error);
 }
 
-//Start a Status ADC Conversion
-void LTC6813_adstat(uint8_t MD, //ADC Mode
-					uint8_t CHST //GPIO Channels to be measured
-)
-{
-	LTC681x_adstat(MD,CHST);
-} 
-
 /*
 Reads and parses the LTC6813 stat registers.
 The function is used
@@ -321,174 +197,22 @@ to read the  parsed stat codes of the LTC6813. This function will send the reque
 read commands parse the data and store the stat voltages in stat_codes variable
 */
 int8_t LTC6813_rdstat(uint8_t reg, //Determines which Stat  register is read back.
-                      uint8_t total_ic,//the number of ICs in the system
-                      cell_asic *ic
+                      uint8_t total_ic,//The number of ICs in the system
+                      cell_asic *ic //A two dimensional array of the stat codes.
                        )
 {
     int8_t pec_error = 0;
     pec_error = LTC681x_rdstat(reg,total_ic,ic);
     return (pec_error);
 }
- 
-// Starts cell voltage  and GPIO 1&2 conversion
-void LTC6813_adcvax(uint8_t MD, //ADC Mode
-					uint8_t DCP //Discharge Permit
-					)
-{
-    LTC681x_adcvax(MD,DCP);
-}  
 
-//Starts cell voltage and SOC conversion
-void LTC6813_adcvsc( uint8_t MD, //ADC Mode
-                     uint8_t DCP //Discharge Permit
-                   )
-{
-    LTC681x_adcvsc(MD,DCP);
-}
-
-//Starts the Mux Decoder diagnostic self test
-void LTC6813_diagn()
-{
-     LTC681x_diagn();
-}
-
-//Starts cell voltage self test conversion
-void LTC6813_cvst(uint8_t MD, //ADC Mode
-                  uint8_t ST //Self Test
-                 )
-{
-    LTC681x_cvst(MD,ST);
-}
-
-//Start an Auxiliary Register Self Test Conversion
-void LTC6813_axst(uint8_t MD, //ADC Mode
-				  uint8_t ST //Self Test
-                 )
-{
-	LTC681x_axst(MD,ST);
-}
-
-//Start a Status Register Self Test Conversion
-void LTC6813_statst(uint8_t MD, //ADC Mode
-                    uint8_t ST //Self Test
-)
-{
-    LTC681x_statst(MD,ST);
-}
-
-// Runs the Digital Filter Self Test
-int16_t LTC6813_run_cell_adc_st(uint8_t adc_reg,uint8_t total_ic, cell_asic *ic,uint8_t md,bool adcopt)
-{
-	int16_t error = 0;
-	error = LTC681x_run_cell_adc_st(adc_reg,total_ic,ic,md,adcopt);
-	return(error);
-}
-
-//Starts cell voltage overlap conversion
-void LTC6813_adol(uint8_t MD, //ADC Mode
-                  uint8_t DCP //Discharge Permit
-                 )
-{
-  LTC681x_adol(MD,DCP);
-}
-
-// Runs the ADC overlap test for the IC
-uint16_t LTC6813_run_adc_overlap(uint8_t total_ic, cell_asic *ic)
-{
-	uint16_t error = 0;
-	int32_t measure_delta =0;
-	int16_t failure_pos_limit = 20;
-	int16_t failure_neg_limit = -20;
-	uint32_t conv_time=0;  
-	wakeup_idle(total_ic);
-	LTC681x_adol(MD_7KHZ_3KHZ,DCP_DISABLED);
-	conv_time = LTC681x_pollAdc();
-
-	wakeup_idle(total_ic);
-	error = LTC681x_rdcv(0, total_ic,ic);
-	for (int cic = 0; cic<total_ic; cic++)
-	{
-		
-
-		measure_delta = (int32_t)ic[cic].cells.c_codes[6]-(int32_t)ic[cic].cells.c_codes[7]; 
-		if ((measure_delta>failure_pos_limit) || (measure_delta<failure_neg_limit))
-		{
-		  error = error | (1<<(cic-1));
-		}
-		measure_delta = (int32_t)ic[cic].cells.c_codes[12]-(int32_t)ic[cic].cells.c_codes[13]; 
-		if ((measure_delta>failure_pos_limit) || (measure_delta<failure_neg_limit))
-		{
-		  error = error | (1<<(cic-1));
-		}
-	}
-	return(error);
-}
-
-//Start GPIOs open wire ADC conversion
-void LTC6813_axow(uint8_t MD, //ADC Mode
-				  uint8_t PUP //Discharge Permit
-				 )
-{
-   LTC681x_axow(MD, PUP);
-}
-
-// Start an open wire Conversion
-void LTC6813_adow(uint8_t MD,uint8_t PUP,uint8_t CH,uint8_t DCP)
-{
-    LTC681x_adow(MD,PUP,CH,DCP);
-}
-
-//Runs open wire for GPIOs
-void LTC6813_run_gpio_openwire(uint8_t total_ic, 
-								cell_asic *ic
-								)
-{
-	LTC681x_run_gpio_openwire(total_ic, ic);
-}
-
-//Runs the data sheet algorithm for open wire for single cell detection
-void LTC6813_run_openwire_single(uint8_t total_ic, cell_asic *ic)
-{
-	LTC681x_run_openwire_single(total_ic, ic);
-}
-
-//Runs the data sheet algorithm for open wire for multiple cell and two consecutive cells detection
-void LTC6813_run_openwire_multi(uint8_t total_ic, cell_asic *ic)
-{
-	LTC681x_run_openwire_multi( total_ic, ic);
-}
-
-//Start an GPIO Redundancy test
-void LTC6813_adaxd(uint8_t MD, //ADC Mode
-				   uint8_t CHG //GPIO Channels to be measured)
-                   )
-{
-	LTC681x_adaxd(MD,CHG);
-}
-
-// Start a Status register redundancy test Conversion
-void LTC6813_adstatd(uint8_t MD, //ADC Mode
-					 uint8_t CHST //GPIO Channels to be measured
-                    )
-{
- LTC681x_adstatd(MD,CHST);
-}
-
-//Runs the redundancy self test
-int16_t LTC6813_run_adc_redundancy_st(uint8_t adc_mode, uint8_t adc_reg, uint8_t total_ic, cell_asic *ic)
-{
-	int16_t error = 0;
-	LTC681x_run_adc_redundancy_st(adc_mode,adc_reg,total_ic,ic);
-	return(error);
-}
-
-//Sends the poll ADC command
+/* Sends the poll ADC command */
 uint8_t LTC6813_pladc()
 {
 	return(LTC681x_pladc());
 }
 
-//This function will block operation until the ADC has finished it's conversion
+/* This function will block operation until the ADC has finished it's conversion */
 uint32_t LTC6813_pollAdc()
 {
 	return(LTC681x_pollAdc());
@@ -523,19 +247,217 @@ void LTC6813_clrstat()
 {
 	LTC681x_clrstat();
 }
+ 
+/* Starts the Mux Decoder diagnostic self test */
+void LTC6813_diagn()
+{
+     LTC681x_diagn();
+}
 
-//Writes the pwm registers of a LTC6813 daisy chain 
-void LTC6813_wrpwm(uint8_t total_ic,
-				   uint8_t pwmReg,  //The number of ICs being written to
+/* Starts cell voltage self test conversion */
+void LTC6813_cvst(uint8_t MD, //ADC Mode
+                  uint8_t ST //Self Test
+                 )
+{
+    LTC681x_cvst(MD,ST);
+}
+
+/* Start an Auxiliary Register Self Test Conversion */
+void LTC6813_axst(uint8_t MD, //ADC Mode
+				  uint8_t ST //Self Test
+                 )
+{
+	LTC681x_axst(MD,ST);
+}
+
+/* Start a Status Register Self Test Conversion */
+void LTC6813_statst(uint8_t MD, //ADC Mode
+                    uint8_t ST //Self Test
+					)
+{
+    LTC681x_statst(MD,ST);
+}
+
+/* Starts cell voltage overlap conversion */
+void LTC6813_adol(uint8_t MD, //ADC Mode
+                  uint8_t DCP //Discharge Permit
+                 )
+{
+	LTC681x_adol(MD,DCP);
+}
+
+/* Start an GPIO Redundancy test */
+void LTC6813_adaxd(uint8_t MD, //ADC Mode
+				   uint8_t CHG //GPIO Channels to be measured
+                   )
+{
+	LTC681x_adaxd(MD,CHG);
+}
+
+/* Start a Status register redundancy test Conversion */
+void LTC6813_adstatd(uint8_t MD, //ADC Mode
+					 uint8_t CHST //Stat Channels to be measured
+                    )
+{
+	LTC681x_adstatd(MD,CHST);
+}
+
+/* Runs the Digital Filter Self Test */
+int16_t LTC6813_run_cell_adc_st(uint8_t adc_reg, // Type of register
+								uint8_t total_ic, // Number of ICs in the system
+								cell_asic *ic, // A two dimensional array that will store the data
+								uint8_t md, //ADC Mode
+								bool adcopt // The adcopt bit in the configuration register
+								)
+{
+	int16_t error = 0;
+	error = LTC681x_run_cell_adc_st(adc_reg,total_ic,ic,md,adcopt);
+	return(error);
+}
+
+/*  Runs the ADC overlap test for the IC */
+uint16_t LTC6813_run_adc_overlap(uint8_t total_ic, // Number of ICs in the system
+								cell_asic *ic // A two dimensional array that will store the data
+								)
+{
+	uint16_t error = 0;
+	int32_t measure_delta =0;
+	int16_t failure_pos_limit = 20;
+	int16_t failure_neg_limit = -20;
+	uint32_t conv_time=0;  
+	wakeup_idle(total_ic);
+	LTC681x_adol(MD_7KHZ_3KHZ,DCP_DISABLED);
+	conv_time = LTC681x_pollAdc();
+
+	wakeup_idle(total_ic);
+	error = LTC681x_rdcv(0, total_ic,ic);
+	for (int cic = 0; cic<total_ic; cic++)
+	{
+		
+
+		measure_delta = (int32_t)ic[cic].cells.c_codes[6]-(int32_t)ic[cic].cells.c_codes[7]; 
+		if ((measure_delta>failure_pos_limit) || (measure_delta<failure_neg_limit))
+		{
+		  error = error | (1<<(cic-1));
+		}
+		measure_delta = (int32_t)ic[cic].cells.c_codes[12]-(int32_t)ic[cic].cells.c_codes[13]; 
+		if ((measure_delta>failure_pos_limit) || (measure_delta<failure_neg_limit))
+		{
+		  error = error | (1<<(cic-1));
+		}
+	}
+	return(error);
+}
+
+/* Runs the redundancy self test */
+int16_t LTC6813_run_adc_redundancy_st(uint8_t adc_mode, //ADC Mode
+									  uint8_t adc_reg, // Type of register
+									  uint8_t total_ic, // Number of ICs in the system 
+									  cell_asic *ic // A two dimensional array that will store the data
+									  )
+{
+	int16_t error = 0;
+	LTC681x_run_adc_redundancy_st(adc_mode,adc_reg,total_ic,ic);
+	return(error);
+}
+
+/* Start an open wire Conversion */
+void LTC6813_adow(uint8_t MD,   //ADC Mode
+                  uint8_t PUP, //Pull up/Pull down current
+				  uint8_t CH,  //Sets which Cell channels are converted
+				  uint8_t DCP //Discharge Permit
+				  )
+{
+    LTC681x_adow(MD,PUP,CH,DCP);
+}
+
+/* Start GPIOs open wire ADC conversion */
+void LTC6813_axow(uint8_t MD, //ADC Mode
+				  uint8_t PUP //Pull up/Pull down current
+				 )
+{
+   LTC681x_axow(MD, PUP);
+}
+
+/* Runs the data sheet algorithm for open wire for single cell detection */
+void LTC6813_run_openwire_single(uint8_t total_ic, // Number of ICs in the system 
+								cell_asic *ic // A two dimensional array that will store the data
+								)
+{
+	LTC681x_run_openwire_single(total_ic, ic);
+}
+
+/* Runs the data sheet algorithm for open wire for multiple cell and two consecutive cells detection */
+void LTC6813_run_openwire_multi(uint8_t total_ic, // Number of ICs in the system 
+								cell_asic *ic // A two dimensional array that will store the data
+								)
+{
+	LTC681x_run_openwire_multi( total_ic, ic);
+}
+
+/* Runs open wire for GPIOs */
+void LTC6813_run_gpio_openwire(uint8_t total_ic, // Number of ICs in the system 
+								cell_asic *ic // A two dimensional array that will store the data
+								)
+{
+	LTC681x_run_gpio_openwire(total_ic, ic);
+}
+
+/* Helper function to set discharge bit in CFG register */
+void LTC6813_set_discharge(int Cell, // Cell to be discharged
+						   uint8_t total_ic, // Number of ICs in the system 
+						   cell_asic *ic // A two dimensional array that will store the data
+						   )
+{
+	for (int i=0; i<total_ic; i++)
+	{
+		if (Cell==0)
+		{
+		  ic[i].configb.tx_data[1] = ic[i].configb.tx_data[1] |(0x04);
+		}
+		else if (Cell<9)
+		{
+		  ic[i].config.tx_data[4] = ic[i].config.tx_data[4] | (1<<(Cell-1));
+		}
+		else if (Cell < 13)
+		{
+		  ic[i].config.tx_data[5] = ic[i].config.tx_data[5] | (1<<(Cell-9));
+		}
+		else if (Cell<17)
+		{
+		  ic[i].configb.tx_data[0] = ic[i].configb.tx_data[0] | (1<<(Cell-9));
+		}
+		else if (Cell<19)
+		{
+		  ic[i].configb.tx_data[1] = ic[i].configb.tx_data[1] | (1<<(Cell-17));
+		}
+		else
+		{
+			break;
+		}
+	}
+}
+
+/* Clears all of the DCC bits in the configuration registers */
+void LTC6813_clear_discharge(uint8_t total_ic, // Number of ICs in the system
+                             cell_asic *ic // A two dimensional array that will store the data
+							 )
+{
+    LTC681x_clear_discharge(total_ic,ic);
+}
+
+/* Writes the pwm registers of a LTC6813 daisy chain  */
+void LTC6813_wrpwm(uint8_t total_ic, // Number of ICs in the system
+				   uint8_t pwmReg,  // PWM Register A or B
 				   cell_asic *ic //A two dimensional array of the configuration data that will be written
 				  )
 {
 	LTC681x_wrpwm(total_ic,pwmReg,ic);
 }
 
-//Reads pwm registers of a LTC6813 daisy chain 
+/* Reads pwm registers of a LTC6813 daisy chain */ 
 int8_t LTC6813_rdpwm(uint8_t total_ic, //Number of ICs in the system
-					 uint8_t pwmReg,
+					 uint8_t pwmReg, // PWM Register A or B
 				     cell_asic *ic //A two dimensional array that the function stores the read configuration data.
 				    )
 {
@@ -544,25 +466,26 @@ int8_t LTC6813_rdpwm(uint8_t total_ic, //Number of ICs in the system
 	return(pec_error);
 }
 
-//Writes data in S control register the ltc6813-1  connected in a daisy chain stack. 
-void LTC6813_wrsctrl(uint8_t total_ic, //< number of ICs in the daisy chain
-                     uint8_t sctrl_reg,
-                     cell_asic *ic
+/* Writes data in S control register the ltc6813-1  connected in a daisy chain stack */ 
+void LTC6813_wrsctrl(uint8_t total_ic, // number of ICs in the daisy chain
+                     uint8_t sctrl_reg, // SCTRL Register A or B
+                     cell_asic *ic // A two dimensional array that will store the data
                     )
 {
 	LTC681x_wrsctrl(total_ic, sctrl_reg, ic);
 }
 
-// Reads sctrl registers of a ltc6812 daisy chain   
-int8_t LTC6813_rdsctrl(uint8_t total_ic, //< number of ICs in the daisy chain
-                       uint8_t sctrl_reg,
-                       cell_asic *ic //< a two dimensional array that the function stores the read pwm data
+/* Reads sctrl registers of a LTC6813 daisy chain */   
+int8_t LTC6813_rdsctrl(uint8_t total_ic, // number of ICs in the daisy chain
+                       uint8_t sctrl_reg, // SCTRL Register A or B
+                       cell_asic *ic //< a two dimensional array that the function stores the read data
                       )
 {
 	LTC681x_rdsctrl( total_ic, sctrl_reg,ic );
 }
 
-/* Start Sctrl data communication        
+/* 
+Start Sctrl data communication        
 This command will start the sctrl pulse communication over the spins
 */
 void LTC6813_stsctrl()
@@ -580,84 +503,10 @@ void LTC6813_clrsctrl()
 	LTC681x_clrsctrl();
 }
 
-//Writes the COMM registers of a LTC6813 daisy chain
-void LTC6813_wrcomm(uint8_t total_ic, //The number of ICs being written to
-				    cell_asic *ic //A two dimensional array of the comm data that will be written
-				   )
-{
-	LTC681x_wrcomm(total_ic,ic);
-}
-
-// Reads COMM registers of a LTC6813 daisy chain 
-int8_t LTC6813_rdcomm(uint8_t total_ic, //Number of ICs in the system
-					  cell_asic *ic //A two dimensional array that the function stores the read configuration data.
-				     )
-{
-	int8_t pec_error = 0;
-	LTC681x_rdcomm(total_ic, ic);
-	return(pec_error);
-}
-
-// Shifts data in COMM register out over LTC6813 SPI/I2C port 
-void LTC6813_stcomm()
-{
-    LTC681x_stcomm();
-}
-
-//Helper function to set discharge bit in CFG register
-void LTC6813_set_discharge(int Cell, uint8_t total_ic, cell_asic *ic)
-{
-  for (int i=0; i<total_ic; i++)
-  {
-    if (Cell==0)
-	{
-	  ic[i].configb.tx_data[1] = ic[i].configb.tx_data[1] |(0x04);
-	}
-    else if (Cell<9)
-    {
-      ic[i].config.tx_data[4] = ic[i].config.tx_data[4] | (1<<(Cell-1));
-    }
-    else if (Cell < 13)
-    {
-      ic[i].config.tx_data[5] = ic[i].config.tx_data[5] | (1<<(Cell-9));
-    }
-    else if (Cell<17)
-    {
-      ic[i].configb.tx_data[0] = ic[i].configb.tx_data[0] | (1<<(Cell-9));
-    }
-    else if (Cell<19)
-    {
-      ic[i].configb.tx_data[1] = ic[i].configb.tx_data[1] | (1<<(Cell-17));
-    }
-	else
-	{
-		break;
-	}
-  }
-}
-
-//Clears all of the DCC bits in the configuration registers
-void LTC6813_clear_discharge(uint8_t total_ic,
-                             cell_asic *ic)
-{
-    LTC681x_clear_discharge(total_ic,ic);
-
-}
-
-//Helper function that increments PEC counters
-void LTC6813_check_pec(uint8_t total_ic,uint8_t reg, cell_asic *ic)
-{
-	LTC681x_check_pec(total_ic,reg,ic);
-}
-
-//Helper Function to reset PEC counters
-void LTC6813_reset_crc_count(uint8_t total_ic, cell_asic *ic)
-{
-     LTC681x_reset_crc_count(total_ic,ic);
-}
-
-// Write the 6813 PWM/S ctrl Register B 
-void LTC6813_wrpsb(uint8_t total_ic,cell_asic *ic)
+/* Write the 6813 PWM/Sctrl Register B  */
+void LTC6813_wrpsb(uint8_t total_ic, // Number of ICs in the system
+					cell_asic *ic // A two dimensional array that will store the data
+					)
 {
 	uint8_t cmd[2];
 	uint8_t write_buffer[256];
@@ -680,9 +529,9 @@ void LTC6813_wrpsb(uint8_t total_ic,cell_asic *ic)
 	write_68(total_ic, cmd, write_buffer);	
 }
 
-//Reading pwm/s control register b
+/* Reading the 6813 PWM/Sctrl Register B */
 uint8_t LTC6813_rdpsb(uint8_t total_ic, //< number of ICs in the daisy chain
-                      cell_asic *ic //< a two dimensional array that the function stores the read pwm data
+                      cell_asic *ic //< a two dimensional array that the function stores the read data
                       )	
 {
     uint8_t cmd[4];
@@ -733,18 +582,41 @@ uint8_t LTC6813_rdpsb(uint8_t total_ic, //< number of ICs in the daisy chain
     return(pec_error);
 }
 
-//Mutes the LTC6813 discharge transistors
+/* Writes the COMM registers of a LTC6813 daisy chain */
+void LTC6813_wrcomm(uint8_t total_ic, //The number of ICs being written to
+				    cell_asic *ic //A two dimensional array of the comm data that will be written
+				   )
+{
+	LTC681x_wrcomm(total_ic,ic);
+}
+
+/* Reads COMM registers of a LTC6813 daisy chain */ 
+int8_t LTC6813_rdcomm(uint8_t total_ic, //Number of ICs in the system
+					  cell_asic *ic //A two dimensional array that the function stores the read data.
+				     )
+{
+	int8_t pec_error = 0;
+	LTC681x_rdcomm(total_ic, ic);
+	return(pec_error);
+}
+
+/* Shifts data in COMM register out over LTC6813 SPI/I2C port */ 
+void LTC6813_stcomm(uint8_t len) //Length of data to be transmitted 
+{
+    LTC681x_stcomm(len);
+}
+
+/* Mutes the LTC6813 discharge transistors */
 void LTC6813_mute()
 {
 	uint8_t cmd[2];
 
 	cmd[0] = 0x00;
 	cmd[1] = 0x28;
-
 	cmd_68(cmd);
 }
 
-//Clears the LTC6813 Mute Discharge
+/* Clears the LTC6813 Mute Discharge */
 void LTC6813_unmute()
 {
 	uint8_t cmd[2];
@@ -752,4 +624,160 @@ void LTC6813_unmute()
 	cmd[0] = 0x00;
 	cmd[1] = 0x29;
 	cmd_68(cmd);
+}
+
+/* Helper function that increments PEC counters */
+void LTC6813_check_pec(uint8_t total_ic,//Number of ICs in the system
+						uint8_t reg, //  Type of register 
+						cell_asic *ic // A two dimensional array that will store the data
+						)
+{
+	LTC681x_check_pec(total_ic,reg,ic);
+}
+
+/* Helper Function to reset PEC counters */
+void LTC6813_reset_crc_count(uint8_t total_ic, //Number of ICs in the system
+							 cell_asic *ic // A two dimensional array that will store the data
+							 )
+{
+	LTC681x_reset_crc_count(total_ic,ic);
+}
+
+/* Helper function to initialize CFG variables */
+void LTC6813_init_cfg(uint8_t total_ic, cell_asic *ic)
+{
+   LTC681x_init_cfg(total_ic,ic);
+}
+
+/* Helper function to set CFGR variable */
+void LTC6813_set_cfgr(uint8_t nIC, cell_asic *ic, bool refon, bool adcopt, bool gpio[5],bool dcc[12],bool dcto[4], uint16_t uv, uint16_t  ov)
+{
+    LTC681x_set_cfgr_refon(nIC,ic,refon);
+    LTC681x_set_cfgr_adcopt(nIC,ic,adcopt);
+    LTC681x_set_cfgr_gpio(nIC,ic,gpio);
+    LTC681x_set_cfgr_dis(nIC,ic,dcc);
+	LTC681x_set_cfgr_dcto(nIC,ic,dcto);
+	LTC681x_set_cfgr_uv(nIC, ic, uv);
+    LTC681x_set_cfgr_ov(nIC, ic, ov);
+}
+
+/* Helper function to set the REFON bit */
+void LTC6813_set_cfgr_refon(uint8_t nIC, cell_asic *ic, bool refon) 
+{
+	LTC681x_set_cfgr_refon(nIC,ic,refon);
+}
+
+/* Helper function to set the adcopt bit */
+void LTC6813_set_cfgr_adcopt(uint8_t nIC, cell_asic *ic, bool adcopt)
+{
+	LTC681x_set_cfgr_adcopt(nIC,ic,adcopt);
+}
+
+/* Helper function to set GPIO bits */
+void LTC6813_set_cfgr_gpio(uint8_t nIC, cell_asic *ic,bool gpio[5])
+{  
+	LTC681x_set_cfgr_gpio(nIC,ic,gpio);
+}
+
+/* Helper function to control discharge */
+void LTC6813_set_cfgr_dis(uint8_t nIC, cell_asic *ic,bool dcc[12])
+{  
+	LTC681x_set_cfgr_dis(nIC,ic,dcc);
+}
+
+/* Helper Function to set uv value in CFG register */
+void LTC6813_set_cfgr_uv(uint8_t nIC, cell_asic *ic,uint16_t uv)
+{
+    LTC681x_set_cfgr_uv(nIC, ic, uv);
+}
+
+/* Helper Function to set dcto value in CFG register */
+void LTC6813_set_cfgr_dcto(uint8_t nIC, cell_asic *ic,bool dcto[4])
+{
+    LTC681x_set_cfgr_dcto(nIC, ic, dcto);
+}
+
+/* Helper function to set OV value in CFG register */
+void LTC6813_set_cfgr_ov(uint8_t nIC, cell_asic *ic,uint16_t ov)
+{
+    LTC681x_set_cfgr_ov( nIC, ic, ov);
+}
+
+/* Helper Function to initialize the CFGRB data structures */
+void LTC6813_init_cfgb(uint8_t total_ic,cell_asic *ic)
+{
+	for (uint8_t current_ic = 0; current_ic<total_ic;current_ic++)
+    {
+		for(int j =0; j<6;j++)
+        {
+            ic[current_ic].configb.tx_data[j] = 0;
+        }  
+    }
+}
+
+/* Helper Function to set the configuration register B */ 
+void LTC6813_set_cfgrb(uint8_t nIC, cell_asic *ic,bool fdrf,bool dtmen,bool ps[2],bool gpiobits[4],bool dccbits[7])
+{
+    LTC6813_set_cfgrb_fdrf(nIC,ic,fdrf);
+    LTC6813_set_cfgrb_dtmen(nIC,ic,dtmen);
+    LTC6813_set_cfgrb_ps(nIC,ic,ps);
+    LTC6813_set_cfgrb_gpio_b(nIC,ic,gpiobits);
+	LTC6813_set_cfgrb_dcc_b(nIC,ic,dccbits);
+}
+
+/* Helper function to set the FDRF bit */
+void LTC6813_set_cfgrb_fdrf(uint8_t nIC, cell_asic *ic, bool fdrf) 
+{
+	if(fdrf) ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|0x40;
+	else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&0xBF;
+}
+
+/* Helper function to set the DTMEN bit */
+void LTC6813_set_cfgrb_dtmen(uint8_t nIC, cell_asic *ic, bool dtmen) 
+{
+	if(dtmen) ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|0x08;
+	else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&0xF7;
+}
+	
+/* Helper function to set the PATH SELECT bit */
+void LTC6813_set_cfgrb_ps(uint8_t nIC, cell_asic *ic, bool ps[]) 
+{
+	for(int i =0;i<2;i++)
+	{
+	  if(ps[i])ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|(0x01<<(i+4));
+	  else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&(~(0x01<<(i+4)));
+	}
+}
+
+/*  Helper function to set the gpio bits in configb b register  */
+void LTC6813_set_cfgrb_gpio_b(uint8_t nIC, cell_asic *ic, bool gpiobits[]) 
+{
+	for(int i =0;i<4;i++)
+	{
+	  if(gpiobits[i])ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]|(0x01<<i);
+	  else ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]&(~(0x01<<i));
+	}
+}
+
+/*  Helper function to set the dcc bits in configb b register */ 
+void LTC6813_set_cfgrb_dcc_b(uint8_t nIC, cell_asic *ic, bool dccbits[]) 
+{
+	for(int i =0;i<7;i++)
+	{ 
+		if(i==0)
+		{
+			if(dccbits[i])ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|0x04;
+			else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&0xFB;
+		}
+		if(i>0 and i<5)
+		{	
+			if(dccbits[i])ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]|(0x01<<(i+3));
+			else ic[nIC].configb.tx_data[0] = ic[nIC].configb.tx_data[0]&(~(0x01<<(i+3)));
+		}
+		if(i>4 and i<7)
+		{
+			if(dccbits[i])ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]|(0x01<<(i-5));
+			else ic[nIC].configb.tx_data[1] = ic[nIC].configb.tx_data[1]&(~(0x01<<(i-5)));	
+		}
+	}
 }

--- a/LTSketchbook/libraries/LTC6813/LTC6813.h
+++ b/LTSketchbook/libraries/LTC6813/LTC6813.h
@@ -1,7 +1,7 @@
 /*! LTC6813: Multicell Battery Monitors
 *
 *@verbatim
-*The LTC6813 is multicell battery stack monitor that measures up to 18 series 
+*The LTC6813 is multi-cell battery stack monitor that measures up to 18 series 
 *connected battery cells with a total measurement error of less than 2.2mV. 
 *The cell measurement range of 0V to 5V makes the LTC6813 suitable for most 
 *battery chemistries. All 18 cell voltages can be captured in 290uS, and lower 
@@ -64,453 +64,574 @@
 #define AUX 2
 #define STAT 3
 
-/*! Helper function to initialize register limits */
-//!@return void
+/*!
+ Helper function to initialize register limits 
+ @return void
+ */
 void LTC6813_init_reg_limits(uint8_t total_ic, //!< Number of ICs in the system
 							cell_asic *ic //!< A two dimensional array that will store the data
 							);
-
-/*! Helper Function to initialize the CFGR data structures*/
-//!@return void
-void LTC6813_init_cfg(uint8_t total_ic, //!< Number of ICs in the system
-                      cell_asic *ic //!< A two dimensional array that will store the data
-					  );
-
-/*! Helper function to set appropriate bits in CFGR register based on bit function*/
-//!@return void
-void LTC6813_set_cfgr(uint8_t nIC,  //!< the number of ICs in the daisy chain
-                      cell_asic *ic, //!< A two dimensional array that will store the data
-                      bool refon, //!< the REFON bit
-                      bool adcopt, //!< the ADCOPT bit 
-                      bool gpio[5], //!< the GPIO bits
-                      bool dcc[12], //!< the DCC bits
-					  bool dcto[4], //!< the Dcto bits
-					  uint16_t uv, //!< the UV value
-					  uint16_t  ov //!< the OV value
-					  );
-
-/*! Helper function to turn the refon bit HIGH or LOW*/
-//!@return void
-void LTC6813_set_cfgr_refon(uint8_t nIC, //!< the number of ICs in the daisy chain
-                            cell_asic *ic, //!< A two dimensional array that will store the data
-                            bool refon //!< the REFON bit
-							);
-                            
-/*! Helper function to turn the ADCOPT bit HIGH or LOW*/
-//!@return void
-void LTC6813_set_cfgr_adcopt(uint8_t nIC, //!< the number of ICs in the daisy chain
-                             cell_asic *ic, //!< A two dimensional array that will store the data
-                             bool adcopt //!< the ADCOPT bit
-							 );
-
-/*! Helper function to turn the GPIO bits HIGH or LOW*/
-//!@return void
-void LTC6813_set_cfgr_gpio(uint8_t nIC, //!< the number of ICs in the daisy chain
-                           cell_asic *ic, //!< A two dimensional array that will store the data
-                           bool gpio[] //!< the GPIO bits
-						   );
-
-/*! Helper function to turn the DCC bits HIGH or LOW*/
-//!@return void
-void LTC6813_set_cfgr_dis(uint8_t nIC, //!< the number of ICs in the daisy chain
-                          cell_asic *ic, //!< A two dimensional array that will store the data
-                          bool dcc[] //!< the DCC bits
-						  );
-						  
-/*!  Helper function to set uv field in CFGRA register*/
-//!@return void
-void LTC6813_set_cfgr_uv(uint8_t nIC, //!< the number of ICs in the daisy chain
-                         cell_asic *ic, //!< A two dimensional array that will store the data
-                         uint16_t uv //!< the UV value
-						 );
-						 
-/*!  Helper function to set DCTO  field in CFGRA register*/
-//!@return void
-void LTC6813_set_cfgr_dcto(uint8_t nIC, //!< the number of ICs in the daisy chain
-                         cell_asic *ic, //!< A two dimensional array that will store the data
-                         bool dcto[4] //!< the Dcto bits
-						 );
-                         
-/*!  Helper function to set ov field in CFGRA register*/
-//!@return void
-void LTC6813_set_cfgr_ov(uint8_t nIC, //!< the number of ICs in the daisy chain
-                         cell_asic *ic, //!< A two dimensional array that will store the data
-                         uint16_t ov //!< the OV value
-						 );
-
-/*! Helper Function to initialize the CFGR B data structures*/
-//!@return void
-void LTC6813_init_cfgb(uint8_t total_ic, //!< Number of ICs in the system
-                      cell_asic *ic //!< A two dimensional array that will store the data
-					  );
-					  
-/*! Helper function to set appropriate bits in CFGR register based on bit function*/
-//!@return void
-void LTC6813_set_cfgrb(uint8_t nIC, //!< the number of ICs in the daisy chain
-                      cell_asic *ic, //!< A two dimensional array that will store the data
-					  bool fdrf, //!< the FDRF bit
-                      bool dtmen, //!< the DTMEN bit
-                      bool ps[2], //!< Path selection bits
-                      bool gpiobits[4], //!< the GPIO bits
-					  bool dccbits[7] //!< the DCC bits
-					  );
-					  
-/*! Helper function to turn the fdrf bit HIGH or LOW*/
-//!@return void
-void LTC6813_set_cfgrb_fdrf(uint8_t nIC, //!< the number of ICs in the daisy chain
-                            cell_asic *ic, //!< A two dimensional array that will store the data
-                            bool fdrf //!< the FDRF bit
-							);
 							
-/*! Helper function to turn the DTMEN bit HIGH or LOW*/
-//!@return void
-void LTC6813_set_cfgrb_dtmen(uint8_t nIC, //!< the number of ICs in the daisy chain
-                            cell_asic *ic, //!< A two dimensional array that will store the data
-                            bool dtmen //!< the DTMEN bit
-							);
-							
-/*! Helper function to turn the Path Select bit HIGH or LOW*/
-//!@return void
-void LTC6813_set_cfgrb_ps(uint8_t nIC, //!< the number of ICs in the daisy chain
-                            cell_asic *ic, //!< A two dimensional array that will store the data
-                            bool ps[] //!< Path selection bits
-							);
-							
-/*! Helper function to turn the GPIO bit HIGH or LOW*/
-//!@return void
-void LTC6813_set_cfgrb_gpio_b(uint8_t nIC, //!< the number of ICs in the daisy chain
-                            cell_asic *ic, //!< A two dimensional array that will store the data
-                            bool gpiobits[] //!< the GPIO bits
-							);
-							
-/*! Helper function to turn the dcc bit HIGH or LOW*/
-//!@return void
-void LTC6813_set_cfgrb_dcc_b(uint8_t nIC, //!< the number of ICs in the daisy chain
-                            cell_asic *ic, //!< A two dimensional array that will store the data
-                            bool dccbits[] //!< the DCC bits
-							); 
-							
-/*! Write the LTC6813 configuration register A*/
-//!@return void
-void LTC6813_wrcfg(uint8_t nIC, //!< Number of ICs in the system
-                   cell_asic *ic //!< a two dimensional array of the configuration data that will be written
+/*!
+ Write the LTC6813 configuration register A
+ @return void
+ */
+void LTC6813_wrcfg(uint8_t total_ic, //!< Number of ICs in the system
+                   cell_asic *ic //!< A two dimensional array of the configuration data that will be written
                    );
 
-/*! Write the LTC6813 configuration register B*/
-//!@return void
-void LTC6813_wrcfgb(uint8_t nIC, //!< Number of ICs in the system
-                   cell_asic *ic //!< a two dimensional array of the configuration data that will be written
+/*!
+ Write the LTC6813 configuration register B
+ @return void  
+ */
+void LTC6813_wrcfgb(uint8_t total_ic, //!< Number of ICs in the system
+                   cell_asic *ic //!< A two dimensional array of the configuration data that will be written
                     );
 					
-/*! Reads configuration register A of a LTC6813 daisy chain
-@return int8_t, PEC Status.
- 0: Data read back has matching PEC
--1: Data read back has incorrect PEC */
-int8_t LTC6813_rdcfg(uint8_t nIC, //!< Number of ICs in the system
-                     cell_asic *ic //!< a two dimensional array that the function stores the read configuration data
+/*!
+ Reads configuration register A of a LTC6813 daisy chain
+ @return int8_t, PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC  
+ */
+int8_t LTC6813_rdcfg(uint8_t total_ic, //!< Number of ICs in the system
+                     cell_asic *ic //!< A two dimensional array that the function stores the read configuration data
                     );
 
-/*! Reads configuration register B of a LTC6813 daisy chain
-@return int8_t, PEC Status.
- 0: Data read back has matching PEC
--1: Data read back has incorrect PEC */
-int8_t LTC6813_rdcfgb(uint8_t nIC, //!< Number of ICs in the system
-                     cell_asic *ic //!< a two dimensional array that the function stores the read configuration data
+/*!
+ Reads configuration register B of a LTC6813 daisy chain
+ @return int8_t, pec_error PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC 
+ */  
+int8_t LTC6813_rdcfgb(uint8_t total_ic, //!< Number of ICs in the system
+                     cell_asic *ic //!< A two dimensional array that the function stores the read configuration data
                     );
 					
-/*! Starts cell voltage conversion */
-//!@return void
+/*!
+ Starts cell voltage conversion  
+ @return void 
+ */
 void LTC6813_adcv(uint8_t MD, //!< ADC Conversion Mode
                   uint8_t DCP, //!< Controls if Discharge is permitted during conversion
                   uint8_t CH //!< Sets which Cell channels are converted
                  );
-				 
-/*! Reads and parses the LTC6813 cell voltage registers.
-@return uint8_t, PEC Status.
-0: No PEC error detected
--1: PEC error detected, retry read 
-*/
-uint8_t LTC6813_rdcv(uint8_t reg, //!< controls which cell voltage register is read back.
-                     uint8_t total_ic, //!< the number of ICs in the daisy chain(-1 only)
-                     cell_asic *ic //!< array of the parsed cell codes from lowest to highest.
-                    );
-					
-/*! Start a GPIO and Vref2 Conversion */
-//!@return void
+
+/*!
+ Start a GPIO and Vref2 Conversion  
+ @return void 
+ */
 void LTC6813_adax(uint8_t MD, //!< ADC Conversion Mode
 				  uint8_t CHG //!< Sets which GPIO channels are converted
                   );
-				  
-/*! Reads and parses the LTC6813 auxiliary registers.
-@return  int8_t, PEC Status
-  0: No PEC error detected
- -1: PEC error detected, retry read 
+
+/*!
+ Start a Status ADC Conversion  
+ @return void 
  */
-int8_t LTC6813_rdaux(uint8_t reg, //!< controls which GPIO voltage register is read back
-                     uint8_t nIC, //!< the number of ICs in the daisy chain
-                     cell_asic *ic //!< A two dimensional array of the parsed gpio voltage codes
-                    );
-					
-/*! Start a Status ADC Conversion */
-//!@return void
 void LTC6813_adstat( uint8_t MD, //!< ADC Conversion Mode
 					 uint8_t CHST //!< Sets which Stat channels are converted
-);					
+					);	
 
-/*! Reads and parses the LTC6813 stat registers.
-@return  int8_t, PEC Status
-  0: No PEC error detected
- -1: PEC error detected, retry read
-*/
-int8_t LTC6813_rdstat(uint8_t reg, //!< Determines which Stat  register is read back.
-                      uint8_t total_ic,//!< Number of ICs in the system
-                      cell_asic *ic //!< A two dimensional array that will store the data
-                     );	
-					   
-/*! Starts cell voltage  and GPIO 1&2 conversion */
-//!@return void
+/*!
+ Starts cell voltage  and GPIO 1 & 2 conversion  
+ @return void 
+ */
 void LTC6813_adcvax(uint8_t MD, //!< ADC Conversion Mode
 					uint8_t DCP //!< Controls if Discharge is permitted during conversion
 					);
 
-/*! Starts cell voltage and SOC conversion */
-//!@return void
+/*! Starts cell voltage and Sum of cells conversion  
+ @return void 
+ */
 void LTC6813_adcvsc(uint8_t MD, //!< ADC Conversion Mode
 					uint8_t DCP //!< Controls if Discharge is permitted during conversion
 					);
 					
-/*! Starts the Mux Decoder diagnostic self test
+/*!
+ Reads and parses the LTC6813 cell voltage registers.
+ @return uint8_t, pec_error PEC Status.
+ 0: No PEC error detected
+ -1: PEC error detected, retry read  
+ */
+uint8_t LTC6813_rdcv(uint8_t reg, //!< Controls which cell voltage register is read back.
+                     uint8_t total_ic, //!< The number of ICs in the daisy chain
+                     cell_asic *ic //!< Array of the parsed cell codes from lowest to highest.
+                    );
+									  
+/*! Reads and parses the LTC6813 auxiliary registers.
+ @return  int8_t, pec_error PEC Status
+   0: No PEC error detected
+  -1: PEC error detected, retry read
+  */ 
+int8_t LTC6813_rdaux(uint8_t reg, //!< Controls which GPIO voltage register is read back
+                     uint8_t nIC, //!< The number of ICs in the daisy chain
+                     cell_asic *ic //!< A two dimensional array of the parsed gpio voltage codes
+                    );
+					
+/*!
+ Reads and parses the LTC6813 stat registers.
+ @return  int8_t, pec_error PEC Status
+  0: No PEC error detected
+  -1: PEC error detected, retry read 
+  */
+int8_t LTC6813_rdstat(uint8_t reg, //!< Determines which Stat  register is read back.
+                      uint8_t total_ic,//!< Number of ICs in the system
+                      cell_asic *ic //!< A two dimensional array that will store the data
+                     );	
+
+/*!
+  Sends the poll ADC command
+  @returns 1 byte read back after a pladc command. If the byte is not 0xFF ADC conversion has completed 
+  */
+uint8_t LTC6813_pladc();
+
+/*!
+  This function will block operation until the ADC has finished it's conversion
+  @returns uint32_t, counter The approximate time it took for the ADC function to complete. 
+  */
+uint32_t LTC6813_pollAdc();
+
+/*!
+ Clears the LTC6813 cell voltage registers  
+ @return void 
+ */
+void LTC6813_clrcell();
+
+/*!
+ Clears the LTC6813 Auxiliary registers  
+ @return void 
+ */
+void LTC6813_clraux();
+					 
+/*!
+ Clears the LTC6813 Stat registers  
+ @return void 
+ */
+void LTC6813_clrstat();
+
+/*!
+ Starts the Mux Decoder diagnostic self test
  Running this command will start the Mux Decoder Diagnostic Self Test
  This test takes roughly 1mS to complete. The MUXFAIL bit will be updated,
  the bit will be set to 1 for a failure and 0 if the test has been passed.
-*/
-//!@return void
+ @return void 
+ */
 void LTC6813_diagn();
 
-/*! Starts cell voltage self test conversion */
-//!@return void
+/*!
+ Starts cell voltage self test conversion  
+ @return void 
+ */
 void LTC6813_cvst(uint8_t MD, //!< ADC Conversion Mode
 				  uint8_t ST //!< Self Test Mode
 				 );
 				 
-/*! Start an Auxiliary Register Self Test Conversion */
-//!@return void
+/*!
+ Start an Auxiliary Register Self Test Conversion  
+ @return void 
+ */
 void LTC6813_axst(uint8_t MD, //!< ADC Conversion Mode
 				  uint8_t ST //!< Sets if self test 1 or 2 is run
 				 );
 				 
-/*! Start a Status Register Self Test Conversion */
-//!@return void
+/*!
+ Start a Status Register Self Test Conversion  
+ @return void 
+ */
 void LTC6813_statst(uint8_t MD, //!< ADC Conversion Mode
 					uint8_t ST //!< Sets if self test 1 or 2 is run
 					);
-					
-/*! Helper function that runs the ADC Self Tests*/
-//!@return int16_t, error
-//! Number of errors detected.
-int16_t LTC6813_run_cell_adc_st(uint8_t adc_reg, //!<  Type of register
-                                uint8_t total_ic, //!< Number of ICs in the system
-                                cell_asic *ic, //!< A two dimensional array that will store the data
-								uint8_t md, //!< ADC Mode
-								bool adcopt //!< the adcopt bit in the configuration register
-								);
-								
-/*! Starts cell voltage overlap conversion */
-//!@return void
+
+/*!
+ Starts cell voltage overlap conversion  
+ @return void 
+ */
 void LTC6813_adol(uint8_t MD, //!< ADC Conversion Mode
 				  uint8_t DCP //!< Discharge permitted during conversion
 				 );	
-				 
-/*! Helper Function that runs the ADC Overlap test*/
-//!@return uint16_t, error
-//! 0: Pass
-//!-1: False, Error detected
-uint16_t LTC6813_run_adc_overlap(uint8_t total_ic, //!< Number of ICs in the system
-                                 cell_asic *ic //!< A two dimensional array that will store the data
-								 );
-								 
-/*! Start an open wire Conversion
-*/
-//!@return void
-void LTC6813_adow(uint8_t MD, //!< ADC Conversion Mode
-				  uint8_t PUP,//!< Controls if Discharge is permitted during 
-				  uint8_t CH, //!< Sets which Cell channels are converted
-				  uint8_t DCP //!< Discharge permitted during conversion
-				 );	
-				 
-/*! start GPIOs open wire ADC conversion */
-//!@return void
-void LTC6813_axow(uint8_t MD, //!< ADC Mode
-				  uint8_t PUP //!< Discharge Permit
-				  );
-				  
-/*! Runs open wire for GPIOs*/
-//!@return void
-void LTC6813_run_gpio_openwire(uint8_t total_ic, //!< Number of ICs in the system
-								cell_asic *ic //!< A two dimensional array that will store the data
-								);
-				  
-/*! Helper function that runs the data sheet algorithm for open wire for single cell detection*/
-//!@return void
-void LTC6813_run_openwire_single(uint8_t total_ic, //!< Number of ICs in the system
-								 cell_asic *ic //!< A two dimensional array that will store the data
-								 );
 
-/*! Helper function that runs open wire for multiple cell and two consecutive cells detection*/
-//!@return void
-void LTC6813_run_openwire_multi(uint8_t total_ic, //!< Number of ICs in the system
-								cell_asic *ic //!< A two dimensional array that will store the data
-								);								 
-
-/*! Start an GPIO Redundancy test */
-//!@return void
+/*!
+ Start an GPIO Redundancy test  
+ @return void 
+ */
 void LTC6813_adaxd(uint8_t MD, //!< ADC Conversion Mode
 				   uint8_t CHG //!< Sets which GPIO channels are converted
 				   );
 
-/*!  Start a Status register redundancy test Conversion */
-//!@return void
+/*!
+ Start a Status register redundancy test Conversion  
+ @return void 
+  */
 void LTC6813_adstatd(uint8_t MD, //!< ADC Mode
 					 uint8_t CHST //!< Sets which Status channels are converted
-					);	
-					
-/*! Helper function that runs the ADC Digital Redundancy commands and checks output for errors*/
-//!@return int16_t, error
+					);
+				 
+/*!
+ Helper function that runs the ADC Self Tests 
+ @return int16_t, error Number of errors detected. 
+ */
+int16_t LTC6813_run_cell_adc_st(uint8_t adc_reg, //!< Type of register
+                                uint8_t total_ic, //!< Number of ICs in the system
+                                cell_asic *ic, //!< A two dimensional array that will store the data
+								uint8_t md, //!< ADC Mode
+								bool adcopt //!< The adcopt bit in the configuration register
+								);
+												 
+/*!
+ Helper Function that runs the ADC Overlap test 
+ @return uint16_t, error
+  0: Pass
+ -1: False, Error detected 
+ */
+uint16_t LTC6813_run_adc_overlap(uint8_t total_ic, //!< Number of ICs in the system
+                                 cell_asic *ic //!< A two dimensional array that will store the data
+								 );
+
+/*!
+ Helper function that runs the ADC Digital Redundancy commands and checks output for errors 
+ @return int16_t, error Number of errors detected. 
+ */
 int16_t LTC6813_run_adc_redundancy_st(uint8_t adc_mode, //!< ADC Mode
                                       uint8_t adc_reg, //!< Type of register
                                       uint8_t total_ic, //!< Number of ICs in the system
                                       cell_asic *ic //!< A two dimensional array that will store the data
 									  );
-									  
-//! Sends the poll ADC command
-//! @returns 1 byte read back after a pladc command. If the byte is not 0xFF ADC conversion has completed
-uint8_t LTC6813_pladc();
+								 
+/*!
+ Start an open wire Conversion
+ @return void 
+ */
+void LTC6813_adow(uint8_t MD, //!< ADC Conversion Mode
+				  uint8_t PUP,//!< Pull up/Pull down current
+				  uint8_t CH, //!< Sets which Cell channels are converted
+				  uint8_t DCP //!< Discharge permitted during conversion
+				 );	
+				 
+/*!
+ Start GPIOs open wire ADC conversion  
+ @return void 
+ */
+void LTC6813_axow(uint8_t MD, //!< ADC Mode
+				  uint8_t PUP //!< Pull up/Pull down current
+				  );
+				  				  
+/*!
+ Helper function that runs the data sheet algorithm for open wire for single cell detection 
+ @return void 
+ */
+void LTC6813_run_openwire_single(uint8_t total_ic, //!< Number of ICs in the system
+								 cell_asic *ic //!< A two dimensional array that will store the data
+								 );
 
-//! This function will block operation until the ADC has finished it's conversion
-//! @returns the approximate time it took for the ADC function to complete.
-uint32_t LTC6813_pollAdc();
+/*!
+ Helper function that runs open wire for multiple cell and two consecutive cells detection 
+ @return void 
+ */
+void LTC6813_run_openwire_multi(uint8_t total_ic, //!< Number of ICs in the system
+								cell_asic *ic //!< A two dimensional array that will store the data
+								);								 
 
-/*! Clears the LTC6813 cell voltage registers */
-//!@return void
-void LTC6813_clrcell();
-
-/*! Clears the LTC6813 Auxiliary registers */
-//!@return void
-void LTC6813_clraux();
-
-/*! Clears the LTC6813 Stat registers */
-//!@return void
-void LTC6813_clrstat();
-
-/*! Write the LTC6813 PWM register */
-//!@return void
-void LTC6813_wrpwm(uint8_t nIC, //!< number of ICs in the daisy chain
-                   uint8_t pwmReg, //!<  PWM  Register A or B
-                   cell_asic *ic //!< A two dimensional array that will store the data
-                  );
-				  
-/*! Reads pwm registers of a LTC6813 daisy chain */
-//!@return int8_t, PEC Status.
-//!  0: Data read back has matching PEC
-//! -1: Data read back has incorrect PEC
-int8_t LTC6813_rdpwm(uint8_t nIC, //!< number of ICs in the daisy chain
-                     uint8_t pwmReg, //! PWM  Register A or B
-                     cell_asic *ic //!< A two dimensional array that will store the data
-                    );
-
-/*! Write the LTC6813 Sctrl register */
-//!@return void
-void LTC6813_wrsctrl(uint8_t nIC, //!< number of ICs in the daisy chain
-                     uint8_t sctrl_reg,//! SCTRL  Register A or B
-                     cell_asic *ic //!< A two dimensional array that will store the data
-                    );
-
-/*! Reads sctrl registers of a LTC6813 daisy chain
-@return int8_t, PEC Status.
-  0: Data read back has matching PEC
-  -1: Data read back has incorrect PEC
-*/
-int8_t LTC6813_rdsctrl(uint8_t nIC, //!< number of ICs in the daisy chain
-                       uint8_t sctrl_reg,//! SCTRL  Register A or B
-                       cell_asic *ic  //!< A two dimensional array that will store the data
-                      );
-					  
-/*! Start Sctrl data communication
-This command will start the sctrl pulse communication over the spins
-*/
-//!@return void
-void LTC6813_stsctrl();
-
-/*! Clears the LTC6813 Sctrl registers */
-//!@return void
-void LTC6813_clrsctrl();
-
-/*! Write the LTC6813 COMM register */
-//!@return void
-void LTC6813_wrcomm(uint8_t total_ic, //!< Number of ICs in the daisy chain
-                    cell_asic *ic //!< A two dimensional array of the comm data that will be written
-                   );
-
-/*! Reads comm registers of a LTC6813 daisy chain
-@return int8_t, PEC Status.
-  0: Data read back has matching PEC
- -1: Data read back has incorrect PEC
-*/
-int8_t LTC6813_rdcomm(uint8_t total_ic, //!< number of ICs in the daisy chain
-                      cell_asic *ic //!< Two dimensional array that the function stores the read comm data.
-                     );
-
-/*! Issues a stcomm command and clocks data out of the COMM register */
-//!@return void
-void LTC6813_stcomm();
-
-/*! Helper Function to Set DCC bits in the CFGR Registers*/ 
-//!@return void                  
+/*!
+ Runs open wire for GPIOs 
+ @return void 
+ */
+void LTC6813_run_gpio_openwire(uint8_t total_ic, //!< Number of ICs in the system
+								cell_asic *ic //!< A two dimensional array that will store the data
+								);	
+					
+/*!
+ Helper Function to Set DCC bits in the CFGR Registers  
+ @return void   
+ */                
 void LTC6813_set_discharge(int Cell, //!< The cell to be discharged
                            uint8_t total_ic, //!< Number of ICs in the system
                            cell_asic *ic //!< A two dimensional array that will store the data
 						   );
 						   
-/*! Helper Function to clear DCC bits in the CFGR Registers*/
-//!@return void
+/*!
+ Helper Function to clear DCC bits in the CFGR Registers 
+ @return void 
+ */
 void LTC6813_clear_discharge(uint8_t total_ic, //!< Number of ICs in the system
 							 cell_asic *ic //!< A two dimensional array that will store the data
-							 );                   
+							 ); 
+
+/*!
+ Write the LTC6813 PWM register  
+ @return void 
+ */
+void LTC6813_wrpwm(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                   uint8_t pwmReg, //!<  PWM  Register A or B
+                   cell_asic *ic //!< A two dimensional array that will store the data
+                  );
+				  
+/*!
+ Reads pwm registers of a LTC6813 daisy chain  
+ @return int8_t, pec_error PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC 
+  */
+int8_t LTC6813_rdpwm(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                     uint8_t pwmReg, //!< PWM  Register A or B
+                     cell_asic *ic //!< A two dimensional array that will store the data
+                    );
+
+/*!
+ Write the LTC6813 Sctrl register  
+ @return void 
+ */
+void LTC6813_wrsctrl(uint8_t nIC, //!< Number of ICs in the daisy chain
+                     uint8_t sctrl_reg,//! SCTRL  Register A or B
+                     cell_asic *ic //!< A two dimensional array that will store the data
+                    );
+
+/*!
+ Reads sctrl registers of a LTC6813 daisy chain
+ @return int8_t, pec_error PEC Status.
+   0: Data read back has matching PEC
+   -1: Data read back has incorrect PEC 
+   */
+int8_t LTC6813_rdsctrl(uint8_t nIC, //!< Number of ICs in the daisy chain
+                       uint8_t sctrl_reg,//!< SCTRL Register A or B
+                       cell_asic *ic  //!< A two dimensional array that will store the data
+                      );
+					  
+/*!
+ Start Sctrl data communication
+ This command will start the sctrl pulse communication over the spins
+ @return void 
+ */
+void LTC6813_stsctrl();
+
+/*!
+ Clears the LTC6813 Sctrl registers  
+ @return void 
+ */
+void LTC6813_clrsctrl();
+
+/*!
+ Write the 6813 PWM/Sctrl Register B  
+ @return void 
+ */
+void LTC6813_wrpsb(uint8_t total_ic, //!< Number of ICs in the system
+					cell_asic *ic //!< A two dimensional array that will store the data
+					);
+					
+/*!
+ Reading pwm/s control register B 
+ @return uint8_t, pec_error PEC Status.
+   0: Data read back has matching PEC
+  -1: Data read back has incorrect PEC 
+  */
+uint8_t LTC6813_rdpsb(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                       cell_asic *ic //!< A two dimensional array that the function stores the read data
+                      );	
+
+/*!
+ Write the LTC6813 COMM register  
+ @return void 
+ */
+void LTC6813_wrcomm(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                    cell_asic *ic //!< A two dimensional array of the comm data that will be written
+                   );
+
+/*!
+ Reads comm registers of a LTC6813 daisy chain
+ @return int8_t, pec_error PEC Status.
+   0: Data read back has matching PEC
+  -1: Data read back has incorrect PEC 
+  */
+int8_t LTC6813_rdcomm(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                      cell_asic *ic //!< Two dimensional array that the function stores the read comm data.
+                     );
+
+/*!
+ Issues a stcomm command and clocks data out of the COMM register  
+ @return void 
+ */
+void LTC6813_stcomm(uint8_t len //!< Length of data to be transmitted 
+					);
                                  
-/*! Helper Function that counts overall PEC errors and register/IC PEC errors*/
-//!@return void
+/*!
+ Mutes the LTC6813 discharge transistors  
+ @return void 
+ */
+void LTC6813_mute();
+
+/*!
+ Clears the LTC6813 Mute Discharge  
+ @return void 
+ */
+void LTC6813_unmute();
+
+/*!
+ Helper Function that counts overall PEC errors and register/IC PEC errors 
+ @return void 
+ */
 void LTC6813_check_pec(uint8_t total_ic, //!< Number of ICs in the system
                        uint8_t reg, //!<  Type of register
                        cell_asic *ic //!< A two dimensional array that will store the data
 					   );
 
-/*! Helper Function that resets the PEC error counters */
-//!@return void
+/*!
+ Helper Function that resets the PEC error counters  
+ @return void 
+ */
 void LTC6813_reset_crc_count(uint8_t total_ic, //!< Number of ICs in the system
                              cell_asic *ic //!< A two dimensional array that will store the data
 							 );
-
-/*! Write the 6813 PWM/Sctrl Register B */
-//!@return void
-void LTC6813_wrpsb(uint8_t total_ic, //!< Number of ICs in the system
-					cell_asic *ic //!< A two dimensional array that will store the data
-					);
-					
-/*! Reading pwm/s control register B 
-@return uint8_t, PEC Status.
-  0: Data read back has matching PEC
- -1: Data read back has incorrect PEC
- */
-uint8_t LTC6813_rdpsb(uint8_t total_ic, //!< number of ICs in the daisy chain
-                       cell_asic *ic //!< a two dimensional array that the function stores the read pwm data
-                      );	
 					  
-/*! Mutes the LTC6813 discharge transistors */
-//!@return void
-void LTC6813_mute();
+/*!
+ Helper Function to initialize the CFGR data structures 
+ @return void 
+ */
+void LTC6813_init_cfg(uint8_t total_ic, //!< Number of ICs in the system
+                      cell_asic *ic //!< A two dimensional array that will store the data
+					  );
 
-/*! Clears the LTC6813 Mute Discharge */
-//!@return void
-void LTC6813_unmute();
+/*!
+ Helper function to set appropriate bits in CFGR register based on bit function 
+ @return void 
+ */
+void LTC6813_set_cfgr(uint8_t nIC,  //!< The number of ICs in the daisy chain
+                      cell_asic *ic, //!< A two dimensional array that will store the data
+                      bool refon, //!< The REFON bit
+                      bool adcopt, //!< The ADCOPT bit 
+                      bool gpio[5], //!< The GPIO bits
+                      bool dcc[12], //!< The DCC bits
+					  bool dcto[4], //!< The Dcto bits
+					  uint16_t uv, //!< The UV value
+					  uint16_t  ov //!< The OV value
+					  );
+
+/*!
+ Helper function to turn the REFON bit HIGH or LOW 
+ @return void 
+ */
+void LTC6813_set_cfgr_refon(uint8_t nIC, //!< The number of ICs in the daisy chain
+                            cell_asic *ic, //!< A two dimensional array that will store the data
+                            bool refon //!< The REFON bit
+							);
+                            
+/*!
+ Helper function to turn the ADCOPT bit HIGH or LOW 
+ @return void 
+ */
+void LTC6813_set_cfgr_adcopt(uint8_t nIC, //!< The number of ICs in the daisy chain
+                             cell_asic *ic, //!< A two dimensional array that will store the data
+                             bool adcopt //!< The ADCOPT bit
+							 );
+
+/*!
+ Helper function to turn the GPIO bits HIGH or LOW 
+ @return void 
+ */
+void LTC6813_set_cfgr_gpio(uint8_t nIC, //!< The number of ICs in the daisy chain
+                           cell_asic *ic, //!< A two dimensional array that will store the data
+                           bool gpio[] //!< The GPIO bits
+						   );
+
+/*!
+ Helper function to turn the DCC bits HIGH or LOW 
+ @return void 
+ */
+void LTC6813_set_cfgr_dis(uint8_t nIC, //!< The number of ICs in the daisy chain
+                          cell_asic *ic, //!< A two dimensional array that will store the data
+                          bool dcc[] //!< The DCC bits
+						  );
+						  
+/*!
+ Helper function to set UV field in CFGRA register 
+ @return void 
+ */
+void LTC6813_set_cfgr_uv(uint8_t nIC, //!< The number of ICs in the daisy chain
+                         cell_asic *ic, //!< A two dimensional array that will store the data
+                         uint16_t uv //!< The UV value
+						 );
+						 
+/*!
+ Helper function to set DCTO  field in CFGRA register 
+ @return void 
+ */
+void LTC6813_set_cfgr_dcto(uint8_t nIC, //!< The number of ICs in the daisy chain
+                         cell_asic *ic, //!< A two dimensional array that will store the data
+                         bool dcto[4] //!< The Dcto bits
+						 );
+                         
+/*!
+ Helper function to set OV field in CFGRA register 
+ @return void 
+ */
+void LTC6813_set_cfgr_ov(uint8_t nIC, //!< The number of ICs in the daisy chain
+                         cell_asic *ic, //!< A two dimensional array that will store the data
+                         uint16_t ov //!< The OV value
+						 );
+
+/*!
+ Helper Function to initialize the CFGR B data structures 
+ @return void 
+ */
+void LTC6813_init_cfgb(uint8_t total_ic, //!< Number of ICs in the system
+                      cell_asic *ic //!< A two dimensional array that will store the data
+					  );
+					  
+/*!
+ Helper function to set appropriate bits in CFGR register based on bit function 
+ @return void 
+ */
+void LTC6813_set_cfgrb(uint8_t nIC, //!< The number of ICs in the daisy chain
+                      cell_asic *ic, //!< A two dimensional array that will store the data
+					  bool fdrf, //!< The FDRF bit
+                      bool dtmen, //!< The DTMEN bit
+                      bool ps[2], //!< Path selection bits
+                      bool gpiobits[4], //!< The GPIO bits
+					  bool dccbits[7] //!< The DCC bits
+					  );
+					  
+/*!
+ Helper function to turn the FDRF bit HIGH or LOW 
+ @return void 
+ */
+void LTC6813_set_cfgrb_fdrf(uint8_t nIC, //!< The number of ICs in the daisy chain
+                            cell_asic *ic, //!< A two dimensional array that will store the data
+                            bool fdrf //!< The FDRF bit
+							);
+							
+/*!
+ Helper function to turn the DTMEN bit HIGH or LOW 
+ @return void 
+ */
+void LTC6813_set_cfgrb_dtmen(uint8_t nIC, //!< The number of ICs in the daisy chain
+                            cell_asic *ic, //!< A two dimensional array that will store the data
+                            bool dtmen //!< The DTMEN bit
+							);
+							
+/*!
+ Helper function to turn the Path Select bit HIGH or LOW 
+ @return void 
+ */
+void LTC6813_set_cfgrb_ps(uint8_t nIC, //!< The number of ICs in the daisy chain
+                            cell_asic *ic, //!< A two dimensional array that will store the data
+                            bool ps[] //!< Path selection bits
+							);
+							
+/*!
+ Helper function to turn the GPIO bit HIGH or LOW 
+ @return void 
+ */
+void LTC6813_set_cfgrb_gpio_b(uint8_t nIC, //!< The number of ICs in the daisy chain
+                            cell_asic *ic, //!< A two dimensional array that will store the data
+                            bool gpiobits[] //!< The GPIO bits
+							);
+							
+/*!
+ Helper function to turn the DCC bit HIGH or LOW 
+ @return void 
+ */
+void LTC6813_set_cfgrb_dcc_b(uint8_t nIC, //!< The number of ICs in The daisy chain
+                            cell_asic *ic, //!< A two dimensional array that will store The data
+                            bool dccbits[] //!< The DCC bits
+							); 
 
 #endif

--- a/LTSketchbook/libraries/LTC681x/LTC681x.cpp
+++ b/LTSketchbook/libraries/LTC681x/LTC681x.cpp
@@ -46,54 +46,59 @@
 #include "LTC681x.h"
 #include "bms_hardware.h"
 
-
 #ifdef LINDUINO
 #include <Arduino.h>
 #endif
 
-//Wake isoSPI up from idle state 
-void wakeup_idle(uint8_t total_ic)
+/* Wake isoSPI up from IDlE state and enters the READY state */
+void wakeup_idle(uint8_t total_ic) //Number of ICs in the system
 {
-  for (int i =0; i<total_ic; i++)
-  {
-    cs_low(CS_PIN);
-    spi_read_byte(0xff);//Guarantees the isoSPI will be in ready mode
-    cs_high(CS_PIN);
-  }
+	for (int i =0; i<total_ic; i++)
+	{
+	   cs_low(CS_PIN);
+	   spi_read_byte(0xff);//Guarantees the isoSPI will be in ready mode
+	   cs_high(CS_PIN);
+	}
 }
 
-//Generic wakeup command to wake the LTC681x from sleep
-void wakeup_sleep(uint8_t total_ic)
+/* Generic wakeup command to wake the LTC681x from sleep state */
+void wakeup_sleep(uint8_t total_ic) //Number of ICs in the system
 {
-  for (int i =0; i<total_ic; i++)
-  {
-	cs_low(CS_PIN);
-	delay_u(300); // Guarantees the LTC681x will be in standby
-	cs_high(CS_PIN);
-	delay_u(10);
-  }
+	for (int i =0; i<total_ic; i++)
+	{
+	   cs_low(CS_PIN);
+	   delay_u(300); // Guarantees the LTC681x will be in standby
+	   cs_high(CS_PIN);
+	   delay_u(10);
+	}
 }
 
-//Generic function to write 68xx commands. Function calculated PEC for tx_cmd data
-void cmd_68(uint8_t tx_cmd[2])
+/* Generic function to write 68xx commands. Function calculates PEC for tx_cmd data. */
+void cmd_68(uint8_t tx_cmd[2]) //The command to be transmitted
 {
 	uint8_t cmd[4];
 	uint16_t cmd_pec;
 	uint8_t md_bits;
+	
 	cmd[0] = tx_cmd[0];
 	cmd[1] =  tx_cmd[1];
 	cmd_pec = pec15_calc(2, cmd);
 	cmd[2] = (uint8_t)(cmd_pec >> 8);
 	cmd[3] = (uint8_t)(cmd_pec);
+	
 	cs_low(CS_PIN);
 	spi_write_array(4,cmd);
 	cs_high(CS_PIN);
 }
 
-//Generic function to write 68xx commands and write payload data. Function calculated PEC for tx_cmd data
-void write_68(uint8_t total_ic, 
-			  uint8_t tx_cmd[2], 
-			  uint8_t data[])
+/* 
+Generic function to write 68xx commands and write payload data. 
+Function calculates PEC for tx_cmd data and the data to be transmitted.
+ */
+void write_68(uint8_t total_ic, //Number of ICs to be written to 
+			  uint8_t tx_cmd[2], //The command to be transmitted 
+			  uint8_t data[] // Payload Data
+			  )
 {
 	const uint8_t BYTES_IN_REG = 6;
 	const uint8_t CMD_LEN = 4+(8*total_ic);
@@ -101,36 +106,41 @@ void write_68(uint8_t total_ic,
 	uint16_t data_pec;
 	uint16_t cmd_pec;
 	uint8_t cmd_index;
+	
 	cmd = (uint8_t *)malloc(CMD_LEN*sizeof(uint8_t));
 	cmd[0] = tx_cmd[0];
 	cmd[1] = tx_cmd[1];
 	cmd_pec = pec15_calc(2, cmd);
 	cmd[2] = (uint8_t)(cmd_pec >> 8);
 	cmd[3] = (uint8_t)(cmd_pec);
+	
 	cmd_index = 4;
-	for (uint8_t current_ic = total_ic; current_ic > 0; current_ic--)       // executes for each LTC681x, this loops starts with the last IC on the stack.
-    {	                                                                   //The first configuration written is received by the last IC in the daisy chain
-
+	for (uint8_t current_ic = total_ic; current_ic > 0; current_ic--)               // Executes for each LTC681x, this loops starts with the last IC on the stack.
+    {	                                                                            //The first configuration written is received by the last IC in the daisy chain
 		for (uint8_t current_byte = 0; current_byte < BYTES_IN_REG; current_byte++)
 		{
 			cmd[cmd_index] = data[((current_ic-1)*6)+current_byte];
 			cmd_index = cmd_index + 1;
 		}
-		data_pec = (uint16_t)pec15_calc(BYTES_IN_REG, &data[(current_ic-1)*6]);    // calculating the PEC for each Iss configuration register data
+		
+		data_pec = (uint16_t)pec15_calc(BYTES_IN_REG, &data[(current_ic-1)*6]);    // Calculating the PEC for each ICs configuration register data
 		cmd[cmd_index] = (uint8_t)(data_pec >> 8);
 		cmd[cmd_index + 1] = (uint8_t)data_pec;
 		cmd_index = cmd_index + 2;
 	}
+	
 	cs_low(CS_PIN);
 	spi_write_array(CMD_LEN, cmd);
 	cs_high(CS_PIN);
+	
 	free(cmd);
 }
 
-//Generic function to write 68xx commands and read data. Function calculated PEC for tx_cmd data
-int8_t read_68( uint8_t total_ic, 
-				uint8_t tx_cmd[2], 
-				uint8_t *rx_data)
+/* Generic function to write 68xx commands and read data. Function calculated PEC for tx_cmd data */
+int8_t read_68( uint8_t total_ic, // Number of ICs in the system 
+				uint8_t tx_cmd[2], // The command to be transmitted 
+				uint8_t *rx_data // Data to be read
+				)
 {
 	const uint8_t BYTES_IN_REG = 8;
 	uint8_t cmd[4];
@@ -139,153 +149,204 @@ int8_t read_68( uint8_t total_ic,
 	uint16_t cmd_pec;
 	uint16_t data_pec;
 	uint16_t received_pec;
+	
 	cmd[0] = tx_cmd[0];
 	cmd[1] = tx_cmd[1];
 	cmd_pec = pec15_calc(2, cmd);
 	cmd[2] = (uint8_t)(cmd_pec >> 8);
 	cmd[3] = (uint8_t)(cmd_pec);
+	
 	cs_low(CS_PIN);
-	spi_write_read(cmd, 4, data, (BYTES_IN_REG*total_ic));         //Read the configuration data of all ICs on the daisy chain into rx_data[] array
+	spi_write_read(cmd, 4, data, (BYTES_IN_REG*total_ic));         //Transmits the command and reads the configuration data of all ICs on the daisy chain into rx_data[] array
 	cs_high(CS_PIN);                                         
 
-	for (uint8_t current_ic = 0; current_ic < total_ic; current_ic++) //executes for each LTC681x in the daisy chain and packs the data
-	{																//into the r_comm array as well as check the received data for any bit errors
+	for (uint8_t current_ic = 0; current_ic < total_ic; current_ic++) //Executes for each LTC681x in the daisy chain and packs the data
+	{																//into the rx_data array as well as check the received data for any bit errors
 		for (uint8_t current_byte = 0; current_byte < BYTES_IN_REG; current_byte++)
 		{
 			rx_data[(current_ic*8)+current_byte] = data[current_byte + (current_ic*BYTES_IN_REG)];
 		}
+		
 		received_pec = (rx_data[(current_ic*8)+6]<<8) + rx_data[(current_ic*8)+7];
 		data_pec = pec15_calc(6, &rx_data[current_ic*8]);
+		
 		if (received_pec != data_pec)
 		{
 		  pec_error = -1;
 		}
 	}
+	
 	return(pec_error);
 }
 
-//Calculates  and returns the CRC15 
+/* Calculates  and returns the CRC15 */
 uint16_t pec15_calc(uint8_t len, //Number of bytes that will be used to calculate a PEC
                     uint8_t *data //Array of data that will be used to calculate  a PEC
                    )
 {
 	uint16_t remainder,addr;
 	remainder = 16;//initialize the PEC
+	
 	for (uint8_t i = 0; i<len; i++) // loops for each byte in data array
 	{
-	addr = ((remainder>>7)^data[i])&0xff;//calculate PEC table address
-	#ifdef MBED
-		remainder = (remainder<<8)^crc15Table[addr];
-	#else
-		remainder = (remainder<<8)^pgm_read_word_near(crc15Table+addr);
-	#endif
+		addr = ((remainder>>7)^data[i])&0xff;//calculate PEC table address
+		#ifdef MBED
+			remainder = (remainder<<8)^crc15Table[addr];
+		#else
+			remainder = (remainder<<8)^pgm_read_word_near(crc15Table+addr);
+		#endif
 	}
+	
 	return(remainder*2);//The CRC15 has a 0 in the LSB so the remainder must be multiplied by 2
 }
 
-//Helper function to initialize CFG variables.
-void LTC681x_init_cfg(uint8_t total_ic, 
-					  cell_asic *ic
-					  )
+/* Write the LTC681x CFGRA */
+void LTC681x_wrcfg(uint8_t total_ic, //The number of ICs being written to
+                   cell_asic ic[]  // A two dimensional array of the configuration data that will be written
+                  )
 {
-   for (uint8_t current_ic = 0; current_ic<total_ic;current_ic++)  
-   {
-		for (int j =0; j<6; j++)
+	uint8_t cmd[2] = {0x00 , 0x01} ;
+	uint8_t write_buffer[256];
+	uint8_t write_count = 0;
+	uint8_t c_ic = 0;
+	
+	for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
+	{
+		if (ic->isospi_reverse == true)
 		{
-		  ic[current_ic].config.tx_data[j] = 0;
+			c_ic = current_ic;
 		}
-   }
+		else
+		{
+			c_ic = total_ic - current_ic - 1;
+		}
+		
+		for (uint8_t data = 0; data<6; data++)
+		{
+			write_buffer[write_count] = ic[c_ic].config.tx_data[data];
+			write_count++;
+		}
+	}
+	write_68(total_ic, cmd, write_buffer);
 }
 
-//Helper function to set CFGR variable
-void LTC681x_set_cfgr(uint8_t nIC, 
-					 cell_asic *ic, 
-					 bool refon, 
-					 bool adcopt, 
-					 bool gpio[5],
-					 bool dcc[12], 
-					 bool dcto[4], 
-					 uint16_t uv, 
-					 uint16_t  ov
-					 )
+/* Write the LTC681x CFGRB */
+void LTC681x_wrcfgb(uint8_t total_ic, //The number of ICs being written to
+                    cell_asic ic[] // A two dimensional array of the configuration data that will be written
+                   )
 {
-  LTC681x_set_cfgr_refon(nIC,ic,refon);
-  LTC681x_set_cfgr_adcopt(nIC,ic,adcopt);
-  LTC681x_set_cfgr_gpio(nIC,ic,gpio);
-  LTC681x_set_cfgr_dis(nIC,ic,dcc);
-  LTC681x_set_cfgr_dcto(nIC,ic,dcto);
-  LTC681x_set_cfgr_uv(nIC, ic, uv);
-  LTC681x_set_cfgr_ov(nIC, ic, ov);
+	uint8_t cmd[2] = {0x00 , 0x24} ;
+	uint8_t write_buffer[256];
+	uint8_t write_count = 0;
+	uint8_t c_ic = 0;
+	
+	for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
+	{
+		if (ic->isospi_reverse == true)
+		{
+			c_ic = current_ic;
+		}
+		else
+		{
+			c_ic = total_ic - current_ic - 1;
+		}
+		
+		for (uint8_t data = 0; data<6; data++)
+		{
+			write_buffer[write_count] = ic[c_ic].configb.tx_data[data];
+			write_count++;
+		}
+	}
+	write_68(total_ic, cmd, write_buffer);
 }
 
-
-//Helper function to set the REFON bit
-void LTC681x_set_cfgr_refon(uint8_t nIC, cell_asic *ic, bool refon)
+/* Read the LTC681x CFGA */
+int8_t LTC681x_rdcfg(uint8_t total_ic, //Number of ICs in the system
+                     cell_asic ic[] // A two dimensional array that the function stores the read configuration data.
+                    )
 {
-  if (refon) ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]|0x04;
-  else ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]&0xFB;
+	uint8_t cmd[2]= {0x00 , 0x02};
+	uint8_t read_buffer[256];
+	int8_t pec_error = 0;
+	uint16_t data_pec;
+	uint16_t calc_pec;
+	uint8_t c_ic = 0;
+	
+	pec_error = read_68(total_ic, cmd, read_buffer);
+	
+	for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
+	{
+		if (ic->isospi_reverse == false)
+		{
+			c_ic = current_ic;
+		}
+		else
+		{
+			c_ic = total_ic - current_ic - 1;
+		}
+		
+		for (int byte=0; byte<8; byte++)
+		{
+			ic[c_ic].config.rx_data[byte] = read_buffer[byte+(8*current_ic)];
+		}
+		
+		calc_pec = pec15_calc(6,&read_buffer[8*current_ic]);
+		data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
+		if (calc_pec != data_pec )
+		{
+			ic[c_ic].config.rx_pec_match = 1;
+		}
+		else ic[c_ic].config.rx_pec_match = 0;
+	}
+	LTC681x_check_pec(total_ic,CFGR,ic);
+	
+	return(pec_error);
 }
 
-//Helper function to set the adcopt bit
-void LTC681x_set_cfgr_adcopt(uint8_t nIC, cell_asic *ic, bool adcopt)
+/* Reads the LTC681x CFGB */
+int8_t LTC681x_rdcfgb(uint8_t total_ic, //Number of ICs in the system
+                      cell_asic ic[] // A two dimensional array that the function stores the read configuration data.
+                     )
 {
-  if (adcopt) ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]|0x01;
-  else ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]&0xFE;
+	uint8_t cmd[2]= {0x00 , 0x26};
+	uint8_t read_buffer[256];
+	int8_t pec_error = 0;
+	uint16_t data_pec;
+	uint16_t calc_pec;
+	uint8_t c_ic = 0;
+	
+	pec_error = read_68(total_ic, cmd, read_buffer);
+	
+	for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
+	{
+		if (ic->isospi_reverse == false)
+		{
+			c_ic = current_ic;
+		}
+		else
+		{
+			c_ic = total_ic - current_ic - 1;
+		}
+		
+		for (int byte=0; byte<8; byte++)
+		{
+			ic[c_ic].configb.rx_data[byte] = read_buffer[byte+(8*current_ic)];
+		}
+		
+		calc_pec = pec15_calc(6,&read_buffer[8*current_ic]);
+		data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
+		if (calc_pec != data_pec )
+		{
+			ic[c_ic].configb.rx_pec_match = 1;
+		}
+		else ic[c_ic].configb.rx_pec_match = 0;
+	}
+	LTC681x_check_pec(total_ic,CFGRB,ic);
+	
+	return(pec_error);
 }
 
-//Helper function to set GPIO bits
-void LTC681x_set_cfgr_gpio(uint8_t nIC, cell_asic *ic,bool gpio[5])
-{
-  for (int i =0; i<5; i++)
-  {
-    if (gpio[i])ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]|(0x01<<(i+3));
-    else ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]&(~(0x01<<(i+3)));
-  }
-}
-
-//Helper function to control discharge
-void LTC681x_set_cfgr_dis(uint8_t nIC, cell_asic *ic,bool dcc[12])
-{
-  for (int i =0; i<8; i++)
-  {
-    if (dcc[i])ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]|(0x01<<i);
-    else ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]& (~(0x01<<i));
-  }
-  for (int i =0; i<4; i++)
-  {
-    if (dcc[i+8])ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]|(0x01<<i);
-    else ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]&(~(0x01<<i));
-  }
-}
-
-//Helper function to control discharge time value
-void LTC681x_set_cfgr_dcto(uint8_t nIC, cell_asic *ic,bool dcto[4])
-{  
-  for(int i =0;i<4;i++)
-  {
-      if(dcto[i])ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]|(0x01<<(i+4));
-      else ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]&(~(0x01<<(i+4)));
-  } 
-}
-//Helper Function to set uv value in CFG register
-void LTC681x_set_cfgr_uv(uint8_t nIC, cell_asic *ic,uint16_t uv)
-{
-  uint16_t tmp = (uv/16)-1;
-  ic[nIC].config.tx_data[1] = 0x00FF & tmp;
-  ic[nIC].config.tx_data[2] = ic[nIC].config.tx_data[2]&0xF0;
-  ic[nIC].config.tx_data[2] = ic[nIC].config.tx_data[2]|((0x0F00 & tmp)>>8);
-}
-
-//helper function to set OV value in CFG register
-void LTC681x_set_cfgr_ov(uint8_t nIC, cell_asic *ic,uint16_t ov)
-{
-  uint16_t tmp = (ov/16);
-  ic[nIC].config.tx_data[3] = 0x00FF & (tmp>>4);
-  ic[nIC].config.tx_data[2] = ic[nIC].config.tx_data[2]&0x0F;
-  ic[nIC].config.tx_data[2] = ic[nIC].config.tx_data[2]|((0x000F & tmp)<<4);
-}
-
-//Starts cell voltage conversion
+/* Starts ADC conversion for cell voltage */
 void LTC681x_adcv( uint8_t MD, //ADC Mode
 				   uint8_t DCP, //Discharge Permit
 				   uint8_t CH //Cell Channels to be measured
@@ -293,441 +354,579 @@ void LTC681x_adcv( uint8_t MD, //ADC Mode
 {
 	uint8_t cmd[2];
 	uint8_t md_bits;
+	
 	md_bits = (MD & 0x02) >> 1;
 	cmd[0] = md_bits + 0x02;
 	md_bits = (MD & 0x01) << 7;
 	cmd[1] =  md_bits + 0x60 + (DCP<<4) + CH;
+	
 	cmd_68(cmd);
 }
 
-//Start a GPIO and Vref2 Conversion
+/* Start ADC Conversion for GPIO and Vref2  */
 void LTC681x_adax(uint8_t MD, //ADC Mode
-				  uint8_t CHG //GPIO Channels to be measured)
+				  uint8_t CHG //GPIO Channels to be measured
 				  )
 {
-  uint8_t cmd[4];
-  uint8_t md_bits;
-
-  md_bits = (MD & 0x02) >> 1;
-  cmd[0] = md_bits + 0x04;
-  md_bits = (MD & 0x01) << 7;
-  cmd[1] = md_bits + 0x60 + CHG ;
-  cmd_68(cmd);
-
+	uint8_t cmd[4];
+	uint8_t md_bits;
+	
+	md_bits = (MD & 0x02) >> 1;
+	cmd[0] = md_bits + 0x04;
+	md_bits = (MD & 0x01) << 7;
+	cmd[1] = md_bits + 0x60 + CHG ;
+	
+	cmd_68(cmd);
 }
 
-//Start an GPIO Redundancy test
-void LTC681x_adaxd(uint8_t MD, //ADC Mode
-				   uint8_t CHG //GPIO Channels to be measured)
-				   )
-{
-  uint8_t cmd[4];
-  uint8_t md_bits;
-
-  md_bits = (MD & 0x02) >> 1;
-  cmd[0] = md_bits + 0x04;
-  md_bits = (MD & 0x01) << 7;
-  cmd[1] = md_bits + CHG ;
-  cmd_68(cmd);
-}
-
-//Start a Status ADC Conversion
+/* Start ADC Conversion for Status  */
 void LTC681x_adstat(uint8_t MD, //ADC Mode
-				    uint8_t CHST //GPIO Channels to be measured
+				    uint8_t CHST //Stat Channels to be measured
 				    )
 {
-  uint8_t cmd[4];
-  uint8_t md_bits;
-
-  md_bits = (MD & 0x02) >> 1;
-  cmd[0] = md_bits + 0x04;
-  md_bits = (MD & 0x01) << 7;
-  cmd[1] = md_bits + 0x68 + CHST ;
-  cmd_68(cmd);
+	uint8_t cmd[4];
+	uint8_t md_bits;
+	
+	md_bits = (MD & 0x02) >> 1;
+	cmd[0] = md_bits + 0x04;
+	md_bits = (MD & 0x01) << 7;
+	cmd[1] = md_bits + 0x68 + CHST ;
+	
+	cmd_68(cmd);
 }
 
-// Start a Status register redundancy test Conversion
-void LTC681x_adstatd(uint8_t MD, //ADC Mode
-					 uint8_t CHST //GPIO Channels to be measured
-					 )
-{
-  uint8_t cmd[2];
-  uint8_t md_bits;
-
-  md_bits = (MD & 0x02) >> 1;
-  cmd[0] = md_bits + 0x04;
-  md_bits = (MD & 0x01) << 7;
-  cmd[1] = md_bits + 0x08 + CHST ;
-  cmd_68(cmd);
-
-}
-
-// Start an open wire Conversion
-void LTC681x_adow(uint8_t MD, //ADC Mode
-				  uint8_t PUP,//PULL UP OR DOWN current
-				  uint8_t CH, //Channels
-				  uint8_t DCP//Discharge Permit
-				 )
-{
-  uint8_t cmd[2];
-  uint8_t md_bits;
-  md_bits = (MD & 0x02) >> 1;
-  cmd[0] = md_bits + 0x02;
-  md_bits = (MD & 0x01) << 7;
-  cmd[1] =  md_bits + 0x28 + (PUP<<6) + CH+(DCP<<4);
-  cmd_68(cmd);
-}
-
-//Starts cell voltage and SOC conversion
+/* Starts cell voltage and SOC conversion */
 void LTC681x_adcvsc(uint8_t MD, //ADC Mode
 					uint8_t DCP //Discharge Permit
 					)
 {
 	uint8_t cmd[2];
 	uint8_t md_bits;
+	
 	md_bits = (MD & 0x02) >> 1;
 	cmd[0] = md_bits | 0x04;
 	md_bits = (MD & 0x01) << 7;
 	cmd[1] =  md_bits | 0x60 | (DCP<<4) | 0x07;
+	
 	cmd_68(cmd);
-
 }
 
-// Starts cell voltage  and GPIO 1&2 conversion
+/* Starts cell voltage and GPIO 1&2 conversion */
 void LTC681x_adcvax(uint8_t MD, //ADC Mode
 					uint8_t DCP //Discharge Permit
 				   )
 {
 	uint8_t cmd[2];
 	uint8_t md_bits;
+	
 	md_bits = (MD & 0x02) >> 1;
 	cmd[0] = md_bits | 0x04;
 	md_bits = (MD & 0x01) << 7;
 	cmd[1] =  md_bits | ((DCP&0x01)<<4) + 0x6F;
+	
 	cmd_68(cmd);
 }
 
-//Starts cell voltage overlap conversion
-void LTC681x_adol(uint8_t MD, //ADC Mode
-                  uint8_t DCP //Discharge Permit
-				 )
+/*
+Reads and parses the LTC681x cell voltage registers.
+The function is used to read the parsed Cell voltages codes of the LTC681x. 
+This function will send the requested read commands parse the data 
+and store the cell voltages in c_codes variable.
+*/
+uint8_t LTC681x_rdcv(uint8_t reg, // Controls which cell voltage register is read back.
+                     uint8_t total_ic, // The number of ICs in the system
+                     cell_asic *ic // Array of the parsed cell codes
+                    )
 {
-	uint8_t cmd[2];
-	uint8_t md_bits;
-	md_bits = (MD & 0x02) >> 1;
-	cmd[0] = md_bits + 0x02;
-	md_bits = (MD & 0x01) << 7;
-	cmd[1] =  md_bits + (DCP<<4) +0x01;
-	cmd_68(cmd);
+	int8_t pec_error = 0;
+	uint8_t *cell_data;
+	uint8_t c_ic = 0;
+	cell_data = (uint8_t *) malloc((NUM_RX_BYT*total_ic)*sizeof(uint8_t));
+
+	if (reg == 0)
+	{
+		for (uint8_t cell_reg = 1; cell_reg<ic[0].ic_reg.num_cv_reg+1; cell_reg++) //Executes once for each of the LTC681x cell voltage registers
+		{
+			LTC681x_rdcv_reg(cell_reg, total_ic,cell_data );
+			for (int current_ic = 0; current_ic<total_ic; current_ic++)
+			{
+			if (ic->isospi_reverse == false)
+			{
+			  c_ic = current_ic;
+			}
+			else
+			{
+			  c_ic = total_ic - current_ic - 1;
+			}
+			pec_error = pec_error + parse_cells(current_ic,cell_reg, cell_data,
+												&ic[c_ic].cells.c_codes[0],
+												&ic[c_ic].cells.pec_match[0]);
+			}
+		}
+	}
+
+	else
+	{
+		LTC681x_rdcv_reg(reg, total_ic,cell_data);
+
+		for (int current_ic = 0; current_ic<total_ic; current_ic++)
+		{
+			if (ic->isospi_reverse == false)
+			{
+			c_ic = current_ic;
+			}
+			else
+			{
+			c_ic = total_ic - current_ic - 1;
+			}
+			pec_error = pec_error + parse_cells(current_ic,reg, &cell_data[8*c_ic],
+											  &ic[c_ic].cells.c_codes[0],
+											  &ic[c_ic].cells.pec_match[0]);
+		}
+	}
+	LTC681x_check_pec(total_ic,CELL,ic);
+	free(cell_data);
+
+	return(pec_error);
 }
 
-//Starts cell voltage self test conversion
-void LTC681x_cvst(uint8_t MD, //ADC Mode
-				  uint8_t ST //Self Test
-                 )
+/*
+The function is used to read the  parsed GPIO codes of the LTC681x. 
+This function will send the requested read commands parse the data 
+and store the gpio voltages in a_codes variable.
+*/
+int8_t LTC681x_rdaux(uint8_t reg, //Determines which GPIO voltage register is read back.
+                     uint8_t total_ic,//The number of ICs in the system
+                     cell_asic *ic//A two dimensional array of the gpio voltage codes.
+                    )
 {
-	uint8_t cmd[2];
-	uint8_t md_bits;
-	md_bits = (MD & 0x02) >> 1;
-	cmd[0] = md_bits + 0x02;
-	md_bits = (MD & 0x01) << 7;
-	cmd[1] =  md_bits + ((ST)<<5) +0x07;
-	cmd_68(cmd);
+	uint8_t *data;
+	int8_t pec_error = 0;
+	uint8_t c_ic =0;
+	data = (uint8_t *) malloc((NUM_RX_BYT*total_ic)*sizeof(uint8_t));
+
+	if (reg == 0)
+	{
+		for (uint8_t gpio_reg = 1; gpio_reg<ic[0].ic_reg.num_gpio_reg+1; gpio_reg++) //Executes once for each of the LTC681x aux voltage registers
+		{
+			LTC681x_rdaux_reg(gpio_reg, total_ic,data);                 //Reads the raw auxiliary register data into the data[] array
+			for (int current_ic = 0; current_ic<total_ic; current_ic++)
+			{
+				if (ic->isospi_reverse == false)
+				{
+				  c_ic = current_ic;
+				}
+				else
+				{
+				  c_ic = total_ic - current_ic - 1;
+				}
+				pec_error = parse_cells(current_ic,gpio_reg, data,
+										&ic[c_ic].aux.a_codes[0],
+										&ic[c_ic].aux.pec_match[0]);
+			}
+		}
+	}
+	else
+	{
+		LTC681x_rdaux_reg(reg, total_ic, data);
+
+		for (int current_ic = 0; current_ic<total_ic; current_ic++)
+		{
+			if (ic->isospi_reverse == false)
+			{
+			c_ic = current_ic;
+			}
+			else
+			{
+			c_ic = total_ic - current_ic - 1;
+			}
+			pec_error = parse_cells(current_ic,reg, data,
+								  &ic[c_ic].aux.a_codes[0],
+								  &ic[c_ic].aux.pec_match[0]);
+		}
+	}
+	LTC681x_check_pec(total_ic,AUX,ic);
+	free(data);
+
+	return (pec_error);
 }
 
-//Start an Auxiliary Register Self Test Conversion
-void LTC681x_axst(uint8_t MD, //ADC Mode
-				  uint8_t ST //Self Test
-				  )
+/*
+Reads and parses the LTC681x stat registers.
+The function is used to read the  parsed Stat codes of the LTC681x. 
+This function will send the requested read commands parse the data 
+and store the gpio voltages in stat_codes variable.
+*/
+int8_t LTC681x_rdstat(uint8_t reg, //Determines which Stat  register is read back.
+                      uint8_t total_ic,//The number of ICs in the system
+                      cell_asic *ic //A two dimensional array of the stat codes.
+                     )
+
 {
-  uint8_t cmd[2];
-  uint8_t md_bits;
-
-  md_bits = (MD & 0x02) >> 1;
-  cmd[0] = md_bits + 0x04;
-  md_bits = (MD & 0x01) << 7;
-  cmd[1] =  md_bits + ((ST&0x03)<<5) +0x07;
-  cmd_68(cmd);
-
-}
-
-//Start a Status Register Self Test Conversion
-void LTC681x_statst(uint8_t MD, //ADC Mode
-				    uint8_t ST //Self Test
-					)
-{
-  uint8_t cmd[2];
-  uint8_t md_bits;
-
-  md_bits = (MD & 0x02) >> 1;
-  cmd[0] = md_bits + 0x04;
-  md_bits = (MD & 0x01) << 7;
-  cmd[1] =  md_bits + ((ST&0x03)<<5) +0x0F;
-  cmd_68(cmd);
-
-}
-
-//Sends the poll adc command
-uint8_t LTC681x_pladc()
-{
-  uint8_t cmd[4];
-  uint8_t adc_state = 0xFF;
-  uint16_t cmd_pec;
-
-  cmd[0] = 0x07;
-  cmd[1] = 0x14;
-  cmd_pec = pec15_calc(2, cmd);
-  cmd[2] = (uint8_t)(cmd_pec >> 8);
-  cmd[3] = (uint8_t)(cmd_pec);
-
-
-  cs_low(CS_PIN);
-  spi_write_array(4,cmd);
-  adc_state = spi_read_byte(0xFF);
-
-  cs_high(CS_PIN);
-  return(adc_state);
-}
-
-//This function will block operation until the ADC has finished it's conversion
-uint32_t LTC681x_pollAdc()
-{
-  uint32_t counter = 0;
-  uint8_t finished = 0;
-  uint8_t current_time = 0;
-  uint8_t cmd[4];
-  uint16_t cmd_pec;
-
-
-  cmd[0] = 0x07;
-  cmd[1] = 0x14;
-  cmd_pec = pec15_calc(2, cmd);
-  cmd[2] = (uint8_t)(cmd_pec >> 8);
-  cmd[3] = (uint8_t)(cmd_pec);
-
-  cs_low(CS_PIN);
-  spi_write_array(4,cmd);
-
-  while ((counter<200000)&&(finished == 0))
-  {
-    current_time = spi_read_byte(0xff);
-    if (current_time>0)
-    {
-      finished = 1;
-    }
-    else
-    {
-      counter = counter + 10;
-    }
-  }
-
-  cs_high(CS_PIN);
-
-
-  return(counter);
-}
-
-//Starts the Mux Decoder diagnostic self test
-void LTC681x_diagn()
-{
-  uint8_t cmd[2] = {0x07 , 0x15};
-  cmd_68(cmd);
-}
-
-//Helper function that parses voltage measurement registers
-int8_t parse_cells(uint8_t current_ic, 
-					uint8_t cell_reg, 
-					uint8_t cell_data[], 
-					uint16_t *cell_codes, 
-					uint8_t *ic_pec
-					)
-{
-
-  const uint8_t BYT_IN_REG = 6;
-  const uint8_t CELL_IN_REG = 3;
-  int8_t pec_error = 0;
-  uint16_t parsed_cell;
-  uint16_t received_pec;
-  uint16_t data_pec;
-  uint8_t data_counter = current_ic*NUM_RX_BYT; //data counter
-
-
-  for (uint8_t current_cell = 0; current_cell<CELL_IN_REG; current_cell++)  // This loop parses the read back data into cell voltages, it
-  {																			// loops once for each of the 3 cell voltage codes in the register
-																			
-
-    parsed_cell = cell_data[data_counter] + (cell_data[data_counter + 1] << 8);//Each cell code is received as two bytes and is combined to
+	const uint8_t BYT_IN_REG = 6;
+	const uint8_t STAT_IN_REG = 3;
+	uint8_t *data;
+	uint8_t data_counter = 0;
+	int8_t pec_error = 0;
+	uint16_t parsed_stat;
+	uint16_t received_pec;
+	uint16_t data_pec;
+	uint8_t c_ic = 0;
 	
-																		  // create the parsed cell voltage code
+	data = (uint8_t *) malloc((12*total_ic)*sizeof(uint8_t));
 	
-    cell_codes[current_cell  + ((cell_reg - 1) * CELL_IN_REG)] = parsed_cell;
+	if (reg == 0)
+	{
+		for (uint8_t stat_reg = 1; stat_reg< 3; stat_reg++)                      //Executes once for each of the LTC681x stat voltage registers
+		{
+			data_counter = 0;
+			LTC681x_rdstat_reg(stat_reg, total_ic,data);                            //Reads the raw status register data into the data[] array
+		
+			for (uint8_t current_ic = 0 ; current_ic < total_ic; current_ic++)      // Executes for every LTC681x in the daisy chain
+			{																		// current_ic is used as the IC counter
+				if (ic->isospi_reverse == false)
+				{
+					c_ic = current_ic;
+				}
+				else
+				{
+					c_ic = total_ic - current_ic - 1;
+				}
+
+				if (stat_reg ==1)
+				{
+					for (uint8_t current_stat = 0; current_stat< STAT_IN_REG; current_stat++) // This loop parses the read back data into Status registers, 
+					{																		 // it loops once for each of the 3 stat codes in the register
+						parsed_stat = data[data_counter] + (data[data_counter+1]<<8);       //Each stat codes is received as two bytes and is combined to create the parsed status code
+						ic[c_ic].stat.stat_codes[current_stat] = parsed_stat;
+						data_counter=data_counter+2;                                       //Because stat codes are two bytes the data counter
+					}
+				}
+				else if (stat_reg == 2)
+				{
+					parsed_stat = data[data_counter] + (data[data_counter+1]<<8);          //Each stat is received as two bytes and is combined to create the parsed status code
+					data_counter = data_counter +2;
+					ic[c_ic].stat.stat_codes[3] = parsed_stat;
+					ic[c_ic].stat.flags[0] = data[data_counter++];
+					ic[c_ic].stat.flags[1] = data[data_counter++];
+					ic[c_ic].stat.flags[2] = data[data_counter++];
+					ic[c_ic].stat.mux_fail[0] = (data[data_counter] & 0x02)>>1;
+					ic[c_ic].stat.thsd[0] = data[data_counter++] & 0x01;
+				}
+			
+				received_pec = (data[data_counter]<<8)+ data[data_counter+1];        //The received PEC for the current_ic is transmitted as the 7th and 8th
+																					//after the 6 status data bytes
+				data_pec = pec15_calc(BYT_IN_REG, &data[current_ic*NUM_RX_BYT]);
+			
+				if (received_pec != data_pec)
+				{
+					pec_error = -1;                         //The pec_error variable is simply set negative if any PEC errors
+					ic[c_ic].stat.pec_match[stat_reg-1]=1;  //are detected in the received serial data
+					
+				}
+				else
+				{
+					ic[c_ic].stat.pec_match[stat_reg-1]=0;
+				}
+			
+				data_counter=data_counter+2;    //Because the transmitted PEC code is 2 bytes long the data_counter
+											//must be incremented by 2 bytes to point to the next ICs status data
+			}
+		}
+	}
+	else
+	{
+		LTC681x_rdstat_reg(reg, total_ic, data);
+		for (int current_ic = 0 ; current_ic < total_ic; current_ic++)            // Executes for every LTC681x in the daisy chain
+		{																		  // current_ic is used as an IC counter																			
+			if (ic->isospi_reverse == false)
+			{
+			c_ic = current_ic;
+			}
+			else
+			{
+			c_ic = total_ic - current_ic - 1;
+			}
+			if (reg ==1)
+			{
+				for (uint8_t current_stat = 0; current_stat< STAT_IN_REG; current_stat++) // This loop parses the read back data into Status voltages, it
+				{																		  // loops once for each of the 3 stat codes in the register
+					
+					parsed_stat = data[data_counter] + (data[data_counter+1]<<8);           //Each stat codes is received as two bytes and is combined to
+																							// create the parsed stat code
+			
+					ic[c_ic].stat.stat_codes[current_stat] = parsed_stat;
+					data_counter=data_counter+2;                     //Because stat codes are two bytes the data counter
+																	//must increment by two for each parsed stat code
+				}
+			}
+			else if (reg == 2)
+			{
+				parsed_stat = data[data_counter++] + (data[data_counter++]<<8); //Each stat codes is received as two bytes and is combined to
+				ic[c_ic].stat.stat_codes[3] = parsed_stat;
+				ic[c_ic].stat.flags[0] = data[data_counter++];
+				ic[c_ic].stat.flags[1] = data[data_counter++];
+				ic[c_ic].stat.flags[2] = data[data_counter++];
+				ic[c_ic].stat.mux_fail[0] = (data[data_counter] & 0x02)>>1;
+				ic[c_ic].stat.thsd[0] = data[data_counter++] & 0x01;
+			}
+		
+			received_pec = (data[data_counter]<<8)+ data[data_counter+1]; //The received PEC for the current_ic is transmitted as the 7th and 8th
+																		  //after the 6 status data bytes
+			data_pec = pec15_calc(BYT_IN_REG, &data[current_ic*NUM_RX_BYT]);
+			if (received_pec != data_pec)
+			{
+				pec_error = -1;                  //The pec_error variable is simply set negative if any PEC errors
+				ic[c_ic].stat.pec_match[reg-1]=1;
+			}
+		
+			data_counter=data_counter+2;
+		}
+	}
+	LTC681x_check_pec(total_ic,STAT,ic);
 	
-    data_counter = data_counter + 2;                       //Because cell voltage codes are two bytes the data counter
-														  //must increment by two for each parsed cell code
-  }
-
-  received_pec = (cell_data[data_counter] << 8) | cell_data[data_counter+1]; //The received PEC for the current_ic is transmitted as the 7th and 8th
-																			//after the 6 cell voltage data bytes
-  data_pec = pec15_calc(BYT_IN_REG, &cell_data[(current_ic) * NUM_RX_BYT]);
-
-  if (received_pec != data_pec)
-  {
-    pec_error = 1;                             //The pec_error variable is simply set negative if any PEC errors
-    ic_pec[cell_reg-1]=1;
-  }
-  else
-  {
-    ic_pec[cell_reg-1]=0;
-  }
-  data_counter=data_counter+2;
-  return(pec_error);
+	free(data);
+	
+	return (pec_error);
 }
 
-
-// Reads the raw cell voltage register data
+/* Writes the command and reads the raw cell voltage register data */
 void LTC681x_rdcv_reg(uint8_t reg, //Determines which cell voltage register is read back
                       uint8_t total_ic, //the number of ICs in the
                       uint8_t *data //An array of the unparsed cell codes
                      )
 {
-  const uint8_t REG_LEN = 8; //number of bytes in each ICs register + 2 bytes for the PEC
-  uint8_t cmd[4];
-  uint16_t cmd_pec;
+	const uint8_t REG_LEN = 8; //Number of bytes in each ICs register + 2 bytes for the PEC
+	uint8_t cmd[4];
+	uint16_t cmd_pec;
 
-  if (reg == 1)     //1: RDCVA
-  {
-    cmd[1] = 0x04;
-    cmd[0] = 0x00;
-  }
-  else if (reg == 2) //2: RDCVB
-  {
-    cmd[1] = 0x06;
-    cmd[0] = 0x00;
-  }
-  else if (reg == 3) //3: RDCVC
-  {
-    cmd[1] = 0x08;
-    cmd[0] = 0x00;
-  }
-  else if (reg == 4) //4: RDCVD
-  {
-    cmd[1] = 0x0A;
-    cmd[0] = 0x00;
-  }
-  else if (reg == 5) //4: RDCVE
-  {
-    cmd[1] = 0x09;
-    cmd[0] = 0x00;
-  }
-  else if (reg == 6) //4: RDCVF
-  {
-    cmd[1] = 0x0B;
-    cmd[0] = 0x00;
-  }
+	if (reg == 1)     //1: RDCVA
+	{
+		cmd[1] = 0x04;
+		cmd[0] = 0x00;
+	}
+	else if (reg == 2) //2: RDCVB
+	{
+		cmd[1] = 0x06;
+		cmd[0] = 0x00;
+	}
+	else if (reg == 3) //3: RDCVC
+	{
+		cmd[1] = 0x08;
+		cmd[0] = 0x00;
+	}
+	else if (reg == 4) //4: RDCVD
+	{
+		cmd[1] = 0x0A;
+		cmd[0] = 0x00;
+	}
+	else if (reg == 5) //4: RDCVE
+	{
+		cmd[1] = 0x09;
+		cmd[0] = 0x00;
+	}
+	else if (reg == 6) //4: RDCVF
+	{
+		cmd[1] = 0x0B;
+		cmd[0] = 0x00;
+	}
 
+	cmd_pec = pec15_calc(2, cmd);
+	cmd[2] = (uint8_t)(cmd_pec >> 8);
+	cmd[3] = (uint8_t)(cmd_pec);
 
-  cmd_pec = pec15_calc(2, cmd);
-  cmd[2] = (uint8_t)(cmd_pec >> 8);
-  cmd[3] = (uint8_t)(cmd_pec);
-
-  cs_low(CS_PIN);
-  spi_write_read(cmd,4,data,(REG_LEN*total_ic));
-  cs_high(CS_PIN);
-
+	cs_low(CS_PIN);
+	spi_write_read(cmd,4,data,(REG_LEN*total_ic));
+	cs_high(CS_PIN);
 }
-
 
 /*
 The function reads a single GPIO voltage register and stores the read data
 in the *data point as a byte array. This function is rarely used outside of
-the LTC6811_rdaux() command.
+the LTC681x_rdaux() command.
 */
 void LTC681x_rdaux_reg(uint8_t reg, //Determines which GPIO voltage register is read back
                        uint8_t total_ic, //The number of ICs in the system
                        uint8_t *data //Array of the unparsed auxiliary codes
                       )
 {
-  const uint8_t REG_LEN = 8; // number of bytes in the register + 2 bytes for the PEC
-  uint8_t cmd[4];
-  uint16_t cmd_pec;
+	const uint8_t REG_LEN = 8; // Number of bytes in the register + 2 bytes for the PEC
+	uint8_t cmd[4];
+	uint16_t cmd_pec;
 
+	if (reg == 1)     //Read back auxiliary group A
+	{
+		cmd[1] = 0x0C;
+		cmd[0] = 0x00;
+	}
+	else if (reg == 2)  //Read back auxiliary group B
+	{
+		cmd[1] = 0x0E;
+		cmd[0] = 0x00;
+	}
+	else if (reg == 3)  //Read back auxiliary group C
+	{
+		cmd[1] = 0x0D;
+		cmd[0] = 0x00;
+	}
+	else if (reg == 4)  //Read back auxiliary group D
+	{
+		cmd[1] = 0x0F;
+		cmd[0] = 0x00;
+	}
+	else          //Read back auxiliary group A
+	{
+		cmd[1] = 0x0C;
+		cmd[0] = 0x00;
+	}
 
-  if (reg == 1)     //Read back auxiliary group A
-  {
-    cmd[1] = 0x0C;
-    cmd[0] = 0x00;
-  }
-  else if (reg == 2)  //Read back auxiliary group B
-  {
-    cmd[1] = 0x0E;
-    cmd[0] = 0x00;
-  }
-  else if (reg == 3)  //Read back auxiliary group C
-  {
-    cmd[1] = 0x0D;
-    cmd[0] = 0x00;
-  }
-  else if (reg == 4)  //Read back auxiliary group D
-  {
-    cmd[1] = 0x0F;
-    cmd[0] = 0x00;
-  }
-  else          //Read back auxiliary group A
-  {
-    cmd[1] = 0x0C;
-    cmd[0] = 0x00;
-  }
+	cmd_pec = pec15_calc(2, cmd);
+	cmd[2] = (uint8_t)(cmd_pec >> 8);
+	cmd[3] = (uint8_t)(cmd_pec);
 
-  cmd_pec = pec15_calc(2, cmd);
-  cmd[2] = (uint8_t)(cmd_pec >> 8);
-  cmd[3] = (uint8_t)(cmd_pec);
-
-  cs_low(CS_PIN);
-  spi_write_read(cmd,4,data,(REG_LEN*total_ic));
-  cs_high(CS_PIN);
-
+	cs_low(CS_PIN);
+	spi_write_read(cmd,4,data,(REG_LEN*total_ic));
+	cs_high(CS_PIN);
 }
 
 /*
 The function reads a single stat  register and stores the read data
 in the *data point as a byte array. This function is rarely used outside of
-the LTC6811_rdstat() command.
+the LTC681x_rdstat() command.
 */
 void LTC681x_rdstat_reg(uint8_t reg, //Determines which stat register is read back
                         uint8_t total_ic, //The number of ICs in the system
                         uint8_t *data //Array of the unparsed stat codes
                        )
 {
-  const uint8_t REG_LEN = 8; // number of bytes in the register + 2 bytes for the PEC
-  uint8_t cmd[4];
-  uint16_t cmd_pec;
+	const uint8_t REG_LEN = 8; // number of bytes in the register + 2 bytes for the PEC
+	uint8_t cmd[4];
+	uint16_t cmd_pec;
+
+	if (reg == 1)     //Read back status group A
+	{
+		cmd[1] = 0x10;
+		cmd[0] = 0x00;
+	}
+	else if (reg == 2)  //Read back status group B
+	{
+		cmd[1] = 0x12;
+		cmd[0] = 0x00;
+	}
+
+	else          //Read back status group A
+	{
+		cmd[1] = 0x10;
+		cmd[0] = 0x00;
+	}
+
+	cmd_pec = pec15_calc(2, cmd);
+	cmd[2] = (uint8_t)(cmd_pec >> 8);
+	cmd[3] = (uint8_t)(cmd_pec);
+
+	cs_low(CS_PIN);
+	spi_write_read(cmd,4,data,(REG_LEN*total_ic));
+	cs_high(CS_PIN);
+}
+
+/* Helper function that parses voltage measurement registers */
+int8_t parse_cells(uint8_t current_ic, // Current IC
+					uint8_t cell_reg,  // Type of register
+					uint8_t cell_data[], // Unparsed data
+					uint16_t *cell_codes, // Parsed data
+					uint8_t *ic_pec // PEC error
+					)
+{
+	const uint8_t BYT_IN_REG = 6;
+	const uint8_t CELL_IN_REG = 3;
+	int8_t pec_error = 0;
+	uint16_t parsed_cell;
+	uint16_t received_pec;
+	uint16_t data_pec;
+	uint8_t data_counter = current_ic*NUM_RX_BYT; //data counter
 
 
-  if (reg == 1)     //Read back status group A
-  {
-    cmd[1] = 0x10;
-    cmd[0] = 0x00;
-  }
-  else if (reg == 2)  //Read back status group B
-  {
-    cmd[1] = 0x12;
-    cmd[0] = 0x00;
-  }
+	for (uint8_t current_cell = 0; current_cell<CELL_IN_REG; current_cell++) // This loop parses the read back data into the register codes, it
+	{																		// loops once for each of the 3 codes in the register
+																			
+		parsed_cell = cell_data[data_counter] + (cell_data[data_counter + 1] << 8);//Each code is received as two bytes and is combined to
+																				   // create the parsed code
+		cell_codes[current_cell  + ((cell_reg - 1) * CELL_IN_REG)] = parsed_cell;
 
-  else          //Read back status group A
-  {
-    cmd[1] = 0x10;
-    cmd[0] = 0x00;
-  }
+		data_counter = data_counter + 2;                       //Because the codes are two bytes, the data counter
+															  //must increment by two for each parsed code
+	}
+	received_pec = (cell_data[data_counter] << 8) | cell_data[data_counter+1]; //The received PEC for the current_ic is transmitted as the 7th and 8th
+																			   //after the 6 cell voltage data bytes
+	data_pec = pec15_calc(BYT_IN_REG, &cell_data[(current_ic) * NUM_RX_BYT]);
 
-  cmd_pec = pec15_calc(2, cmd);
-  cmd[2] = (uint8_t)(cmd_pec >> 8);
-  cmd[3] = (uint8_t)(cmd_pec);
+	if (received_pec != data_pec)
+	{
+		pec_error = 1;                             //The pec_error variable is simply set negative if any PEC errors
+		ic_pec[cell_reg-1]=1;
+	}
+	else
+	{
+		ic_pec[cell_reg-1]=0;
+	}
+	data_counter=data_counter+2;
+	
+	return(pec_error);
+}
 
-  cs_low(CS_PIN);
-  spi_write_read(cmd,4,data,(REG_LEN*total_ic));
-  cs_high(CS_PIN);
+/* Sends the poll ADC command */
+uint8_t LTC681x_pladc()
+{
+	uint8_t cmd[4];
+	uint8_t adc_state = 0xFF;
+	uint16_t cmd_pec;
+	
+	cmd[0] = 0x07;
+	cmd[1] = 0x14;
+	cmd_pec = pec15_calc(2, cmd);
+	cmd[2] = (uint8_t)(cmd_pec >> 8);
+	cmd[3] = (uint8_t)(cmd_pec);
+	
+	cs_low(CS_PIN);
+	spi_write_array(4,cmd);
+	adc_state = spi_read_byte(0xFF);
+	cs_high(CS_PIN);
+	
+	return(adc_state);
+}
 
+/* This function will block operation until the ADC has finished it's conversion */
+uint32_t LTC681x_pollAdc()
+{
+	uint32_t counter = 0;
+	uint8_t finished = 0;
+	uint8_t current_time = 0;
+	uint8_t cmd[4];
+	uint16_t cmd_pec;
+	
+	cmd[0] = 0x07;
+	cmd[1] = 0x14;
+	cmd_pec = pec15_calc(2, cmd);
+	cmd[2] = (uint8_t)(cmd_pec >> 8);
+	cmd[3] = (uint8_t)(cmd_pec);
+	
+	cs_low(CS_PIN);
+	spi_write_array(4,cmd);
+	while ((counter<200000)&&(finished == 0))
+	{
+		current_time = spi_read_byte(0xff);
+		if (current_time>0)
+		{
+			finished = 1;
+		}
+		else
+		{
+			counter = counter + 10;
+		}
+	}
+	cs_high(CS_PIN);
+	
+	return(counter);
 }
 
 /*
@@ -737,8 +936,8 @@ after the command is sent.
 */
 void LTC681x_clrcell()
 {
-  uint8_t cmd[2]= {0x07 , 0x11};
-  cmd_68(cmd);
+	uint8_t cmd[2]= {0x07 , 0x11};
+	cmd_68(cmd);
 }
 
 /*
@@ -748,10 +947,9 @@ after the command is sent.
 */
 void LTC681x_clraux()
 {
-  uint8_t cmd[2]= {0x07 , 0x12};
-  cmd_68(cmd);
+	uint8_t cmd[2]= {0x07 , 0x12};
+	cmd_68(cmd);
 }
-
 
 /*
 The command clears the Stat registers and initializes
@@ -761,608 +959,838 @@ after the command is sent.
 */
 void LTC681x_clrstat()
 {
-  uint8_t cmd[2]= {0x07 , 0x13};
-  cmd_68(cmd);
+	uint8_t cmd[2]= {0x07 , 0x13};
+	cmd_68(cmd);
 }
 
-/*
-The command clears the Sctrl registers and initializes
-all values to 0. The register will read back hexadecimal 0x00
-after the command is sent.
-*/
-void LTC681x_clrsctrl()
+/* Starts the Mux Decoder diagnostic self test */
+void LTC681x_diagn()
 {
-  uint8_t cmd[2]= {0x00 , 0x18};
-  cmd_68(cmd);
+	uint8_t cmd[2] = {0x07 , 0x15};
+	cmd_68(cmd);
 }
 
-//Reads and parses the LTC681x cell voltage registers.
-uint8_t LTC681x_rdcv(uint8_t reg, // Controls which cell voltage register is read back.
-                     uint8_t total_ic, // the number of ICs in the system
-                     cell_asic *ic // Array of the parsed cell codes
-                    )
+/* Starts cell voltage self test conversion */
+void LTC681x_cvst(uint8_t MD, //ADC Mode
+				  uint8_t ST //Self Test
+                 )
 {
-  int8_t pec_error = 0;
-  uint8_t *cell_data;
-  uint8_t c_ic = 0;
-  cell_data = (uint8_t *) malloc((NUM_RX_BYT*total_ic)*sizeof(uint8_t));
-
-  if (reg == 0)
-  {
-    for (uint8_t cell_reg = 1; cell_reg<ic[0].ic_reg.num_cv_reg+1; cell_reg++) //executes once for each of the LTC6811 cell voltage registers
-    {
-      LTC681x_rdcv_reg(cell_reg, total_ic,cell_data );
-      for (int current_ic = 0; current_ic<total_ic; current_ic++)
-      {
-        if (ic->isospi_reverse == false)
-        {
-          c_ic = current_ic;
-        }
-        else
-        {
-          c_ic = total_ic - current_ic - 1;
-        }
-        pec_error = pec_error + parse_cells(current_ic,cell_reg, cell_data,
-                                            &ic[c_ic].cells.c_codes[0],
-                                            &ic[c_ic].cells.pec_match[0]);
-      }
-    }
-   }
-
-  else
-  {
-    LTC681x_rdcv_reg(reg, total_ic,cell_data);
-
-    for (int current_ic = 0; current_ic<total_ic; current_ic++)
-    {
-      if (ic->isospi_reverse == false)
-      {
-        c_ic = current_ic;
-      }
-      else
-      {
-        c_ic = total_ic - current_ic - 1;
-      }
-      pec_error = pec_error + parse_cells(current_ic,reg, &cell_data[8*c_ic],
-                                          &ic[c_ic].cells.c_codes[0],
-                                          &ic[c_ic].cells.pec_match[0]);
-    }
-  }
-  LTC681x_check_pec(total_ic,CELL,ic);
-  free(cell_data);
-  return(pec_error);
+	uint8_t cmd[2];
+	uint8_t md_bits;
+	
+	md_bits = (MD & 0x02) >> 1;
+	cmd[0] = md_bits + 0x02;
+	md_bits = (MD & 0x01) << 7;
+	cmd[1] =  md_bits + ((ST)<<5) +0x07;
+	
+	cmd_68(cmd);
 }
 
-/*
-The function is used
-to read the  parsed GPIO codes of the LTC6811. This function will send the requested
-read commands parse the data and store the gpio voltages in aux_codes variable
-*/
-int8_t LTC681x_rdaux(uint8_t reg, //Determines which GPIO voltage register is read back.
-                     uint8_t total_ic,//the number of ICs in the system
-                     cell_asic *ic//A two dimensional array of the gpio voltage codes.
-                    )
+/* Start an Auxiliary Register Self Test Conversion */
+void LTC681x_axst(uint8_t MD, //ADC Mode
+				  uint8_t ST //Self Test
+				  )
 {
-  uint8_t *data;
-  int8_t pec_error = 0;
-  uint8_t c_ic =0;
-  data = (uint8_t *) malloc((NUM_RX_BYT*total_ic)*sizeof(uint8_t));
+	uint8_t cmd[2];
+	uint8_t md_bits;
 
-  if (reg == 0)
-  {
-    for (uint8_t gpio_reg = 1; gpio_reg<ic[0].ic_reg.num_gpio_reg+1; gpio_reg++) //executes once for each of the LTC6811 aux voltage registers
-    {
-      LTC681x_rdaux_reg(gpio_reg, total_ic,data);                 //Reads the raw auxiliary register data into the data[] array
-      for (int current_ic = 0; current_ic<total_ic; current_ic++)
-      {
-        if (ic->isospi_reverse == false)
-        {
-          c_ic = current_ic;
-        }
-        else
-        {
-          c_ic = total_ic - current_ic - 1;
-        }
-        pec_error = parse_cells(current_ic,gpio_reg, data,
-                                &ic[c_ic].aux.a_codes[0],
-                                &ic[c_ic].aux.pec_match[0]);
+	md_bits = (MD & 0x02) >> 1;
+	cmd[0] = md_bits + 0x04;
+	md_bits = (MD & 0x01) << 7;
+	cmd[1] =  md_bits + ((ST&0x03)<<5) +0x07;
 
-      }
-    }
-  }
-  else
-  {
-    LTC681x_rdaux_reg(reg, total_ic, data);
-
-    for (int current_ic = 0; current_ic<total_ic; current_ic++)
-    {
-      if (ic->isospi_reverse == false)
-      {
-        c_ic = current_ic;
-      }
-      else
-      {
-        c_ic = total_ic - current_ic - 1;
-      }
-      pec_error = parse_cells(current_ic,reg, data,
-                              &ic[c_ic].aux.a_codes[0],
-                              &ic[c_ic].aux.pec_match[0]);
-    }
-
-  }
-  LTC681x_check_pec(total_ic,AUX,ic);
-  free(data);
-  return (pec_error);
+	cmd_68(cmd);
 }
 
-// Reads and parses the LTC681x stat registers.
-int8_t LTC681x_rdstat(uint8_t reg, //Determines which Stat  register is read back.
-                      uint8_t total_ic,//the number of ICs in the system
-                      cell_asic *ic
-                     )
-
+/* Start a Status Register Self Test Conversion */
+void LTC681x_statst(uint8_t MD, //ADC Mode
+				    uint8_t ST //Self Test
+					)
 {
-  const uint8_t BYT_IN_REG = 6;
-  const uint8_t GPIO_IN_REG = 3;
+	uint8_t cmd[2];
+	uint8_t md_bits;
 
-  uint8_t *data;
-  uint8_t data_counter = 0;
-  int8_t pec_error = 0;
-  uint16_t parsed_stat;
-  uint16_t received_pec;
-  uint16_t data_pec;
-  uint8_t c_ic = 0;
-  data = (uint8_t *) malloc((12*total_ic)*sizeof(uint8_t));
+	md_bits = (MD & 0x02) >> 1;
+	cmd[0] = md_bits + 0x04;
+	md_bits = (MD & 0x01) << 7;
+	cmd[1] =  md_bits + ((ST&0x03)<<5) +0x0F;
 
-  if (reg == 0)
-  {
-
-    for (uint8_t stat_reg = 1; stat_reg< 3; stat_reg++)                      //executes once for each of the LTC6811 stat voltage registers
-    {
-      data_counter = 0;
-      LTC681x_rdstat_reg(stat_reg, total_ic,data);                            //Reads the raw status register data into the data[] array
-
-      for (uint8_t current_ic = 0 ; current_ic < total_ic; current_ic++)      // executes for every LTC6811 in the daisy chain
-      {
-        if (ic->isospi_reverse == false)
-        {
-          c_ic = current_ic;
-        }
-        else
-        {
-          c_ic = total_ic - current_ic - 1;
-        }
-        // current_ic is used as the IC counter
-        if (stat_reg ==1)
-        {
-          for (uint8_t current_gpio = 0; current_gpio< GPIO_IN_REG; current_gpio++) // This loop parses the read back data into GPIO voltages, it
-          {
-            // loops once for each of the 3 gpio voltage codes in the register
-
-            parsed_stat = data[data_counter] + (data[data_counter+1]<<8);              //Each gpio codes is received as two bytes and is combined to
-            ic[c_ic].stat.stat_codes[current_gpio] = parsed_stat;
-            data_counter=data_counter+2;                                               //Because gpio voltage codes are two bytes the data counter
-
-          }
-        }
-        else if (stat_reg == 2)
-        {
-          parsed_stat = data[data_counter] + (data[data_counter+1]<<8);              //Each gpio codes is received as two bytes and is combined to
-          data_counter = data_counter +2;
-          ic[c_ic].stat.stat_codes[3] = parsed_stat;
-          ic[c_ic].stat.flags[0] = data[data_counter++];
-          ic[c_ic].stat.flags[1] = data[data_counter++];
-          ic[c_ic].stat.flags[2] = data[data_counter++];
-          ic[c_ic].stat.mux_fail[0] = (data[data_counter] & 0x02)>>1;
-          ic[c_ic].stat.thsd[0] = data[data_counter++] & 0x01;
-        }
-
-        received_pec = (data[data_counter]<<8)+ data[data_counter+1];          //The received PEC for the current_ic is transmitted as the 7th and 8th
-																			  //after the 6 gpio voltage data bytes
-        data_pec = pec15_calc(BYT_IN_REG, &data[current_ic*NUM_RX_BYT]);
-
-        if (received_pec != data_pec)
-        {
-          pec_error = -1; //The pec_error variable is simply set negative if any PEC errors
-          ic[c_ic].stat.pec_match[stat_reg-1]=1;  //are detected in the received serial data
-          
-        }
-        else
-        {
-          ic[c_ic].stat.pec_match[stat_reg-1]=0;
-        }
-
-        data_counter=data_counter+2;                        //Because the transmitted PEC code is 2 bytes long the data_counter
-															//must be incremented by 2 bytes to point to the next ICs gpio voltage data
-      }
-
-
-    }
-
-  }
-  else
-  {
-
-    LTC681x_rdstat_reg(reg, total_ic, data);
-    for (int current_ic = 0 ; current_ic < total_ic; current_ic++)            // executes for every LTC6811 in the daisy chain
-    {																		  // current_ic is used as an IC counter
-																				
-      if (ic->isospi_reverse == false)
-      {
-        c_ic = current_ic;
-      }
-      else
-      {
-        c_ic = total_ic - current_ic - 1;
-      }
-      if (reg ==1)
-      {
-        for (uint8_t current_gpio = 0; current_gpio< GPIO_IN_REG; current_gpio++) // This loop parses the read back data into GPIO voltages, it
-        {																		  // loops once for each of the 3 gpio voltage codes in the register
-          
-          parsed_stat = data[data_counter] + (data[data_counter+1]<<8);              //Each gpio codes is received as two bytes and is combined to
-																					 // create the parsed gpio voltage code
-
-          ic[c_ic].stat.stat_codes[current_gpio] = parsed_stat;
-          data_counter=data_counter+2;                        //Because gpio voltage codes are two bytes the data counter
-															 //must increment by two for each parsed gpio voltage code
-
-        }
-      }
-      else if (reg == 2)
-      {
-        parsed_stat = data[data_counter++] + (data[data_counter++]<<8);              //Each gpio codes is received as two bytes and is combined to
-        ic[c_ic].stat.stat_codes[3] = parsed_stat;
-        ic[c_ic].stat.flags[0] = data[data_counter++];
-        ic[c_ic].stat.flags[1] = data[data_counter++];
-        ic[c_ic].stat.flags[2] = data[data_counter++];
-        ic[c_ic].stat.mux_fail[0] = (data[data_counter] & 0x02)>>1;
-        ic[c_ic].stat.thsd[0] = data[data_counter++] & 0x01;
-      }
-
-
-      received_pec = (data[data_counter]<<8)+ data[data_counter+1];          //The received PEC for the current_ic is transmitted as the 7th and 8th
-																			//after the 6 gpio voltage data bytes
-      data_pec = pec15_calc(BYT_IN_REG, &data[current_ic*NUM_RX_BYT]);
-      if (received_pec != data_pec)
-      {
-        pec_error = -1;                             //The pec_error variable is simply set negative if any PEC errors
-        ic[c_ic].stat.pec_match[reg-1]=1;
-
-      }
-
-      data_counter=data_counter+2;
-    }
-  }
-  LTC681x_check_pec(total_ic,STAT,ic);
-  free(data);
-  return (pec_error);
+	cmd_68(cmd);
 }
 
-//Write the LTC681x CFGRA
-void LTC681x_wrcfg(uint8_t total_ic, //The number of ICs being written to
-                   cell_asic ic[]
+/* Starts cell voltage overlap conversion */
+void LTC681x_adol(uint8_t MD, //ADC Mode
+                  uint8_t DCP //Discharge Permit
+				 )
+{
+	uint8_t cmd[2];
+	uint8_t md_bits;
+	
+	md_bits = (MD & 0x02) >> 1;
+	cmd[0] = md_bits + 0x02;
+	md_bits = (MD & 0x01) << 7;
+	cmd[1] =  md_bits + (DCP<<4) +0x01;
+	
+	cmd_68(cmd);
+}
+
+/* Start an GPIO Redundancy test */
+void LTC681x_adaxd(uint8_t MD, //ADC Mode
+				   uint8_t CHG //GPIO Channels to be measured
+				   )
+{
+	uint8_t cmd[4];
+	uint8_t md_bits;
+
+	md_bits = (MD & 0x02) >> 1;
+	cmd[0] = md_bits + 0x04;
+	md_bits = (MD & 0x01) << 7;
+	cmd[1] = md_bits + CHG ;
+
+	cmd_68(cmd);
+}
+
+/* Start a Status register redundancy test Conversion */
+void LTC681x_adstatd(uint8_t MD, //ADC Mode
+					 uint8_t CHST //Stat Channels to be measured
+					 )
+{
+	uint8_t cmd[2];
+	uint8_t md_bits;
+	
+	md_bits = (MD & 0x02) >> 1;
+	cmd[0] = md_bits + 0x04;
+	md_bits = (MD & 0x01) << 7;
+	cmd[1] = md_bits + 0x08 + CHST ;
+	
+	cmd_68(cmd);
+}
+
+/* Runs the Digital Filter Self Test */
+int16_t LTC681x_run_cell_adc_st(uint8_t adc_reg, // Type of register
+								uint8_t total_ic, // Number of ICs in the daisy chain
+								cell_asic *ic, // A two dimensional array that will store the data
+								uint8_t md, // ADC Mode
+								bool adcopt // ADCOPT bit in the configuration register
+								)
+{
+	int16_t error = 0;
+	uint16_t expected_result = 0;
+
+	for (int self_test = 1; self_test<3; self_test++)
+	{
+		expected_result = LTC681x_st_lookup(md,self_test,adcopt);
+		wakeup_idle(total_ic);
+		
+		switch (adc_reg)
+		{
+		  case CELL:
+			  wakeup_idle(total_ic);
+			  LTC681x_clrcell();
+			  LTC681x_cvst(md,self_test);
+			  LTC681x_pollAdc();
+				 
+			  wakeup_idle(total_ic);
+			  error = LTC681x_rdcv(0, total_ic,ic);      
+			  for (int cic = 0; cic < total_ic; cic++)
+				{
+				  for (int channel=0; channel< ic[cic].ic_reg.cell_channels; channel++)
+				  {
+								 
+					if (ic[cic].cells.c_codes[channel] != expected_result)
+					{
+					  error = error+1;
+					}
+				  }
+				}
+			break;
+		  case AUX:
+			  error = 0;
+			  wakeup_idle(total_ic);
+			  LTC681x_clraux();
+			  LTC681x_axst(md,self_test);
+			  LTC681x_pollAdc();
+			  
+			  wakeup_idle(total_ic);
+			  LTC681x_rdaux(0, total_ic,ic);     
+			  for (int cic = 0; cic < total_ic; cic++)
+				{
+				  for (int channel=0; channel< ic[cic].ic_reg.aux_channels; channel++)
+				  { 
+					 
+					if (ic[cic].aux.a_codes[channel] != expected_result)
+					{
+					  error = error+1;
+					}
+				  }
+				}
+			break;
+		  case STAT:
+			  wakeup_idle(total_ic);
+			  LTC681x_clrstat();
+			  LTC681x_statst(md,self_test);
+			  LTC681x_pollAdc();
+			  
+			  wakeup_idle(total_ic);
+			  error = LTC681x_rdstat(0,total_ic,ic);
+			  for (int cic = 0; cic < total_ic; cic++)
+				{
+				  for (int channel=0; channel< ic[cic].ic_reg.stat_channels; channel++)
+				  {
+					if (ic[cic].stat.stat_codes[channel] != expected_result)
+					{
+					  error = error+1;
+					}
+				  }
+				}
+			break;
+
+		  default:
+			error = -1;
+			break;
+		}
+	}
+	
+	return(error);
+}
+
+/* Runs the ADC overlap test for the IC */
+uint16_t LTC681x_run_adc_overlap(uint8_t total_ic,  // Number of ICs in the daisy chain
+								 cell_asic *ic  // A two dimensional array that will store the data
+								 )
+{
+	uint16_t error = 0;
+	int32_t measure_delta =0;
+	int16_t failure_pos_limit = 20;
+	int16_t failure_neg_limit = -20;
+	int32_t a, b;
+	
+	wakeup_idle(total_ic);
+	LTC681x_adol(MD_7KHZ_3KHZ,DCP_DISABLED);
+	LTC681x_pollAdc();
+	wakeup_idle(total_ic);
+	error = LTC681x_rdcv(0, total_ic,ic);
+
+	  for (int cic = 0; cic<total_ic; cic++)
+	  {
+		  measure_delta = (int32_t)ic[cic].cells.c_codes[6]-(int32_t)ic[cic].cells.c_codes[7];
+		
+		 if ((measure_delta>failure_pos_limit) || (measure_delta<failure_neg_limit))
+		 {
+		  error = error | (1<<(cic-1));
+		 }
+	  }
+	  
+    return(error);
+}
+
+/* Runs the redundancy self test */
+int16_t LTC681x_run_adc_redundancy_st(uint8_t adc_mode, // ADC Mode
+									  uint8_t adc_reg, // Type of register
+									  uint8_t total_ic, // Number of ICs in the daisy chain
+									  cell_asic *ic // A two dimensional array that will store the data
+									  )
+{
+	int16_t error = 0;
+	for (int self_test = 1; self_test<3; self_test++)
+	{
+		wakeup_idle(total_ic);
+		switch (adc_reg)
+		{
+			case AUX:
+			LTC681x_clraux();
+			LTC681x_adaxd(adc_mode,AUX_CH_ALL);
+			LTC681x_pollAdc();
+		
+			wakeup_idle(total_ic);
+			error = LTC681x_rdaux(0, total_ic,ic);
+			for (int cic = 0; cic < total_ic; cic++)
+			{
+				for (int channel=0; channel< ic[cic].ic_reg.aux_channels; channel++)
+				{ 
+					if (ic[cic].aux.a_codes[channel] >= 65280)
+					{
+						error = error+1;
+					}
+				}
+			}
+			break;
+			case STAT:
+			LTC681x_clrstat();
+			LTC681x_adstatd(adc_mode,STAT_CH_ALL);
+			LTC681x_pollAdc();
+			wakeup_idle(total_ic);
+			error = LTC681x_rdstat(0,total_ic,ic);
+			for (int cic = 0; cic < total_ic; cic++)
+			{
+				for (int channel=0; channel< ic[cic].ic_reg.stat_channels; channel++)
+				{
+					if (ic[cic].stat.stat_codes[channel] >= 65280)
+					{
+						error = error+1;
+					}
+				}
+			}
+			break;
+		
+			default:
+			error = -1;
+			break;
+		}
+	}
+	return(error);
+}
+
+/* Looks up the result pattern for digital filter self test */
+uint16_t LTC681x_st_lookup(uint8_t MD, //ADC Mode
+						   uint8_t ST, //Self Test
+						   bool adcopt // ADCOPT bit in the configuration register
+						  )
+{
+	uint16_t test_pattern = 0;
+
+    if (MD == 1)
+    { 
+		if ( adcopt == false)
+		{	
+			if (ST == 1)
+			{
+				test_pattern = 0x9565;
+			}
+			else
+			{
+				test_pattern = 0x6A9A;
+			}
+		}
+		else
+		{	
+			if (ST == 1)
+			{
+				test_pattern = 0x9553;
+			}
+			else
+			{
+				test_pattern = 0x6AAC;
+			}	
+		}
+    }
+    else
+    {
+		if (ST == 1)
+		{
+		   test_pattern = 0x9555;
+		}
+		else
+		{
+		   test_pattern = 0x6AAA;
+		}
+    }
+    return(test_pattern);
+}
+
+/* Start an open wire Conversion */
+void LTC681x_adow(uint8_t MD, //ADC Mode
+				  uint8_t PUP,//Pull up/Pull down current
+				  uint8_t CH, //Channels
+				  uint8_t DCP//Discharge Permit
+				 )
+{
+	uint8_t cmd[2];
+	uint8_t md_bits;
+	
+	md_bits = (MD & 0x02) >> 1;
+	cmd[0] = md_bits + 0x02;
+	md_bits = (MD & 0x01) << 7;
+	cmd[1] =  md_bits + 0x28 + (PUP<<6) + CH+(DCP<<4);
+	
+	cmd_68(cmd);
+}
+
+/* Start GPIOs open wire ADC conversion */
+void LTC681x_axow(uint8_t MD, //ADC Mode
+				  uint8_t PUP //Pull up/Pull down current
+				 )
+{
+	uint8_t cmd[2];
+	uint8_t md_bits;
+	
+	md_bits = (MD & 0x02) >> 1;
+	cmd[0] = md_bits + 0x04;
+	md_bits = (MD & 0x01) << 7;
+	cmd[1] =  md_bits + 0x10+ (PUP<<6) ;//+ CH;
+	
+	cmd_68(cmd);
+}
+
+/* Runs the data sheet algorithm for open wire for single cell detection */
+void LTC681x_run_openwire_single(uint8_t total_ic, // Number of ICs in the daisy chain
+								cell_asic ic[] // A two dimensional array that will store the data
+								)
+{				  
+	uint16_t OPENWIRE_THRESHOLD = 4000;
+	const uint8_t  N_CHANNELS = ic[0].ic_reg.cell_channels;
+	
+	uint16_t pullUp[total_ic][N_CHANNELS];
+	uint16_t pullDwn[total_ic][N_CHANNELS];
+	int16_t openWire_delta[total_ic][N_CHANNELS];
+	
+	int8_t error;
+	int8_t i;
+	uint32_t conv_time=0;
+
+	wakeup_sleep(total_ic);
+	LTC681x_clrcell();
+	
+	// Pull Ups
+	for (i = 0; i < 3; i++)
+	{ 
+	  wakeup_idle(total_ic);
+	  LTC681x_adow(MD_26HZ_2KHZ,PULL_UP_CURRENT,CELL_CH_ALL,DCP_DISABLED);
+	  conv_time =LTC681x_pollAdc();
+	} 
+	
+	wakeup_idle(total_ic);
+	error=LTC681x_rdcv(0, total_ic,ic);
+	
+	for (int cic=0; cic<total_ic; cic++)
+	{
+	    for (int cell=0; cell<N_CHANNELS; cell++)
+		{
+		  pullUp[cic][cell] = ic[cic].cells.c_codes[cell];
+		}	
+	}
+
+	// Pull Downs
+	for (i = 0; i < 3; i++)
+	{  
+	  wakeup_idle(total_ic);
+	  LTC681x_adow(MD_26HZ_2KHZ,PULL_DOWN_CURRENT,CELL_CH_ALL,DCP_DISABLED);
+	  conv_time =LTC681x_pollAdc();
+	}
+	
+	wakeup_idle(total_ic);
+	error=LTC681x_rdcv(0, total_ic,ic); 
+	
+	for (int cic=0; cic<total_ic; cic++)
+	{		  
+	    for (int cell=0; cell<N_CHANNELS; cell++)
+		{
+		   pullDwn[cic][cell] = ic[cic].cells.c_codes[cell];
+		}
+	}
+
+	for (int cic=0; cic<total_ic; cic++)
+	{
+	  ic[cic].system_open_wire = 0xFFFF;
+	  
+		for (int cell=0; cell<N_CHANNELS; cell++)
+		{
+			if (pullDwn[cic][cell] < pullUp[cic][cell])                   
+			{
+				openWire_delta[cic][cell] = (pullUp[cic][cell] - pullDwn[cic][cell]);
+			}
+			else
+			{
+				openWire_delta[cic][cell] = 0;                                             
+			}  
+				
+			if (openWire_delta[cic][cell]>OPENWIRE_THRESHOLD)
+			{
+				ic[cic].system_open_wire = cell+1;
+			}
+		}
+		
+		if (pullUp[cic][0] == 0)
+		{
+		  ic[cic].system_open_wire = 0;
+		}
+		
+		if (pullUp[cic][(N_CHANNELS-1)] == 0)//checking the Pull up value of the top measured channel
+		{
+		  ic[cic].system_open_wire = N_CHANNELS;
+		}	
+	}
+}
+
+/* Runs the data sheet algorithm for open wire for multiple cell and two consecutive cells detection */
+ void LTC681x_run_openwire_multi(uint8_t total_ic, // Number of ICs in the daisy chain
+						  cell_asic ic[] // A two dimensional array that will store the data
+						  )
+{              
+	uint16_t OPENWIRE_THRESHOLD = 4000;
+	const uint8_t  N_CHANNELS = ic[0].ic_reg.cell_channels;
+
+	uint16_t pullUp[total_ic][N_CHANNELS];
+	uint16_t pullDwn[total_ic][N_CHANNELS];
+	uint16_t openWire_delta[total_ic][N_CHANNELS];
+
+	int8_t error;
+	int8_t opencells[N_CHANNELS];
+	int8_t n=0;
+	int8_t i,j,k;
+	uint32_t conv_time=0;
+
+	wakeup_sleep(total_ic);
+	LTC681x_clrcell();
+
+	// Pull Ups
+	for (i = 0; i < 5; i++)
+	{ 
+		wakeup_idle(total_ic);
+		LTC681x_adow(MD_26HZ_2KHZ,PULL_UP_CURRENT,CELL_CH_ALL,DCP_DISABLED);
+		conv_time =LTC681x_pollAdc();
+	} 
+
+	wakeup_idle(total_ic);
+	error = LTC681x_rdcv(0, total_ic,ic);
+
+	for (int cic=0; cic<total_ic; cic++)
+	{
+	    for (int cell=0; cell<N_CHANNELS; cell++)
+		{
+		  pullUp[cic][cell] = ic[cic].cells.c_codes[cell];
+		}
+	}
+
+	// Pull Downs
+	for (i = 0; i < 5; i++)
+	{  
+	  wakeup_idle(total_ic);
+	  LTC681x_adow(MD_26HZ_2KHZ,PULL_DOWN_CURRENT,CELL_CH_ALL,DCP_DISABLED);
+	  conv_time =   LTC681x_pollAdc();
+	}
+
+	wakeup_idle(total_ic);
+	error = LTC681x_rdcv(0, total_ic,ic); 
+
+	for (int cic=0; cic<total_ic; cic++)
+	{
+		for (int cell=0; cell<N_CHANNELS; cell++)
+		{
+		   pullDwn[cic][cell] = ic[cic].cells.c_codes[cell];
+		}
+	}
+
+	for (int cic=0; cic<total_ic; cic++)
+	{			  
+		for (int cell=0; cell<N_CHANNELS; cell++)
+		{
+			if (pullDwn[cic][cell] < pullUp[cic][cell])                   
+				{
+					openWire_delta[cic][cell] = (pullUp[cic][cell] - pullDwn[cic][cell]);
+				}
+				else
+				{
+					openWire_delta[cic][cell] = 0;                                             
+				}
+		}  
+	}
+
+	for (int cic=0; cic<total_ic; cic++)
+	{ 
+		n=0;
+						
+		Serial.print("IC:");
+		Serial.println(cic+1, DEC);
+		
+		for (int cell=0; cell<N_CHANNELS; cell++)
+		{  
+		 
+		  if (openWire_delta[cic][cell]>OPENWIRE_THRESHOLD)
+			{
+				opencells[n] = cell+1;
+				n++;
+				for (int j = cell; j < N_CHANNELS-3 ; j++)                       
+				{
+					if (pullUp[cic][j + 2] == 0)
+					{
+					opencells[n] = j+2;
+					n++;
+					}
+				}
+				if((cell==N_CHANNELS-4) && (pullDwn[cic][N_CHANNELS-3] == 0))
+				{
+					  opencells[n] = N_CHANNELS-2;
+					  n++;
+				}
+			}
+		}
+		if (pullDwn[cic][0] == 0)
+		{
+		  opencells[n] = 0;
+		  Serial.println("Cell 0 is Open and multiple open wires maybe possible.");
+		  n++;
+		}
+					
+		if (pullDwn[cic][N_CHANNELS-1] == 0)
+		{
+		  opencells[n] = N_CHANNELS;
+		  n++;
+		}
+					
+		if (pullDwn[cic][N_CHANNELS-2] == 0)
+		{  
+		  opencells[n] = N_CHANNELS-1;
+		  n++;
+		}
+		
+	//Removing repetitive elements
+		for(i=0;i<n;i++)
+		{
+			for(j=i+1;j<n;)
+			{
+				if(opencells[i]==opencells[j])
+				{
+					for(k=j;k<n;k++)
+						opencells[k]=opencells[k+1];
+						
+					n--;
+				}
+				else
+					j++;
+			}
+		}
+					
+	// Sorting open cell array
+		for(int i=0; i<n; i++)
+		{
+			for(int j=0; j<n-1; j++)
+			{
+				if( opencells[j] > opencells[j+1] )
+				{
+					k = opencells[j];
+					opencells[j] = opencells[j+1];
+					opencells[j+1] = k;
+				}
+			}
+		}
+					
+	//Checking the value of n				
+		Serial.println("Number of Open wires:");
+		Serial.println(n);
+		   
+	//Printing open cell array
+		Serial.println("OPEN CELLS:");
+		if(n==0)
+		{
+			Serial.println("No Open wires");
+		}
+		else
+		{				
+			for(i=0;i<n;i++)
+			{
+					Serial.println(opencells[i]);	
+			}
+		}
+	}
+	Serial.println("\n");
+}
+
+/* Runs open wire for GPIOs */
+void LTC681x_run_gpio_openwire(uint8_t total_ic, // Number of ICs in the daisy chain
+								cell_asic ic[] // A two dimensional array that will store the data
+								)
+ {				  
+	uint16_t OPENWIRE_THRESHOLD = 150;
+	const uint8_t  N_CHANNELS = ic[0].ic_reg.aux_channels +1;
+	
+	uint16_t aux_val[total_ic][N_CHANNELS];
+	uint16_t pDwn[total_ic][N_CHANNELS];
+	uint16_t ow_delta[total_ic][N_CHANNELS];
+	
+	int8_t error;
+	int8_t i;
+	uint32_t conv_time=0;
+
+	wakeup_sleep(total_ic); 
+	LTC681x_clraux();
+	 
+	for (i = 0; i < 3; i++)
+	{ 
+	   wakeup_idle(total_ic);
+	   LTC681x_adax(MD_7KHZ_3KHZ, AUX_CH_ALL);
+	   conv_time= LTC681x_pollAdc();
+	}
+	
+	wakeup_idle(total_ic);
+	error = LTC681x_rdaux(0, total_ic,ic);
+	
+	for (int cic=0; cic<total_ic; cic++)
+	{
+	    for (int channel=0; channel<N_CHANNELS; channel++)
+		{
+			aux_val[cic][channel]=ic[cic].aux.a_codes[channel];
+		}
+	}	
+	LTC681x_clraux();
+	
+	// pull downs
+	for (i = 0; i < 3; i++)
+	{ 
+	   wakeup_idle(total_ic);
+	   LTC681x_axow(MD_7KHZ_3KHZ,PULL_DOWN_CURRENT);
+	   conv_time =LTC681x_pollAdc();
+	} 
+	
+	wakeup_idle(total_ic);
+	error = LTC681x_rdaux(0, total_ic,ic);
+	
+	for (int cic=0; cic<total_ic; cic++)
+	{
+	   for (int channel=0; channel<N_CHANNELS; channel++)
+		{
+			pDwn[cic][channel]=ic[cic].aux.a_codes[channel] ;
+		}
+	}
+	
+	for (int cic=0; cic<total_ic; cic++)
+	{  
+		ic[cic].system_open_wire = 0xFFFF;
+		
+		for (int channel=0; channel<N_CHANNELS; channel++)
+		{
+			if (pDwn[cic][channel] > aux_val[cic][channel])                   
+			{
+				ow_delta[cic][channel] = (pDwn[cic][channel] - aux_val[cic][channel]);
+			}
+			else
+			{
+				ow_delta[cic][channel] = 0;                                             
+			} 
+			
+			if(channel<5)
+			{
+				if (ow_delta[cic][channel] > OPENWIRE_THRESHOLD) 
+				{
+					ic[cic].system_open_wire= channel+1;
+					
+				}  
+			}
+			else if(channel>5)
+			{
+				if (ow_delta[cic][channel] > OPENWIRE_THRESHOLD) 
+				{
+					ic[cic].system_open_wire= channel;
+					
+				}  
+			}	
+		}
+	}	  
+}
+
+/* Clears all of the DCC bits in the configuration registers */
+void LTC681x_clear_discharge(uint8_t total_ic, // Number of ICs in the daisy chain
+							 cell_asic *ic // A two dimensional array that will store the data
+							 )
+{
+	for (int i=0; i<total_ic; i++)
+	{
+	   ic[i].config.tx_data[4] = 0;
+	   ic[i].config.tx_data[5] =ic[i].config.tx_data[5]&(0xF0);
+	   ic[i].configb.tx_data[0]=ic[i].configb.tx_data[0]&(0x0F); 
+	   ic[i].configb.tx_data[1]=ic[i].configb.tx_data[1]&(0xF0);
+	}
+}
+
+/* Writes the pwm register */
+void LTC681x_wrpwm(uint8_t total_ic, // Number of ICs in the daisy chain
+                   uint8_t pwmReg, // The PWM Register to be written A or B
+                   cell_asic ic[] // A two dimensional array that stores the data to be written
                   )
 {
-  uint8_t cmd[2] = {0x00 , 0x01} ;
-  uint8_t write_buffer[256];
-  uint8_t write_count = 0;
-  uint8_t c_ic = 0;
-  for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
-  {
-    if (ic->isospi_reverse == true)
-    {
-      c_ic = current_ic;
-    }
-    else
-    {
-      c_ic = total_ic - current_ic - 1;
-    }
-
-    for (uint8_t data = 0; data<6; data++)
-    {
-      write_buffer[write_count] = ic[c_ic].config.tx_data[data];
-      write_count++;
-    }
-  }
-  write_68(total_ic, cmd, write_buffer);
-}
-
-//Write the LTC681x CFGRB
-void LTC681x_wrcfgb(uint8_t total_ic, //The number of ICs being written to
-                    cell_asic ic[]
-                   )
-{
-  uint8_t cmd[2] = {0x00 , 0x24} ;
-  uint8_t write_buffer[256];
-  uint8_t write_count = 0;
-  uint8_t c_ic = 0;
-  for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
-  {
-    if (ic->isospi_reverse == true)
-    {
-      c_ic = current_ic;
-    }
-    else
-    {
-      c_ic = total_ic - current_ic - 1;
-    }
-
-    for (uint8_t data = 0; data<6; data++)
-    {
-      write_buffer[write_count] = ic[c_ic].configb.tx_data[data];
-      write_count++;
-    }
-  }
-  write_68(total_ic, cmd, write_buffer);
-}
-
-//Read CFGA
-int8_t LTC681x_rdcfg(uint8_t total_ic, //Number of ICs in the system
-                     cell_asic ic[]
-                    )
-{
-  uint8_t cmd[2]= {0x00 , 0x02};
-  uint8_t read_buffer[256];
-  int8_t pec_error = 0;
-  uint16_t data_pec;
-  uint16_t calc_pec;
-  uint8_t c_ic = 0;
-  pec_error = read_68(total_ic, cmd, read_buffer);
-  for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
-  {
-    if (ic->isospi_reverse == false)
-    {
-      c_ic = current_ic;
-    }
-    else
-    {
-      c_ic = total_ic - current_ic - 1;
-    }
-
-    for (int byte=0; byte<8; byte++)
-    {
-      ic[c_ic].config.rx_data[byte] = read_buffer[byte+(8*current_ic)];
-    }
-    calc_pec = pec15_calc(6,&read_buffer[8*current_ic]);
-    data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
-    if (calc_pec != data_pec )
-    {
-      ic[c_ic].config.rx_pec_match = 1;
-    }
-    else ic[c_ic].config.rx_pec_match = 0;
-  }
-  LTC681x_check_pec(total_ic,CFGR,ic);
-  return(pec_error);
-}
-
-//Reads CFGB
-int8_t LTC681x_rdcfgb(uint8_t total_ic, //Number of ICs in the system
-                      cell_asic ic[]
-                     )
-{
-  uint8_t cmd[2]= {0x00 , 0x26};
-  uint8_t read_buffer[256];
-  int8_t pec_error = 0;
-  uint16_t data_pec;
-  uint16_t calc_pec;
-  uint8_t c_ic = 0;
-  pec_error = read_68(total_ic, cmd, read_buffer);
-  for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
-  {
-    if (ic->isospi_reverse == false)
-    {
-      c_ic = current_ic;
-    }
-    else
-    {
-      c_ic = total_ic - current_ic - 1;
-    }
-
-    for (int byte=0; byte<8; byte++)
-    {
-      ic[c_ic].configb.rx_data[byte] = read_buffer[byte+(8*current_ic)];
-    }
-    calc_pec = pec15_calc(6,&read_buffer[8*current_ic]);
-    data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
-    if (calc_pec != data_pec )
-    {
-      ic[c_ic].configb.rx_pec_match = 1;
-    }
-    else ic[c_ic].configb.rx_pec_match = 0;
-  }
-  LTC681x_check_pec(total_ic,CFGRB,ic);
-  return(pec_error);
-}
-
-// Writes the pwm register
-void LTC681x_wrpwm(uint8_t total_ic,
-                   uint8_t pwmReg,
-                   cell_asic ic[]
-                  )
-{
-  uint8_t cmd[2];
-  uint8_t write_buffer[256];
-  uint8_t write_count = 0;
-  uint8_t c_ic = 0;
-  if (pwmReg == 0)
-  {
-    cmd[0] = 0x00;
-    cmd[1] = 0x20;
-  }
-  else
-  {
-    cmd[0] = 0x00;
-    cmd[1] = 0x1C;
-  }
-
-  for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
-  {
-    if (ic->isospi_reverse == true)
-    {
-      c_ic = current_ic;
-    }
-    else
-    {
-      c_ic = total_ic - current_ic - 1;
-    }
-    for (uint8_t data = 0; data<6; data++)
-    {
-      write_buffer[write_count] = ic[c_ic].pwm.tx_data[data];
-      write_count++;
-    }
-  }
-  write_68(total_ic, cmd, write_buffer);
+	uint8_t cmd[2];
+	uint8_t write_buffer[256];
+	uint8_t write_count = 0;
+	uint8_t c_ic = 0;
+	if (pwmReg == 0)
+	{
+	cmd[0] = 0x00;
+	cmd[1] = 0x20;
+	}
+	else
+	{
+	cmd[0] = 0x00;
+	cmd[1] = 0x1C;
+	}
+	
+	for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
+	{
+		if (ic->isospi_reverse == true)
+		{
+			c_ic = current_ic;
+		}
+		else
+		{
+			c_ic = total_ic - current_ic - 1;
+		}
+		
+		for (uint8_t data = 0; data<6; data++)
+		{
+			write_buffer[write_count] = ic[c_ic].pwm.tx_data[data];
+			write_count++;
+		}
+	}
+	write_68(total_ic, cmd, write_buffer);
 }
 
 
-//Reads pwm registers of a LTC6811 daisy chain
+/* Reads pwm registers of a LTC681x daisy chain */
 int8_t LTC681x_rdpwm(uint8_t total_ic, //Number of ICs in the system
-                     uint8_t pwmReg,
-                     cell_asic ic[]
+                     uint8_t pwmReg, // The PWM Register to be written A or B
+                     cell_asic ic[] // A two dimensional array that will store the data
                     )
 {
-  const uint8_t BYTES_IN_REG = 8;
-
-  uint8_t cmd[4];
-  uint8_t read_buffer[256];
-  int8_t pec_error = 0;
-  uint16_t data_pec;
-  uint16_t calc_pec;
-  uint8_t c_ic = 0;
-
-  if (pwmReg == 0)
-  {
-    cmd[0] = 0x00;
-    cmd[1] = 0x22;
-  }
-  else
-  {
-    cmd[0] = 0x00;
-    cmd[1] = 0x1E;
-  }
-
-
-  pec_error = read_68(total_ic, cmd, read_buffer);
-  for (uint8_t current_ic =0; current_ic<total_ic; current_ic++)
-  {
-    if (ic->isospi_reverse == false)
-    {
-      c_ic = current_ic;
-    }
-    else
-    {
-      c_ic = total_ic - current_ic - 1;
-    }
-    for (int byte=0; byte<8; byte++)
-    {
-      ic[c_ic].pwm.rx_data[byte] = read_buffer[byte+(8*current_ic)];
-    }
-    calc_pec = pec15_calc(6,&read_buffer[8*current_ic]);
-    data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
-    if (calc_pec != data_pec )
-    {
-      ic[c_ic].pwm.rx_pec_match = 1;
-    }
-    else ic[c_ic].pwm.rx_pec_match = 0;
-  }
-  return(pec_error);
+	const uint8_t BYTES_IN_REG = 8;
+	uint8_t cmd[4];
+	uint8_t read_buffer[256];
+	int8_t pec_error = 0;
+	uint16_t data_pec;
+	uint16_t calc_pec;
+	uint8_t c_ic = 0;
+	
+	if (pwmReg == 0)
+	{
+		cmd[0] = 0x00;
+		cmd[1] = 0x22;
+	}
+	else
+	{
+		cmd[0] = 0x00;
+		cmd[1] = 0x1E;
+	}
+	
+	pec_error = read_68(total_ic, cmd, read_buffer);
+	for (uint8_t current_ic =0; current_ic<total_ic; current_ic++)
+	{
+		if (ic->isospi_reverse == false)
+		{
+			c_ic = current_ic;
+		}
+		else
+		{
+			c_ic = total_ic - current_ic - 1;
+		}
+		
+		for (int byte=0; byte<8; byte++)
+		{
+			ic[c_ic].pwm.rx_data[byte] = read_buffer[byte+(8*current_ic)];
+		}
+		
+		calc_pec = pec15_calc(6,&read_buffer[8*current_ic]);
+		data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
+		if (calc_pec != data_pec )
+		{
+			ic[c_ic].pwm.rx_pec_match = 1;
+		}
+		else ic[c_ic].pwm.rx_pec_match = 0;
+	}
+	return(pec_error);
 }
 
-//Writes the comm register
-void LTC681x_wrcomm(uint8_t total_ic, //The number of ICs being written to
-                    cell_asic ic[]
-                   )
-{
-  uint8_t cmd[2]= {0x07 , 0x21};
-  uint8_t write_buffer[256];
-  uint8_t write_count = 0;
-  uint8_t c_ic = 0;
-  for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
-  {
-    if (ic->isospi_reverse == true)
-    {
-      c_ic = current_ic;
-    }
-    else
-    {
-      c_ic = total_ic - current_ic - 1;
-    }
-
-    for (uint8_t data = 0; data<6; data++)
-    {
-      write_buffer[write_count] = ic[c_ic].com.tx_data[data];
-      write_count++;
-    }
-  }
-  write_68(total_ic, cmd, write_buffer);
-}
-
-//Reads COMM registers of a LTC6811 daisy chain
-int8_t LTC681x_rdcomm(uint8_t total_ic, //Number of ICs in the system
-                      cell_asic ic[]
-                     )
-{
-  uint8_t cmd[2]= {0x07 , 0x22};
-  uint8_t read_buffer[256];
-  int8_t pec_error = 0;
-  uint16_t data_pec;
-  uint16_t calc_pec;
-  uint8_t c_ic=0;
-  pec_error = read_68(total_ic, cmd, read_buffer);
-  for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
-  {
-    if (ic->isospi_reverse == false)
-    {
-      c_ic = current_ic;
-    }
-    else
-    {
-      c_ic = total_ic - current_ic - 1;
-    }
-
-    for (int byte=0; byte<8; byte++)
-    {
-      ic[c_ic].com.rx_data[byte] = read_buffer[byte+(8*current_ic)];
-    }
-    calc_pec = pec15_calc(6,&read_buffer[8*current_ic]);
-    data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
-    if (calc_pec != data_pec )
-    {
-      ic[c_ic].com.rx_pec_match = 1;
-    }
-    else ic[c_ic].com.rx_pec_match = 0;
-  }
-  return(pec_error);
-}
-
-//Shifts data in COMM register out over LTC6811 SPI/I2C port
-void LTC681x_stcomm()
-{
-
-  uint8_t cmd[4];
-  uint16_t cmd_pec;
-
-  cmd[0] = 0x07;
-  cmd[1] = 0x23;
-  cmd_pec = pec15_calc(2, cmd);
-  cmd[2] = (uint8_t)(cmd_pec >> 8);
-  cmd[3] = (uint8_t)(cmd_pec);
-
-  cs_low(CS_PIN);
-  spi_write_array(4,cmd);
-  for (int i = 0; i<9; i++)
-  {
-    spi_read_byte(0xFF);
-  }
-  cs_high(CS_PIN);
-
-}
-
-// Write the ltc6811 Sctrl register 
-void LTC681x_wrsctrl(uint8_t total_ic, // number of ICs in the daisy chain
-                     uint8_t sctrl_reg,
-                     cell_asic *ic
+/*  Write the LTC681x Sctrl register */
+void LTC681x_wrsctrl(uint8_t total_ic, // Number of ICs in the daisy chain
+                     uint8_t sctrl_reg, // The Sctrl Register to be written A or B
+                     cell_asic *ic  // A two dimensional array that stores the data to be written
                     )
 {
 	uint8_t cmd[2];
@@ -1389,21 +1817,16 @@ void LTC681x_wrsctrl(uint8_t total_ic, // number of ICs in the daisy chain
         for(uint8_t data = 0; data<6;data++)
         {
             write_buffer[write_count] = ic[c_ic].sctrl.tx_data[data];
-			
             write_count++;
         }
     }
     write_68(total_ic, cmd, write_buffer);
 }					
 					
-/* Reads sctrl registers of a ltc6811 daisy chain    
-@return int8_t, PEC Status.
-  0: Data read back has matching PEC
-  -1: Data read back has incorrect PEC
-*/
-int8_t LTC681x_rdsctrl(uint8_t total_ic, // number of ICs in the daisy chain
-                       uint8_t sctrl_reg,
-                       cell_asic *ic // a two dimensional array that the function stores the read pwm data
+/*  Reads sctrl registers of a LTC681x daisy chain */    
+int8_t LTC681x_rdsctrl(uint8_t total_ic, // Number of ICs in the daisy chain
+                       uint8_t sctrl_reg, // The Sctrl Register to be written A or B
+                       cell_asic *ic // A two dimensional array that the function stores the read data
                       )	
 {
     uint8_t cmd[4];
@@ -1422,7 +1845,7 @@ int8_t LTC681x_rdsctrl(uint8_t total_ic, // number of ICs in the daisy chain
     {
       cmd[0] = 0x00;
       cmd[1] = 0x1E;
-	  }
+	}
     
     pec_error = read_68(total_ic, cmd, read_buffer);
 
@@ -1449,12 +1872,13 @@ int8_t LTC681x_rdsctrl(uint8_t total_ic, // number of ICs in the daisy chain
     return(pec_error);
 }
 
-/* Start Sctrl data communication       
+/* 
+Start Sctrl data communication       
 This command will start the sctrl pulse communication over the spins
 */
 void LTC681x_stsctrl()
 {
-	 uint8_t cmd[4];
+	uint8_t cmd[4];
     uint16_t cmd_pec;
     
     cmd[0] = 0x00;
@@ -1464,707 +1888,296 @@ void LTC681x_stsctrl()
     cmd[3] = (uint8_t)(cmd_pec);
     
     cs_low(CS_PIN);
-    spi_write_array(4,cmd);         
-    
+    spi_write_array(4,cmd);          
     cs_high(CS_PIN);
-
 }
 
-//Clears all of the DCC bits in the configuration registers
-void LTC681x_clear_discharge(uint8_t total_ic, 
-							 cell_asic *ic
-							 )
+/*
+The command clears the Sctrl registers and initializes
+all values to 0. The register will read back hexadecimal 0x00
+after the command is sent.
+*/
+void LTC681x_clrsctrl()
 {
-  for (int i=0; i<total_ic; i++)
-  {
-    ic[i].config.tx_data[4] = 0;
-	ic[i].config.tx_data[5] =ic[i].config.tx_data[5]&(0xF0);
-	ic[i].configb.tx_data[0]=ic[i].configb.tx_data[0]&(0x0F); 
-	ic[i].configb.tx_data[1]=ic[i].configb.tx_data[1]&(0xF0);
-  }
-}
-
-//Looks up the result pattern for digital filter self test
-uint16_t LTC681x_st_lookup(uint8_t MD, //ADC Mode
-						   uint8_t ST, //Self Test
-						   bool adcopt
-						  )
-{
- uint16_t test_pattern = 0;
-
-    if (MD == 1)
-    { 
-		if ( adcopt == false)
-		{	 if (ST == 1)
-			  {
-				test_pattern = 0x9565;
-			  }
-			  else
-			  {
-				test_pattern = 0x6A9A;
-			  }
-		}
-		else
-		{	  if (ST == 1)
-			  {
-				test_pattern = 0x9553;
-			  }
-			  else
-			  {
-				test_pattern = 0x6AAC;
-			  }
-			
-		}
-    }
-    else
-    {
-		if (ST == 1)
-		{
-		   test_pattern = 0x9555;
-		}
-		else
-		{
-		   test_pattern = 0x6AAA;
-		}
-    }
-    return(test_pattern);
-}
-
-// Runs the Digital Filter Self Test
-int16_t LTC681x_run_cell_adc_st(uint8_t adc_reg,
-								uint8_t total_ic, 
-								cell_asic *ic, 
-								uint8_t md, 
-								bool adcopt
-								)
-{
-  int16_t error = 0;
-  uint16_t expected_result = 0;
-  
-  for (int self_test = 1; self_test<3; self_test++)
-  {
-
-    expected_result = LTC681x_st_lookup(md,self_test,adcopt);
-    wakeup_idle(total_ic);
-    switch (adc_reg)
-    {
-      case CELL:
-		  wakeup_idle(total_ic);
-		  LTC681x_clrcell();
-		  LTC681x_cvst(md,self_test);
-		  LTC681x_pollAdc();
-		     
-		  wakeup_idle(total_ic);
-		  error = LTC681x_rdcv(0, total_ic,ic);      
-		  for (int cic = 0; cic < total_ic; cic++)
-			{
-			  for (int channel=0; channel< ic[cic].ic_reg.cell_channels; channel++)
-			  {
-				             
-				if (ic[cic].cells.c_codes[channel] != expected_result)
-				{
-				  error = error+1;
-				}
-			  }
-			}
-        break;
-      case AUX:
-		  error = 0;
-		  wakeup_idle(total_ic);
-		  LTC681x_clraux();
-		  LTC681x_axst(md,self_test);
-		  LTC681x_pollAdc();
-		  
-		  wakeup_idle(total_ic);
-		  LTC681x_rdaux(0, total_ic,ic);     
-		  for (int cic = 0; cic < total_ic; cic++)
-			{
-			  for (int channel=0; channel< ic[cic].ic_reg.aux_channels; channel++)
-			  { 
-				 
-				if (ic[cic].aux.a_codes[channel] != expected_result)
-				{
-				  error = error+1;
-				}
-			  }
-			}
-        break;
-      case STAT:
-		  wakeup_idle(total_ic);
-		  LTC681x_clrstat();
-		  LTC681x_statst(md,self_test);
-		  LTC681x_pollAdc();
-		  
-		  wakeup_idle(total_ic);
-		  error = LTC681x_rdstat(0,total_ic,ic);
-		  for (int cic = 0; cic < total_ic; cic++)
-			{
-			  for (int channel=0; channel< ic[cic].ic_reg.stat_channels; channel++)
-			  {
-				if (ic[cic].stat.stat_codes[channel] != expected_result)
-				{
-				  error = error+1;
-				}
-			  }
-			}
-        break;
-
-      default:
-        error = -1;
-        break;
-    }
-  }
-  return(error);
-}
-
-//Runs the redundancy self test
-int16_t LTC681x_run_adc_redundancy_st(uint8_t adc_mode, 
-									  uint8_t adc_reg, 
-									  uint8_t total_ic, 
-									  cell_asic *ic
-									  )
-{
-  int16_t error = 0;
-  for (int self_test = 1; self_test<3; self_test++)
-  {
-    wakeup_idle(total_ic);
-    switch (adc_reg)
-    {
-      case AUX:
-		LTC681x_clraux();
-		LTC681x_adaxd(adc_mode,AUX_CH_ALL);
-	    LTC681x_pollAdc();
-	
-		wakeup_idle(total_ic);
-		error = LTC681x_rdaux(0, total_ic,ic);
-	    for (int cic = 0; cic < total_ic; cic++)
-		{
-			 for (int channel=0; channel< ic[cic].ic_reg.aux_channels; channel++)
-			  { 
-				if (ic[cic].aux.a_codes[channel] >= 65280)
-				{
-				  error = error+1;
-				}
-			  }
-		}
-        break;
-      case STAT:
-		LTC681x_clrstat();
-		LTC681x_adstatd(adc_mode,STAT_CH_ALL);
-		LTC681x_pollAdc();
-		wakeup_idle(total_ic);
-		error = LTC681x_rdstat(0,total_ic,ic);
-		for (int cic = 0; cic < total_ic; cic++)
-		{
-		  for (int channel=0; channel< ic[cic].ic_reg.stat_channels; channel++)
-		  {
-			if (ic[cic].stat.stat_codes[channel] >= 65280)
-			{
-			  error = error+1;
-			}
-		  }
-		}
-		break;
-
-      default:
-        error = -1;
-        break;
-    }
-  }
-  return(error);
-}
-
-//Runs the data sheet algorithm for open wire for single cell detection
-void LTC681x_run_openwire_single(uint8_t total_ic, 
-								cell_asic ic[]
-								)
-	{				  
-		  uint16_t OPENWIRE_THRESHOLD = 4000;
-		  const uint8_t  N_CHANNELS = ic[0].ic_reg.cell_channels;
-		  
-		  uint16_t pullUp[total_ic][N_CHANNELS];
-		  uint16_t pullDwn[total_ic][N_CHANNELS];
-		  int16_t openWire_delta[total_ic][N_CHANNELS];
-		  
-		  int8_t error;
-		  int8_t i;
-		  uint32_t conv_time=0;
-  
-		  wakeup_sleep(total_ic);
-		  LTC681x_clrcell();
-		  
-		  // pull ups
-		  for (i = 0; i < 3; i++)
-		  { 
-			wakeup_idle(total_ic);
-			LTC681x_adow(MD_26HZ_2KHZ,PULL_UP_CURRENT,CELL_CH_ALL,DCP_DISABLED);
-			conv_time =LTC681x_pollAdc();
-		  } 
-		  
-		  wakeup_idle(total_ic);
-		  error=LTC681x_rdcv(0, total_ic,ic);
-		  
-		  for (int cic=0; cic<total_ic; cic++)
-		  {
-			  for (int cell=0; cell<N_CHANNELS; cell++)
-				{
-				  pullUp[cic][cell] = ic[cic].cells.c_codes[cell];
-				}
-				
-		  }
-
-		  // pull downs
-		  for (i = 0; i < 3; i++)
-		  {  
-			wakeup_idle(total_ic);
-			LTC681x_adow(MD_26HZ_2KHZ,PULL_DOWN_CURRENT,CELL_CH_ALL,DCP_DISABLED);
-			conv_time =LTC681x_pollAdc();
-		  }
-		 
-		  wakeup_idle(total_ic);
-		  error=LTC681x_rdcv(0, total_ic,ic); 
-		  
-		  for (int cic=0; cic<total_ic; cic++)
-		  {		  
-			  for (int cell=0; cell<N_CHANNELS; cell++)
-				{
-				   pullDwn[cic][cell] = ic[cic].cells.c_codes[cell];
-				}
-		  }
-
-		  for (int cic=0; cic<total_ic; cic++)
-		  {
-			  ic[cic].system_open_wire = 0xFFFF;
-			  
-				for (int cell=0; cell<N_CHANNELS; cell++)
-				{
-					if (pullDwn[cic][cell] < pullUp[cic][cell])                   
-						{
-							openWire_delta[cic][cell] = (pullUp[cic][cell] - pullDwn[cic][cell]);
-						}
-						else
-						{
-							openWire_delta[cic][cell] = 0;                                             
-						}  
-						
-					if (openWire_delta[cic][cell]>OPENWIRE_THRESHOLD)
-					  {
-						ic[cic].system_open_wire = cell+1;
-					  }
-	  
-				}
-				
-			if (pullUp[cic][0] == 0)
-			{
-			  ic[cic].system_open_wire = 0;
-			}
-		  
-			if (pullUp[cic][(N_CHANNELS-1)] == 0)//checking the Pull up value of the top measured channel
-			{
-			  ic[cic].system_open_wire = N_CHANNELS;
-			}	
-		  }
-	}
-
-//Runs the data sheet algorithm for open wire for multiple cell and two consecutive cells detection
- void LTC681x_run_openwire_multi(uint8_t total_ic, 
-						  cell_asic ic[]
-						  )
-	{              
-		  uint16_t OPENWIRE_THRESHOLD = 4000;
-		  const uint8_t  N_CHANNELS = ic[0].ic_reg.cell_channels;
-		  
-		  uint16_t pullUp[total_ic][N_CHANNELS];
-		  uint16_t pullDwn[total_ic][N_CHANNELS];
-		  uint16_t openWire_delta[total_ic][N_CHANNELS];
-		  
-		  int8_t error;
-		  int8_t opencells[N_CHANNELS];
-		  int8_t n=0;
-		  int8_t i,j,k;
-		  uint32_t conv_time=0;
-
-		  wakeup_sleep(total_ic);
-		  LTC681x_clrcell();
-		  
-		  // pull ups
-		  for (i = 0; i < 5; i++)
-		  { 
-				wakeup_idle(total_ic);
-				LTC681x_adow(MD_26HZ_2KHZ,PULL_UP_CURRENT,CELL_CH_ALL,DCP_DISABLED);
-				conv_time =LTC681x_pollAdc();
-		  } 
-			
-		  wakeup_idle(total_ic);
-		  error = LTC681x_rdcv(0, total_ic,ic);
-		  
-		  for (int cic=0; cic<total_ic; cic++)
-		  {
-			  for (int cell=0; cell<N_CHANNELS; cell++)
-				{
-				  pullUp[cic][cell] = ic[cic].cells.c_codes[cell];
-				}
-		  }
-		  
-		  // pull downs
-		  for (i = 0; i < 5; i++)
-		  {  
-			  wakeup_idle(total_ic);
-			  LTC681x_adow(MD_26HZ_2KHZ,PULL_DOWN_CURRENT,CELL_CH_ALL,DCP_DISABLED);
-			  conv_time =   LTC681x_pollAdc();
-		  }
-		 
-		  wakeup_idle(total_ic);
-		  error = LTC681x_rdcv(0, total_ic,ic); 
-		  
-		  for (int cic=0; cic<total_ic; cic++)
-		  {
-			for (int cell=0; cell<N_CHANNELS; cell++)
-				{
-				   pullDwn[cic][cell] = ic[cic].cells.c_codes[cell];
-				}
-		  }
-
-		   
-		  for (int cic=0; cic<total_ic; cic++)
-		  {			  
-				for (int cell=0; cell<N_CHANNELS; cell++)
-				{
-					if (pullDwn[cic][cell] < pullUp[cic][cell])                   
-						{
-							openWire_delta[cic][cell] = (pullUp[cic][cell] - pullDwn[cic][cell]);
-						}
-						else
-						{
-							openWire_delta[cic][cell] = 0;                                             
-						}
-				}  
-		  }
-		 
-		  for (int cic=0; cic<total_ic; cic++)
-		  { 
-				n=0;
-								
-				Serial.print("IC:");
-				Serial.println(cic+1, DEC);
-				
-				for (int cell=0; cell<N_CHANNELS; cell++)
-				{  
-				 
-				  if (openWire_delta[cic][cell]>OPENWIRE_THRESHOLD)
-					{
-						opencells[n] = cell+1;
-						n++;
-						for (int j = cell; j < N_CHANNELS-3 ; j++)                       
-						{
-							if (pullUp[cic][j + 2] == 0)
-							{
-							opencells[n] = j+2;
-							n++;
-							}
-						}
-						if((cell==N_CHANNELS-4) && (pullDwn[cic][N_CHANNELS-3] == 0))
-						{
-							  opencells[n] = N_CHANNELS-2;
-							  n++;
-						}
-					}
-				}
-				if (pullDwn[cic][0] == 0)
-				{
-
-				  opencells[n] = 0;
-				  Serial.println("Cell 0 is Open and multiple open wires maybe possible.");
-				  n++;
-				}
-							
-				if (pullDwn[cic][N_CHANNELS-1] == 0)
-				{
-
-				  opencells[n] = N_CHANNELS;
-				  n++;
-				}
-							
-				if (pullDwn[cic][N_CHANNELS-2] == 0)
-				{  
-				  opencells[n] = N_CHANNELS-1;
-				  n++;
-
-				}
-				
-			//Removing repetitive elements
-				for(i=0;i<n;i++)
-				{
-					for(j=i+1;j<n;)
-					{
-						if(opencells[i]==opencells[j])
-						{
-							for(k=j;k<n;k++)
-								opencells[k]=opencells[k+1];
-								
-							n--;
-						}
-						else
-							j++;
-					}
-				}
-							
-			// Sorting open cell array
-
-				for(int i=0; i<n; i++)
-				{
-					for(int j=0; j<n-1; j++)
-					{
-						if( opencells[j] > opencells[j+1] )
-						{
-							k = opencells[j];
-							opencells[j] = opencells[j+1];
-							opencells[j+1] = k;
-						}
-					}
-				}
-							
-			//Checking the value of n				
-				Serial.println("Number of Open wires:");
-				Serial.println(n);
-				   
-			//Printing open cell array
-				Serial.println("OPEN CELLS:");
-				if(n==0)
-				{
-					Serial.println("No Open wires");
-				}
-				else
-				{				
-					for(i=0;i<n;i++)
-					{
-							Serial.println(opencells[i]);
-					}
-				}
-		}
-	}
-
-// Runs the ADC overlap test for the IC
-uint16_t LTC681x_run_adc_overlap(uint8_t total_ic, 
-								 cell_asic *ic
-								 )
-{
-	uint16_t error = 0;
-	int32_t measure_delta =0;
-	int16_t failure_pos_limit = 20;
-	int16_t failure_neg_limit = -20;
-	int32_t a, b;
-	wakeup_idle(total_ic);
-	LTC681x_adol(MD_7KHZ_3KHZ,DCP_DISABLED);
-	LTC681x_pollAdc();
-	wakeup_idle(total_ic);
-	error = LTC681x_rdcv(0, total_ic,ic);
-
-	  for (int cic = 0; cic<total_ic; cic++)
-	  {
-		  measure_delta = (int32_t)ic[cic].cells.c_codes[6]-(int32_t)ic[cic].cells.c_codes[7];
-		
-		 if ((measure_delta>failure_pos_limit) || (measure_delta<failure_neg_limit))
-		 {
-		  error = error | (1<<(cic-1));
-		 }
-	  }
-  return(error);
-
-}
-
-//Helper function that increments PEC counters
-void LTC681x_check_pec(uint8_t total_ic,
-					   uint8_t reg, 
-					   cell_asic *ic
-					   )
-{
-  switch (reg)
-  {
-    case CFGR:
-      for (int current_ic = 0 ; current_ic < total_ic; current_ic++)
-      {
-        ic[current_ic].crc_count.pec_count = ic[current_ic].crc_count.pec_count + ic[current_ic].config.rx_pec_match;
-        ic[current_ic].crc_count.cfgr_pec = ic[current_ic].crc_count.cfgr_pec + ic[current_ic].config.rx_pec_match;
-      }
-    break;
-
-    case CFGRB:
-      for (int current_ic = 0 ; current_ic < total_ic; current_ic++)
-      {
-        ic[current_ic].crc_count.pec_count = ic[current_ic].crc_count.pec_count + ic[current_ic].configb.rx_pec_match;
-        ic[current_ic].crc_count.cfgr_pec = ic[current_ic].crc_count.cfgr_pec + ic[current_ic].configb.rx_pec_match;
-      }
-    break;
-    case CELL:
-      for (int current_ic = 0 ; current_ic < total_ic; current_ic++)
-      {
-        for (int i=0; i<ic[0].ic_reg.num_cv_reg; i++)
-        {
-          ic[current_ic].crc_count.pec_count = ic[current_ic].crc_count.pec_count + ic[current_ic].cells.pec_match[i];
-          ic[current_ic].crc_count.cell_pec[i] = ic[current_ic].crc_count.cell_pec[i] + ic[current_ic].cells.pec_match[i];
-        }
-      }
-    break;
-    case AUX:
-      for (int current_ic = 0 ; current_ic < total_ic; current_ic++)
-      {
-        for (int i=0; i<ic[0].ic_reg.num_gpio_reg; i++)
-        {
-          ic[current_ic].crc_count.pec_count = ic[current_ic].crc_count.pec_count + (ic[current_ic].aux.pec_match[i]);
-          ic[current_ic].crc_count.aux_pec[i] = ic[current_ic].crc_count.aux_pec[i] + (ic[current_ic].aux.pec_match[i]);
-        }
-      }
-
-    break;
-    case STAT:
-      for (int current_ic = 0 ; current_ic < total_ic; current_ic++)
-      {
-
-        for (int i=0; i<ic[0].ic_reg.num_stat_reg-1; i++)
-        {
-          ic[current_ic].crc_count.pec_count = ic[current_ic].crc_count.pec_count + ic[current_ic].stat.pec_match[i];
-          ic[current_ic].crc_count.stat_pec[i] = ic[current_ic].crc_count.stat_pec[i] + ic[current_ic].stat.pec_match[i];
-        }
-      }
-    break;
-    default:
-    break;
-  }
-}
-
-//Helper Function to reset PEC counters
-void LTC681x_reset_crc_count(uint8_t total_ic, 
-							 cell_asic *ic
-							 )
-{
-  for (int current_ic = 0 ; current_ic < total_ic; current_ic++)
-  {
-    ic[current_ic].crc_count.pec_count = 0;
-    ic[current_ic].crc_count.cfgr_pec = 0;
-    for (int i=0; i<6; i++)
-    {
-      ic[current_ic].crc_count.cell_pec[i]=0;
-
-    }
-    for (int i=0; i<4; i++)
-    {
-      ic[current_ic].crc_count.aux_pec[i]=0;
-    }
-    for (int i=0; i<2; i++)
-    {
-      ic[current_ic].crc_count.stat_pec[i]=0;
-    }
-  }
-}
-
-//Start GPIOs open wire adc conversion
-void LTC681x_axow(uint8_t MD, //ADC Mode
-				  uint8_t PUP //Discharge Permit
-				 )
-{
-	uint8_t cmd[2];
-	uint8_t md_bits;
-	md_bits = (MD & 0x02) >> 1;
-	cmd[0] = md_bits + 0x04;
-	md_bits = (MD & 0x01) << 7;
-	cmd[1] =  md_bits + 0x10+ (PUP<<6) ;//+ CH;
+	uint8_t cmd[2]= {0x00 , 0x18};
 	cmd_68(cmd);
 }
 
-//Runs open wire for GPIOs
-void LTC681x_run_gpio_openwire(uint8_t total_ic, 
-								cell_asic ic[]
-								)
- {				  
-		  uint16_t OPENWIRE_THRESHOLD = 150;
-		  const uint8_t  N_CHANNELS = ic[0].ic_reg.aux_channels +1;
-		  
-		  uint16_t aux_val[total_ic][N_CHANNELS];
-		  uint16_t pDwn[total_ic][N_CHANNELS];
-		  uint16_t ow_delta[total_ic][N_CHANNELS];
- 		  
-		  int8_t error;
-		  int8_t i;
-		  uint32_t conv_time=0;
-  
-		  wakeup_sleep(total_ic); 
-		  LTC681x_clraux();
-		   
-		  for (i = 0; i < 3; i++)
-		  { 
-		  wakeup_idle(total_ic);
-		  LTC681x_adax(MD_7KHZ_3KHZ, AUX_CH_ALL);
-		  conv_time= LTC681x_pollAdc();
-		  }
-		  
-		  wakeup_idle(total_ic);
-		  error = LTC681x_rdaux(0, total_ic,ic);
-		  
-		  for (int cic=0; cic<total_ic; cic++)
-		  {
-			  for (int channel=0; channel<N_CHANNELS; channel++)
-				{
-					aux_val[cic][channel]=ic[cic].aux.a_codes[channel];
-				}
-
-		  }	
-		  LTC681x_clraux();
-		  
-		  // pull downs
-		  for (i = 0; i < 3; i++)
-		  { 
-			wakeup_idle(total_ic);
-			LTC681x_axow(MD_7KHZ_3KHZ,PULL_DOWN_CURRENT);
-			conv_time =LTC681x_pollAdc();
-		  } 
-		  
-		  wakeup_idle(total_ic);
-		  error = LTC681x_rdaux(0, total_ic,ic);
-		  
-		  for (int cic=0; cic<total_ic; cic++)
-		  {
-			   for (int channel=0; channel<N_CHANNELS; channel++)
-				{
-					pDwn[cic][channel]=ic[cic].aux.a_codes[channel] ;
-				}
-		  }
-		  
-		for (int cic=0; cic<total_ic; cic++)
-		  {  
-				ic[cic].system_open_wire = 0xFFFF;
-				
-				for (int channel=0; channel<N_CHANNELS; channel++)
-				{
-					if (pDwn[cic][channel] > aux_val[cic][channel])                   
-					{
-						ow_delta[cic][channel] = (pDwn[cic][channel] - aux_val[cic][channel]);
-					}
-					else
-					{
-						ow_delta[cic][channel] = 0;                                             
-					} 
-					
-					if(channel<5)
-					{
-						if (ow_delta[cic][channel] > OPENWIRE_THRESHOLD) 
-						{
-							ic[cic].system_open_wire= channel+1;
-							
-						}  
-					}
-					else if(channel>5)
-					{
-						if (ow_delta[cic][channel] > OPENWIRE_THRESHOLD) 
-						{
-							ic[cic].system_open_wire= channel;
-							
-						}  
-					}
-					
-				}
-		  }
-		  
+/* Writes the comm register */
+void LTC681x_wrcomm(uint8_t total_ic, //The number of ICs being written to
+                    cell_asic ic[] // A two dimensional array that stores the data to be written
+                   )
+{
+	uint8_t cmd[2]= {0x07 , 0x21};
+	uint8_t write_buffer[256];
+	uint8_t write_count = 0;
+	uint8_t c_ic = 0;
+	for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
+	{
+		if (ic->isospi_reverse == true)
+		{
+			c_ic = current_ic;
+		}
+		else
+		{
+			c_ic = total_ic - current_ic - 1;
+		}
+	
+		for (uint8_t data = 0; data<6; data++)
+		{
+			write_buffer[write_count] = ic[c_ic].com.tx_data[data];
+			write_count++;
+		}
 	}
+	write_68(total_ic, cmd, write_buffer);
+}
 
+/* Reads COMM registers of a LTC681x daisy chain */
+int8_t LTC681x_rdcomm(uint8_t total_ic, //Number of ICs in the system
+                      cell_asic ic[] //A two dimensional array that stores the read data
+                     )
+{
+	uint8_t cmd[2]= {0x07 , 0x22};
+	uint8_t read_buffer[256];
+	int8_t pec_error = 0;
+	uint16_t data_pec;
+	uint16_t calc_pec;
+	uint8_t c_ic=0;
+	
+	pec_error = read_68(total_ic, cmd, read_buffer);
+	
+	for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
+	{
+		if (ic->isospi_reverse == false)
+		{
+			c_ic = current_ic;
+		}
+		else
+		{
+			c_ic = total_ic - current_ic - 1;
+		}
+	
+		for (int byte=0; byte<8; byte++)
+		{
+			ic[c_ic].com.rx_data[byte] = read_buffer[byte+(8*current_ic)];
+		}
+		
+		calc_pec = pec15_calc(6,&read_buffer[8*current_ic]);
+		data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
+		if (calc_pec != data_pec )
+		{
+			ic[c_ic].com.rx_pec_match = 1;
+		}
+		else ic[c_ic].com.rx_pec_match = 0;
+	}
+	
+    return(pec_error);
+}
 
+/* Shifts data in COMM register out over LTC681x SPI/I2C port */
+void LTC681x_stcomm(uint8_t len) //Length of data to be transmitted 
+{
+	uint8_t cmd[4];
+	uint16_t cmd_pec;
+
+	cmd[0] = 0x07;
+	cmd[1] = 0x23;
+	cmd_pec = pec15_calc(2, cmd);
+	cmd[2] = (uint8_t)(cmd_pec >> 8);
+	cmd[3] = (uint8_t)(cmd_pec);
+
+	cs_low(CS_PIN);
+	spi_write_array(4,cmd);
+	for (int i = 0; i<len*3; i++)
+	{
+	  spi_read_byte(0xFF);
+	}
+	cs_high(CS_PIN);
+}
+
+/* Helper function that increments PEC counters */
+void LTC681x_check_pec(uint8_t total_ic, //Number of ICs in the system
+					   uint8_t reg, //Type of Register
+					   cell_asic *ic //A two dimensional array that stores the data
+					   )
+{
+	switch (reg)
+	{
+		case CFGR:
+		  for (int current_ic = 0 ; current_ic < total_ic; current_ic++)
+		  {
+			ic[current_ic].crc_count.pec_count = ic[current_ic].crc_count.pec_count + ic[current_ic].config.rx_pec_match;
+			ic[current_ic].crc_count.cfgr_pec = ic[current_ic].crc_count.cfgr_pec + ic[current_ic].config.rx_pec_match;
+		  }
+		break;
+
+		case CFGRB:
+		  for (int current_ic = 0 ; current_ic < total_ic; current_ic++)
+		  {
+			ic[current_ic].crc_count.pec_count = ic[current_ic].crc_count.pec_count + ic[current_ic].configb.rx_pec_match;
+			ic[current_ic].crc_count.cfgr_pec = ic[current_ic].crc_count.cfgr_pec + ic[current_ic].configb.rx_pec_match;
+		  }
+		break;
+		case CELL:
+		  for (int current_ic = 0 ; current_ic < total_ic; current_ic++)
+		  {
+			for (int i=0; i<ic[0].ic_reg.num_cv_reg; i++)
+			{
+			  ic[current_ic].crc_count.pec_count = ic[current_ic].crc_count.pec_count + ic[current_ic].cells.pec_match[i];
+			  ic[current_ic].crc_count.cell_pec[i] = ic[current_ic].crc_count.cell_pec[i] + ic[current_ic].cells.pec_match[i];
+			}
+		  }
+		break;
+		case AUX:
+		  for (int current_ic = 0 ; current_ic < total_ic; current_ic++)
+		  {
+			for (int i=0; i<ic[0].ic_reg.num_gpio_reg; i++)
+			{
+			  ic[current_ic].crc_count.pec_count = ic[current_ic].crc_count.pec_count + (ic[current_ic].aux.pec_match[i]);
+			  ic[current_ic].crc_count.aux_pec[i] = ic[current_ic].crc_count.aux_pec[i] + (ic[current_ic].aux.pec_match[i]);
+			}
+		  }
+
+		break;
+		case STAT:
+		  for (int current_ic = 0 ; current_ic < total_ic; current_ic++)
+		  {
+
+			for (int i=0; i<ic[0].ic_reg.num_stat_reg-1; i++)
+			{
+			  ic[current_ic].crc_count.pec_count = ic[current_ic].crc_count.pec_count + ic[current_ic].stat.pec_match[i];
+			  ic[current_ic].crc_count.stat_pec[i] = ic[current_ic].crc_count.stat_pec[i] + ic[current_ic].stat.pec_match[i];
+			}
+		  }
+		break;
+		default:
+		break;
+	}
+}
+
+/* Helper Function to reset PEC counters */
+void LTC681x_reset_crc_count(uint8_t total_ic, //Number of ICs in the system
+							 cell_asic *ic //A two dimensional array that stores the data
+							 )
+{
+	for (int current_ic = 0 ; current_ic < total_ic; current_ic++)
+	{
+		ic[current_ic].crc_count.pec_count = 0;
+		ic[current_ic].crc_count.cfgr_pec = 0;
+		for (int i=0; i<6; i++)
+		{
+			ic[current_ic].crc_count.cell_pec[i]=0;
+		
+		}
+		for (int i=0; i<4; i++)
+		{
+			ic[current_ic].crc_count.aux_pec[i]=0;
+		}
+		for (int i=0; i<2; i++)
+		{
+			ic[current_ic].crc_count.stat_pec[i]=0;
+		}
+	}
+}
+
+/* Helper function to initialize CFG variables */
+void LTC681x_init_cfg(uint8_t total_ic, //Number of ICs in the system
+					  cell_asic *ic //A two dimensional array that stores the data
+					  )
+{
+	for (uint8_t current_ic = 0; current_ic<total_ic;current_ic++)  
+	{
+		for (int j =0; j<6; j++)
+		{
+		  ic[current_ic].config.tx_data[j] = 0;
+		}
+	}
+}
+
+/* Helper function to set CFGR variable */
+void LTC681x_set_cfgr(uint8_t nIC, // Current IC
+					 cell_asic *ic, // A two dimensional array that stores the data
+					 bool refon, // The REFON bit
+					 bool adcopt, // The ADCOPT bit
+					 bool gpio[5], // The GPIO bits
+					 bool dcc[12], // The DCC bits
+					 bool dcto[4], // The Dcto bits
+					 uint16_t uv, // The UV value
+					 uint16_t  ov // The OV value
+					 )
+{
+	LTC681x_set_cfgr_refon(nIC,ic,refon);
+	LTC681x_set_cfgr_adcopt(nIC,ic,adcopt);
+	LTC681x_set_cfgr_gpio(nIC,ic,gpio);
+	LTC681x_set_cfgr_dis(nIC,ic,dcc);
+	LTC681x_set_cfgr_dcto(nIC,ic,dcto);
+	LTC681x_set_cfgr_uv(nIC, ic, uv);
+	LTC681x_set_cfgr_ov(nIC, ic, ov);
+}
+
+/* Helper function to set the REFON bit */
+void LTC681x_set_cfgr_refon(uint8_t nIC, cell_asic *ic, bool refon)
+{
+	if (refon) ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]|0x04;
+	else ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]&0xFB;
+}
+
+/* Helper function to set the ADCOPT bit */
+void LTC681x_set_cfgr_adcopt(uint8_t nIC, cell_asic *ic, bool adcopt)
+{
+	if (adcopt) ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]|0x01;
+	else ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]&0xFE;
+}
+
+/* Helper function to set GPIO bits */
+void LTC681x_set_cfgr_gpio(uint8_t nIC, cell_asic *ic,bool gpio[5])
+{
+	for (int i =0; i<5; i++)
+	{
+		if (gpio[i])ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]|(0x01<<(i+3));
+		else ic[nIC].config.tx_data[0] = ic[nIC].config.tx_data[0]&(~(0x01<<(i+3)));
+	}
+}
+
+/* Helper function to control discharge */
+void LTC681x_set_cfgr_dis(uint8_t nIC, cell_asic *ic,bool dcc[12])
+{
+	for (int i =0; i<8; i++)
+	{
+		if (dcc[i])ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]|(0x01<<i);
+		else ic[nIC].config.tx_data[4] = ic[nIC].config.tx_data[4]& (~(0x01<<i));
+	}
+	for (int i =0; i<4; i++)
+	{
+		if (dcc[i+8])ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]|(0x01<<i);
+		else ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]&(~(0x01<<i));
+	}
+}
+
+/* Helper function to control discharge time value */
+void LTC681x_set_cfgr_dcto(uint8_t nIC, cell_asic *ic,bool dcto[4])
+{  
+	for(int i =0;i<4;i++)
+	{
+		if(dcto[i])ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]|(0x01<<(i+4));
+		else ic[nIC].config.tx_data[5] = ic[nIC].config.tx_data[5]&(~(0x01<<(i+4)));
+	} 
+}
+
+/* Helper Function to set UV value in CFG register */
+void LTC681x_set_cfgr_uv(uint8_t nIC, cell_asic *ic,uint16_t uv)
+{
+	uint16_t tmp = (uv/16)-1;
+	ic[nIC].config.tx_data[1] = 0x00FF & tmp;
+	ic[nIC].config.tx_data[2] = ic[nIC].config.tx_data[2]&0xF0;
+	ic[nIC].config.tx_data[2] = ic[nIC].config.tx_data[2]|((0x0F00 & tmp)>>8);
+}
+
+/* Helper function to set OV value in CFG register */
+void LTC681x_set_cfgr_ov(uint8_t nIC, cell_asic *ic,uint16_t ov)
+{
+	uint16_t tmp = (ov/16);
+	ic[nIC].config.tx_data[3] = 0x00FF & (tmp>>4);
+	ic[nIC].config.tx_data[2] = ic[nIC].config.tx_data[2]&0x0F;
+	ic[nIC].config.tx_data[2] = ic[nIC].config.tx_data[2]|((0x000F & tmp)<<4);
+}

--- a/LTSketchbook/libraries/LTC681x/LTC681x.h
+++ b/LTSketchbook/libraries/LTC681x/LTC681x.h
@@ -113,56 +113,60 @@
 #define CFGRB 4
 #define CS_PIN 10
 
-//! Cell Voltage data structure.
+/*! Cell Voltage data structure. */
 typedef struct
 {
   uint16_t c_codes[18]; //!< Cell Voltage Codes
   uint8_t pec_match[6]; //!< If a PEC error was detected during most recent read cmd
 } cv;
 
-//! AUX Reg Voltage Data
+/*! AUX Reg Voltage Data structure */
 typedef struct
 {
   uint16_t a_codes[9]; //!< Aux Voltage Codes
   uint8_t pec_match[4]; //!< If a PEC error was detected during most recent read cmd
 } ax;
 
-//!Status Reg data structure.
+/*! Status Reg data structure. */
 typedef struct
 {
-  uint16_t stat_codes[4]; //!< A two dimensional array of the stat voltage codes.
-  uint8_t flags[3]; //!< byte array that contains the uv/ov flag data
+  uint16_t stat_codes[4]; //!< Status codes.
+  uint8_t flags[3]; //!< Byte array that contains the uv/ov flag data
   uint8_t mux_fail[1]; //!< Mux self test status flag
   uint8_t thsd[1]; //!< Thermal shutdown status
   uint8_t pec_match[2]; //!< If a PEC error was detected during most recent read cmd
 } st;
 
+/*! IC register structure. */
 typedef struct
 {
-  uint8_t tx_data[6];
-  uint8_t rx_data[8];
+  uint8_t tx_data[6];  //!< Stores data to be transmitted 
+  uint8_t rx_data[8];  //!< Stores received data 
   uint8_t rx_pec_match; //!< If a PEC error was detected during most recent read cmd
 } ic_register;
 
+/*! PEC error counter structure. */
 typedef struct
 {
-  uint16_t pec_count;
-  uint16_t cfgr_pec;
-  uint16_t cell_pec[6];
-  uint16_t aux_pec[4];
-  uint16_t stat_pec[2];
+  uint16_t pec_count; //!< Overall PEC error count
+  uint16_t cfgr_pec;  //!< Configuration register data PEC error count
+  uint16_t cell_pec[6]; //!< Cell voltage register data PEC error count
+  uint16_t aux_pec[4];  //!< Aux register data PEC error count
+  uint16_t stat_pec[2]; //!< Status register data PEC error count
 } pec_counter;
 
+/*! Register configuration structure */
 typedef struct
 {
-  uint8_t cell_channels;
-  uint8_t stat_channels;
-  uint8_t aux_channels;
-  uint8_t num_cv_reg;
-  uint8_t num_gpio_reg;
-  uint8_t num_stat_reg;
+  uint8_t cell_channels; //!< Number of Cell channels
+  uint8_t stat_channels; //!< Number of Stat channels
+  uint8_t aux_channels;  //!< Number of Aux channels
+  uint8_t num_cv_reg;    //!< Number of Cell voltage register
+  uint8_t num_gpio_reg;  //!< Number of Aux register
+  uint8_t num_stat_reg;  //!< Number of  Status register
 } register_cfg;
 
+/*! Cell variable structure */
 typedef struct
 {
   ic_register config;
@@ -182,453 +186,586 @@ typedef struct
   long system_open_wire;
 } cell_asic;
 
-//!  Wake isoSPI up from idle state 
-//!@return void
-void wakeup_idle(uint8_t total_ic);//!<  number of ICs in the daisy chain
+/*!
+ Wake isoSPI up from IDlE state and enters the READY state
+ @return void
+ */
+void wakeup_idle(uint8_t total_ic);//!< Number of ICs in the daisy chain
 
-//!  Wake the LTC681x from the sleep state 
-//!@return void
-void wakeup_sleep(uint8_t total_ic); //!<  number of ICs in the daisy chain
+/*!
+ Wake the LTC681x from the sleep state 
+ @return void  
+ */
+void wakeup_sleep(uint8_t total_ic); //!< Number of ICs in the daisy chain
 
-//! Sends a command to the bms IC. This code will calculate the PEC code for the transmitted command
-//!@return void
-void cmd_68(uint8_t tx_cmd[2]); //!<  2 Byte array containing the BMS command to be sent
+/*!
+ Sends a command to the BMS IC. This code will calculate the PEC code for the transmitted command
+ @return void  
+ */
+void cmd_68(uint8_t tx_cmd[2]); //!< 2 byte array containing the BMS command to be sent
 
-//! Writes an array of data to the daisy chain
-//!@return void
-void write_68(uint8_t total_ic , //!<  number of ICs in the daisy chain
-              uint8_t tx_cmd[2], //!<  2 Byte array containing the BMS command to be sent
-              uint8_t data[] //!<  Array containing the data to be written to the BMS ICs
+/*!
+ Writes an array of data to the daisy chain
+ @return void  
+ */
+void write_68(uint8_t total_ic , //!< Number of ICs in the daisy chain
+              uint8_t tx_cmd[2], //!< 2 byte array containing the BMS command to be sent
+              uint8_t data[] //!< Array containing the data to be written to the BMS ICs
              );
 			 
-//! Issues a command onto the daisy chain and reads back 6*total_ic data in the rx_data array
-//! @return int8_t, PEC Status.
-//! 0: Data read back has matching PEC
-//!-1: Data read back has incorrect PEC
-int8_t read_68( uint8_t total_ic, //!<  number of ICs in the daisy chain
-                uint8_t tx_cmd[2], //!<  2 Byte array containing the BMS command to be sent
-                uint8_t *rx_data); //!<  Array that the read back data will be stored.
+/*!
+ Issues a command onto the daisy chain and reads back 6*total_ic data in the rx_data array
+ @return int8_t, PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC  
+ */
+int8_t read_68( uint8_t total_ic, //!< Number of ICs in the daisy chain
+                uint8_t tx_cmd[2], //!< 2 byte array containing the BMS command to be sent
+                uint8_t *rx_data); //!< Array that the read back data will be stored in.
 				
-//! Calculates  and returns the CRC15
-//! @returns The calculated pec15 as an unsigned int
-uint16_t pec15_calc(uint8_t len, //!<  the length of the data array being passed to the function
-                    uint8_t *data //!<   the array of data that the PEC will be generated from
+/*!
+ Calculates  and returns the CRC15
+ @returns The calculated pec15 as an unsigned int
+  */
+uint16_t pec15_calc(uint8_t len, //!< The length of the data array being passed to the function
+                    uint8_t *data //!< The array of data that the PEC will be generated from
                    );
 				   
-//! Helper Function to initialize the CFGR data structures 
-//!@return void
-void LTC681x_init_cfg(uint8_t total_ic, //!<  number of ICs in the daisy chain
-                      cell_asic *ic //!< A two dimensional array that will store the data
-					  );
+/*!
+ Write the LTC681x CFGRA register
+ This command will write the configuration registers of the LTC681xs connected in a daisy chain stack. 
+ The configuration is written in descending order so the last device's configuration is written first.
+ @return void	 
+ */
+void LTC681x_wrcfg(uint8_t total_ic, //!< The number of ICs being written to
+                   cell_asic *ic //!< A two dimensional array of the configuration data that will be written
+                  );
+				  
+/*!
+ Write the LTC681x CFGRB register
+ This command will write the configuration registers of the LTC681xs connected in a daisy chain stack. 
+ The configuration is written in descending order so the last device's configuration is written first.
+ @return void	 
+ */
+void LTC681x_wrcfgb(uint8_t total_ic, //!< The number of ICs being written to
+                    cell_asic *ic //!< A two dimensional array of the configuration data that will be written
+                   );
+				   
+/*!
+ Reads the LTC681x CFGRA register 
+ @return int8_t, PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC 
+ */
+int8_t LTC681x_rdcfg(uint8_t total_ic, //!< Number of ICs in the system
+                     cell_asic *ic //!< A two dimensional array that the function stores the read configuration data.
+                    );
 
-//! Helper function to set appropriate bits in CFGR register based on bit function
-//!@return void 
-void LTC681x_set_cfgr(uint8_t nIC, //!< Current IC
-                      cell_asic *ic, //!< A two dimensional array that will store the data
-                      bool refon,  //!< the REFON bit
-                      bool adcopt, //!< the ADCOPT bit
-                      bool gpio[5],//!< the GPIO bits
-                      bool dcc[12],//!< the DCC bits 
-					  bool dcto[4],//!< the Dcto bits
-					  uint16_t uv, //!< the UV value
-					  uint16_t ov  //!< the OV value
-					  );
+/*!
+ Reads the LTC681x CFGRB register 
+ @return int8_t, PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC 
+ */
+int8_t LTC681x_rdcfgb(uint8_t total_ic, //!< Number of ICs in the system
+                      cell_asic *ic //!< A two dimensional array that the function stores the read configuration data.
+                     );		   
 
-//! Helper function to turn the refon bit HIGH or LOW 
-//!@return void 
-void LTC681x_set_cfgr_refon(uint8_t nIC, //!< Current IC
-                            cell_asic *ic, //!< A two dimensional array that will store the data
-                            bool refon //!< the REFON bit
-							);
-
-//! Helper function to turn the ADCOPT bit HIGH or LOW 
-//!@return void 
-void LTC681x_set_cfgr_adcopt(uint8_t nIC, //!< Current IC
-                             cell_asic *ic, //!< A two dimensional array that will store the data
-                             bool adcopt //!< the ADCOPT bit
-							 );
-
-//! Helper function to turn the GPIO bits HIGH or LOW 
-//!@return void 
-void LTC681x_set_cfgr_gpio(uint8_t nIC, //!< Current IC
-                           cell_asic *ic, //!< A two dimensional array that will store the data
-                           bool gpio[] //!< the GPIO bits
-						   );
-
-//! Helper function to turn the DCC bits HIGH or LOW 
-//!@return void 
-void LTC681x_set_cfgr_dis(uint8_t nIC, //!< Current IC
-                          cell_asic *ic, //!< A two dimensional array that will store the data
-                          bool dcc[] //!< the DCC bits 
-						  );
-						  
-//!Helper function to control discharge time value
-//!@return void 
-void LTC681x_set_cfgr_dcto(uint8_t nIC,  //!< Current IC
-						   cell_asic *ic, //!< A two dimensional array that will store the data
-						   bool dcto[] //!< the Dcto bits
-						   );
-
-//!  Helper function to set uv field in CFGRA register
-//!@return void  
-void LTC681x_set_cfgr_uv(uint8_t nIC, //!< Current IC
-                         cell_asic *ic, //!< A two dimensional array that will store the data
-                         uint16_t uv //!< the UV value
-						 );
-
-//!  Helper function to set ov field in CFGRA register
-//!@return void  
-void LTC681x_set_cfgr_ov(uint8_t nIC, //!< Current IC
-                         cell_asic *ic, //!< A two dimensional array that will store the data
-                         uint16_t ov //!< the OV value
-						 );				   
-
-//!Starts cell voltage conversion
-//!  Starts ADC conversions of the LTC6811 Cpin inputs.
-//!  The type of ADC conversion executed can be changed by setting the following parameters:
-//!@return void 
-void LTC681x_adcv(uint8_t MD, //!<  ADC Conversion Mode
-                  uint8_t DCP, //!<  Controls if Discharge is permitted during conversion
-                  uint8_t CH //!<  Sets which Cell channels are converted
+/*!
+ Starts cell voltage conversion
+ Starts ADC conversions of the LTC681x Cpin inputs.
+ The type of ADC conversion executed can be changed by setting the following parameters:
+ @return void 
+ */
+void LTC681x_adcv(uint8_t MD, //!< ADC conversion Mode
+                  uint8_t DCP, //!< Controls if Discharge is permitted during conversion
+                  uint8_t CH //!< Sets which Cell channels are converted
                  );
 
-//! Starts cell voltage  and GPIO 1&2 conversion
-//!@return void 
-void LTC681x_adcvax( uint8_t MD, //!<  ADC Conversion Mode
-					  uint8_t DCP //!<  Controls if Discharge is permitted during conversion
+/*!
+ Start a GPIO and Vref2 Conversion
+ @return void 
+ */
+void LTC681x_adax( uint8_t MD, //!< ADC Conversion Mode
+				  uint8_t CHG //!< Sets which GPIO channels are converted
+				);				 
+				 
+/*!
+ Start a Status ADC Conversion
+ @return void
+ */ 
+void LTC681x_adstat(uint8_t MD, //!< ADC Conversion Mode
+					  uint8_t CHST //!< Sets which Stat channels are converted
 					);
 
-
-//! Starts cell voltage self test conversion
-//!@return void 
-void LTC681x_cvst(uint8_t MD, //!<  ADC Conversion Mode
-				  uint8_t ST //!<  Self Test Mode
-				);
-
-//! Starts cell voltage and SOC conversion
-//!@return void 
-void LTC681x_adcvsc(uint8_t MD, //!<  ADC Conversion Mode
-					  uint8_t DCP //!<  Controls if Discharge is permitted during conversion
+/*!
+ Starts cell voltage  and GPIO 1&2 conversion
+ @return void 
+ */ 
+void LTC681x_adcvax( uint8_t MD, //!< ADC Conversion Mode
+					  uint8_t DCP //!< Controls if Discharge is permitted during conversion
+					);					
+					
+/*!
+ Starts cell voltage and SOC conversion
+ @return void  
+ */
+void LTC681x_adcvsc(uint8_t MD, //!< ADC Conversion Mode
+					  uint8_t DCP //!< Controls if Discharge is permitted during conversion
 					);
 
-//! Starts cell voltage overlap conversion
-//!@return void 
-void LTC681x_adol(uint8_t MD, //!<  ADC Conversion Mode
-				  uint8_t DCP //!<  Discharge permitted during conversion
+/*!
+ Reads and parses the LTC681x cell voltage registers.
+ The function is used to read the cell codes of the LTC681x.
+ This function will send the requested read commands parse the data and store the cell voltages in the cell_asic structure.
+ @return uint8_t, PEC Status.
+  0: No PEC error detected
+ -1: PEC error detected, retry read 
+ */
+uint8_t LTC681x_rdcv(uint8_t reg, //!< Controls which cell voltage register is read back.
+                     uint8_t total_ic, //!< The number of ICs in the system
+                     cell_asic *ic //!< Array of the parsed cell codes
+                    );
+
+/*! 
+ Reads and parses the LTC681x auxiliary registers.
+ The function is used to read the  parsed GPIO codes of the LTC681x. 
+ This function will send the requested read commands parse the data and store the gpio voltages in the cell_asic structure.
+ @return  int8_t, PEC Status
+  0: No PEC error detected
+ -1: PEC error detected, retry read 
+  */
+int8_t LTC681x_rdaux(uint8_t reg, //!< Determines which GPIO voltage register is read back.
+                     uint8_t total_ic,//!< the number of ICs in the system
+                     cell_asic *ic//!<  Array of the parsed aux codes
+                    );
+
+/*! 
+ Reads and parses the LTC681x stat registers.
+ The function is used to read the  parsed status codes of the LTC681x. 
+ This function will send the requested read commands parse the data and store the status voltages in the cell_asic structure
+ @return  int8_t, PEC Status
+  0: No PEC error detected
+ -1: PEC error detected, retry read 
+ */
+int8_t LTC681x_rdstat(uint8_t reg, //!< Determines which Stat  register is read back.
+                      uint8_t total_ic,//!< The number of ICs in the system
+                      cell_asic *ic//!< Array of the parsed stat codes
+                     );
+
+/*! 
+ Reads the raw cell voltage register data
+ @return void 
+ */				   
+void LTC681x_rdcv_reg(uint8_t reg, //!< Determines which cell voltage register is read back
+                      uint8_t total_ic, //!< The number of ICs in the
+                      uint8_t *data //!< An array of the unparsed cell codes
+                     );				   
+
+/*! 
+ Read the raw data from the LTC681x auxiliary register
+ The function reads a single GPIO voltage register and stores the read data in the *data point as a byte array. 
+ This function is rarely used outside of the LTC681x_rdaux() command.
+ @return void 
+ */	
+void LTC681x_rdaux_reg(  uint8_t reg, //!< Determines which GPIO voltage register is read back
+                         uint8_t total_ic, //!< The number of ICs in the system
+                         uint8_t *data //!< Array of the unparsed auxiliary codes
+                      );
+					  
+/*! 
+ Read the raw data from the LTC681x stat register
+ The function reads a single Status register and stores the read data in the *data point as a byte array. 
+ This function is rarely used outside of the LTC681x_rdstat() command.
+ @return void 
+ */	
+void LTC681x_rdstat_reg(uint8_t reg, //!< Determines which stat register is read back
+                        uint8_t total_ic, //!< The number of ICs in the system
+                        uint8_t *data //!< Array of the unparsed stat codes
+                       );
+
+/*! 
+ Helper function that parses voltage measurement registers
+ @return int8_t, pec_error PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC 
+ */
+int8_t parse_cells(uint8_t current_ic, //!< Current IC
+                   uint8_t cell_reg, //!< Type of register
+                   uint8_t cell_data[], //!< Unparsed data
+                   uint16_t *cell_codes, //!< Parsed data
+                   uint8_t *ic_pec //!< PEC error
+				   );
+
+/*! 
+ Sends the poll ADC command
+ @returns uint8_t adc_state 1 byte read back after a pladc command. If the byte is not 0xFF ADC conversion has completed
+ */
+uint8_t LTC681x_pladc();
+
+/*! 
+  This function will block operation until the ADC has finished it's conversion
+  @returns uint32_t counter The approximate time it took for the ADC function to complete.
+  */
+uint32_t LTC681x_pollAdc();
+
+/*! 
+ Clears the LTC681x Cell voltage registers
+ The command clears the cell voltage registers and initializes all values to 1.
+ The register will read back hexadecimal 0xFF after the command is sent.
+ @return void 
+ */	
+void LTC681x_clrcell();
+
+/*! 
+ Clears the LTC681x Auxiliary registers
+ The command clears the Auxiliary registers and initializes all values to 1. 
+ The register will read back hexadecimal 0xFF after the command is sent.
+ @return void 
+ */	
+void LTC681x_clraux();
+
+/*! 
+ Clears the LTC681x Stat registers
+ The command clears the Stat registers and initializes all values to 1. 
+ The register will read back hexadecimal 0xFF after the command is sent.
+ @return void 
+ */	
+void LTC681x_clrstat();
+
+/*! 
+ Starts the Mux Decoder diagnostic self test
+ Running this command will start the Mux Decoder Diagnostic Self Test
+ This test takes roughly 1ms to complete. The MUXFAIL bit will be updated,
+ the bit will be set to 1 for a failure and 0 if the test has been passed.
+ @return void 
+ */
+void LTC681x_diagn();
+				   
+/*!
+ Starts cell voltage self test conversion
+ @return void  
+ */
+void LTC681x_cvst(uint8_t MD, //!< ADC Conversion Mode
+				  uint8_t ST //!<  Sets if self test 1 or 2 is run
+				);				
+
+/*! 
+ Start an Auxiliary Register Self Test Conversion
+ @return void  
+ */
+void LTC681x_axst(uint8_t MD, //!< ADC Conversion Mode
+				  uint8_t ST //!< Sets if self test 1 or 2 is run
 				);
 
-//! Start an open wire Conversion 
-//!@return void 
-void LTC681x_adow(uint8_t MD, //!<  ADC Conversion Mode
-				  uint8_t PUP, //!<  Controls if Discharge is permitted during conversion
+/*! 
+ Start a Status Register Self Test Conversion
+ @return void  
+ */
+void LTC681x_statst( uint8_t MD, //!< ADC Conversion Mode
+					  uint8_t ST //!< Sets if self test 1 or 2 is run
+					);	
+				
+/*!
+ Starts cell voltage overlap conversion
+ @return void 
+ */
+void LTC681x_adol(uint8_t MD, //!< ADC Conversion Mode
+				  uint8_t DCP //!< Discharge permitted during conversion
+				);
+				
+/*!
+ Start an GPIO Redundancy test
+ @return void  
+ */
+void LTC681x_adaxd(uint8_t MD, //!< ADC Conversion Mode
+				  uint8_t CHG //!< Sets which GPIO channels are converted
+				);
+
+/*!
+ Start a Status register redundancy test Conversion
+ @return void  
+ */
+void LTC681x_adstatd(uint8_t MD, //!< ADC Mode
+					  uint8_t CHST //!< Sets which Status channels are converted
+					);	
+					
+/*!
+ Helper function that runs the ADC Self Tests 
+ @return int16_t, error   Number of errors detected. 
+ */
+int16_t LTC681x_run_cell_adc_st(uint8_t adc_reg, //!< Type of register
+                                uint8_t total_ic, //!< Number of ICs in the daisy chain
+                                cell_asic *ic, //!< A two dimensional array that will store the data
+								uint8_t md, //!< ADC Mode
+								bool adcopt //!< ADCOPT bit in the configuration register
+								);
+
+/*!
+ Self Test Helper Function 
+ @return uint16_t test_pattern returns the register data pattern for a given ADC MD and Self test 
+ */
+uint16_t LTC681x_st_lookup( uint8_t MD, //!< ADC Mode
+						  uint8_t ST, //!< Self Test
+						  bool adcopt //!< ADCOPT bit in the configuration register
+						);	
+
+/*!
+ Helper Function that runs the ADC Overlap test 
+ @return uint16_t, error
+  0: Pass
+ -1: False, Error detected 
+ */
+uint16_t LTC681x_run_adc_overlap(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                                 cell_asic *ic //!< A two dimensional array that will store the data
+								 );						
+						
+/*!
+ Helper function that runs the ADC Digital Redundancy commands and checks output for errors
+ @return int16_t, error   Number of errors detected.  
+ */
+int16_t LTC681x_run_adc_redundancy_st(uint8_t adc_mode, //!< ADC Mode
+                                      uint8_t adc_reg, //!< Type of register
+                                      uint8_t total_ic, //!< Number of ICs in the daisy chain
+                                      cell_asic *ic //!< A two dimensional array that will store the data
+									  );					
+
+/*!
+ Start an open wire Conversion 
+ @return void  
+ */
+void LTC681x_adow(uint8_t MD, //!< ADC Conversion Mode
+				  uint8_t PUP, //!< Pull up/Pull down current
 				  uint8_t CH, //!< Channels
 				  uint8_t DCP//!< Discharge Permit
 				);
 
-//! Start a GPIO and Vref2 Conversion
-//!@return void 
-void LTC681x_adax( uint8_t MD, //!<  ADC Conversion Mode
-				  uint8_t CHG //!<  Sets which GPIO channels are converted
-				);
-
-//! Start an GPIO Redundancy test
-//!@return void 
-void LTC681x_adaxd(uint8_t MD, //!<  ADC Conversion Mode
-				  uint8_t CHG //!<  Sets which GPIO channels are converted
-				);
-
-//! Start an Auxiliary Register Self Test Conversion
-//!@return void 
-void LTC681x_axst(uint8_t MD, //!<  ADC Conversion Mode
-				  uint8_t ST //!<  Sets if self test 1 or 2 is run
-				);
-
-//! Start a Status ADC Conversion
-//!@return void 
-void LTC681x_adstat(uint8_t MD, //!<  ADC Conversion Mode
-					  uint8_t CHST //!<  Sets which Stat channels are converted
-					);
-
-//! Start a Status register redundancy test Conversion
-//!@return void 
-void LTC681x_adstatd(uint8_t MD, //!<  ADC Mode
-					  uint8_t CHST //!<  Sets which Status channels are converted
-					);
-
-//! Start a Status Register Self Test Conversion
-//!@return void 
-void LTC681x_statst( uint8_t MD, //!<  ADC Conversion Mode
-					  uint8_t ST //!<  Sets if self test 1 or 2 is run
-					);
-
-//! Sends the poll ADC command
-//!@returns 1 byte read back after a pladc command. If the byte is not 0xFF ADC conversion has completed
-uint8_t LTC681x_pladc();
-
-//! This function will block operation until the ADC has finished it's conversion
-//! @returns the approximate time it took for the ADC function to complete.
-uint32_t LTC681x_pollAdc();
-
-//! Starts the Mux Decoder diagnostic self test
-//! Running this command will start the Mux Decoder Diagnostic Self Test
-//! This test takes roughly 1ms to complete. The MUXFAIL bit will be updated,
-//! the bit will be set to 1 for a failure and 0 if the test has been passed.
-//!@return void
-void LTC681x_diagn();
-					 
-//! Helper function that parses voltage measurement registers
-//! @return int8_t, PEC Status.
-//! 0: Data read back has matching PEC
-//!-1: Data read back has incorrect PEC
-int8_t parse_cells(uint8_t current_ic,
-                   uint8_t cell_reg,
-                   uint8_t cell_data[],
-                   uint16_t *cell_codes,
-                   uint8_t *ic_pec);
-
-//! Reads the raw cell voltage register data
-//!@return void				   
-void LTC681x_rdcv_reg(uint8_t reg, //!< Determines which cell voltage register is read back
-                      uint8_t total_ic, //!< the number of ICs in the
-                      uint8_t *data //!< An array of the unparsed cell codes
-                     );				   
-
-//! Read the raw data from the LTC681x auxiliary register
-//! The function reads a single GPIO voltage register and stores the read data in the *data point as a byte array. 
-//! This function is rarely used outside of the LTC681x_rdaux() command.
-//!@return void	
-void LTC681x_rdaux_reg(  uint8_t reg, //!<Determines which GPIO voltage register is read back
-                         uint8_t total_ic, //!<The number of ICs in the system
-                         uint8_t *data //!<Array of the unparsed auxiliary codes
-                      );
-					  
-//! Read the raw data from the LTC681x stat register
-//! The function reads a single GPIO voltage register and stores the read data in the *data point as a byte array. 
-//! This function is rarely used outside of the LTC681x_rdstat() command.
-//!@return void	
-void LTC681x_rdstat_reg(uint8_t reg, //!<Determines which stat register is read back
-                        uint8_t total_ic, //!<The number of ICs in the system
-                        uint8_t *data //!<Array of the unparsed stat codes
-                       );
-
-//! Clears the LTC681x cell voltage registers
-//!The command clears the cell voltage registers and initializes all values to 1.
-//!The register will read back hexadecimal 0xFF after the command is sent.
-//!@return void	
-void LTC681x_clrcell();
-
-//! Clears the LTC681x Auxiliary registers
-//!The command clears the Auxiliary registers and initializes all values to 1. 
-//!The register will read back hexadecimal 0xFF after the command is sent.
-//!@return void	
-void LTC681x_clraux();
-
-//! Clears the LTC681x Stat registers
-//!The command clears the Stat registers and initializes all values to 1. 
-//!The register will read back hexadecimal 0xFF after the command is sent.
-//!@return void	
-void LTC681x_clrstat();
-
-//!  Clears the LTC681x SCTRL registers
-//!The command clears the SCTRL registers and initializes all values to 0. 
-//!The register will read back hexadecimal 0x00 after the command is sent.
-//!@return void	
-void LTC681x_clrsctrl();
-
-//!  Reads and parses the LTC681x cell voltage registers.
-//! The function is used to read the cell codes of the LTC6811.
-//! This function will send the requested read commands parse the data and store the cell voltages in the cell_asic structure.
-//!@return uint8_t, PEC Status.
-//! 0: No PEC error detected
-//!-1: PEC error detected, retry read
-uint8_t LTC681x_rdcv(uint8_t reg, //!< Controls which cell voltage register is read back.
-                     uint8_t total_ic, //!< the number of ICs in the system
-                     cell_asic *ic //!< Array of the parsed cell codes
-                    );
-
-//!  Reads and parses the LTC681x auxiliary registers.
-//! The function is used to read the  parsed GPIO codes of the LTC6811. 
-//! This function will send the requested read commands parse the data and store the gpio voltages in the cell_asic structure.
-//!@return  int8_t, PEC Status
-//!  0: No PEC error detected
-//! -1: PEC error detected, retry read
-int8_t LTC681x_rdaux(uint8_t reg, //!<Determines which GPIO voltage register is read back.
-                     uint8_t total_ic,//!<the number of ICs in the system
-                     cell_asic *ic//!<  Measurement Data Structure
-                    );
-
-//!  Reads and parses the LTC681x stat registers.
-//! The function is used to read the  parsed status codes of the LTC6811. 
-//! This function will send the requested read commands parse the data and store the status voltages in the cell_asic structure
-//!@return  int8_t, PEC Status
-//! 0: No PEC error detected
-//!-1: PEC error detected, retry read
-int8_t LTC681x_rdstat(  uint8_t reg, //!< Determines which Stat  register is read back.
-                        uint8_t total_ic,//!< the number of ICs in the system
-                        cell_asic *ic//!<  Measurement Data Structure
-                     );
-					 
-//! Write the LTC681x CFGRA
-//! This command will write the configuration registers of the LTC681xs
-//! connected in a daisy chain stack. The configuration is written in descending
-//! order so the last device's configuration is written first.
-//!@return void	
-void LTC681x_wrcfg(uint8_t total_ic, //!<The number of ICs being written to
-                   cell_asic *ic //!<A two dimensional array of the configuration data that will be written
-                  );
-				  
-//! Write the LTC681x CFGRB register
-//! This command will write the configuration registers of the LTC681xs connected in a daisy chain stack. 
-//!The configuration is written in descending order so the last device's configuration is written first.
-//!@return void	
-void LTC681x_wrcfgb(uint8_t total_ic, //!<The number of ICs being written to
-                    cell_asic *ic //!<A two dimensional array of the configuration data that will be written
-                   );
-				   
-//! Reads the LTC681x CFGRA register 
-//!@return int8_t, PEC Status.
-//! 0: Data read back has matching PEC
-//!-1: Data read back has incorrect PEC
-int8_t LTC681x_rdcfg(uint8_t total_ic, //!<Number of ICs in the system
-                     cell_asic *ic //!<A two dimensional array that the function stores the read configuration data.
-                    );
-
-//! Reads the LTC681x CFGRB register 
-//!@return int8_t, PEC Status.
-//! 0: Data read back has matching PEC
-//!-1: Data read back has incorrect PEC
-int8_t LTC681x_rdcfgb(uint8_t total_ic, //!<Number of ICs in the system
-                      cell_asic *ic //!<A two dimensional array that the function stores the read configuration data.
-                     );
-
-//! Write the LTC681x PWM register
-//! This command will write the pwm registers of the LTC681x connected in a daisy chain stack. 
-//! The pwm is written in descending order so the last device's pwm is written first. 
-//!@return void	
-void LTC681x_wrpwm(uint8_t total_ic, //!<  The number of ICs being written to
-                   uint8_t pwmReg,  //!<  The PWM Register to be written
-                   cell_asic *ic //!<  ASIC Variable
-                  );
-
-//!  Reads pwm registers of a LTC6811 daisy chain
-//!  @return int8_t, PEC Status.
-//!  0: Data read back has matching PEC
-//! -1: Data read back has incorrect PEC
-int8_t LTC681x_rdpwm(uint8_t total_ic, //!< Number of ICs in the system
-                     uint8_t pwmReg, //!<  The PWM Register to be written A or B
-                     cell_asic *ic //!<  ASIC Variable
-                    );
-
-//! Write the LTC681x COMM register
-//! This command will write the comm registers of the LTC681x connected in a daisy chain stack. 
-//! The comm is written in descending order so the last device's configuration is written first.*/ 
-//!@return void	
-void LTC681x_wrcomm(uint8_t total_ic, //!<  The number of ICs being written to
-                    cell_asic *ic //!<  ASIC Variable
-                   );
-				   
-//! Reads comm registers of a LTC681x daisy chain
-int8_t LTC681x_rdcomm(uint8_t total_ic, //!<  Number of ICs in the system
-                      cell_asic *ic //!<  ASIC Variable
-                     );
-
-//! Issues a stcomm command and clocks data out of the COMM register  
-//!@return void	
-void LTC681x_stcomm();					 
-
-//! Write the ltc6811 Sctrl register
-//!@return void	 					 
-void LTC681x_wrsctrl(uint8_t total_ic, //!<  number of ICs in the daisy chain
-                     uint8_t sctrl_reg,
-                     cell_asic *ic //!< A two dimensional array that will store the data
-                    );                  
-
-//! Reads sctrl registers of a ltc6811 daisy chain    
-//!@return int8_t, PEC Status.
-//!  0: Data read back has matching PEC
-//!  -1: Data read back has incorrect PEC					
-int8_t LTC681x_rdsctrl(uint8_t total_ic, //!<  number of ICs in the daisy chain
-                       uint8_t sctrl_reg,
-                       cell_asic *ic //!<  a two dimensional array that the function stores the read pwm data
-                      );					 
-
-//! Start Sctrl data communication       
-//!This command will start the sctrl pulse communication over the spins	
-//!@return void					  
-void LTC681x_stsctrl();
-
-//! Helper Function to clear DCC bits in the CFGR Registers 
-//!@return void	
-void LTC681x_clear_discharge(uint8_t total_ic,//!<  number of ICs in the daisy chain
-                             cell_asic *ic //!< A two dimensional array that will store the data
-							 );
-		
-//! Self Test Helper Function 
-//! @returns returns the register data pattern for a given ADC MD and Self test
-uint16_t LTC681x_st_lookup( uint8_t MD, //!<ADC Mode
-						  uint8_t ST, //!<Self Test
-						  bool adcopt
-						);
-
-//! Helper function that runs the ADC Self Tests 
-int16_t LTC681x_run_cell_adc_st(uint8_t adc_reg, //!<  Type of register
-                                uint8_t total_ic, //!<  number of ICs in the daisy chain
-                                cell_asic *ic, //!< A two dimensional array that will store the data
-								uint8_t md,
-								bool adcopt);
-
-//! Helper function that runs the ADC Digital Redundancy commands and checks output for errors
-//!@return int16_t, error 
-int16_t LTC681x_run_adc_redundancy_st(uint8_t adc_mode, //!< ADC Mode
-                                      uint8_t adc_reg, //!<  Type of register
-                                      uint8_t total_ic, //!<  number of ICs in the daisy chain
-                                      cell_asic *ic //!< A two dimensional array that will store the data
-									  );
-
-//! Helper function that runs the data sheet algorithm for open wire for single cell detection
-//!@return void	
-void LTC681x_run_openwire_single(uint8_t total_ic, //!<  number of ICs in the daisy chain
+/*!
+ Start GPIOs open wire ADC conversion
+ @return void 
+ */
+void LTC681x_axow(uint8_t MD, //!< ADC Mode
+				  uint8_t PUP //!<Pull up/Pull down current
+				 );
+				 
+/*!
+ Helper function that runs the data sheet algorithm for open wire for single cell detection
+ @return void 
+ */	
+void LTC681x_run_openwire_single(uint8_t total_ic, //!< Number of ICs in the daisy chain
 								cell_asic *ic //!< A two dimensional array that will store the data
 								);
 								
-//! Helper function that runs open wire for multiple cell and two consecutive cells detection
-//!@return void	
- void LTC681x_run_openwire_multi(uint8_t total_ic, //!<  number of ICs in the daisy chain
+/*!
+ Helper function that runs open wire for multiple cell and two consecutive cells detection
+ @return void	 
+ */
+ void LTC681x_run_openwire_multi(uint8_t total_ic, //!< Number of ICs in the daisy chain
 						         cell_asic *ic //!< A two dimensional array that will store the data
 						        );								
+				 
+/*!
+ Runs open wire for GPIOs
+ @return void	 
+ */
+void LTC681x_run_gpio_openwire(uint8_t total_ic, //!< Number of ICs in the daisy chain
+								cell_asic *ic //!< A two dimensional array that will store the data
+								);								
 
-//! Helper Function that runs the ADC Overlap test 
-//!@return uint16_t, error
-//! 0: Pass
-//!-1: False, Error detected
-uint16_t LTC681x_run_adc_overlap(uint8_t total_ic, //!<  number of ICs in the daisy chain
-                                 cell_asic *ic //!< A two dimensional array that will store the data
-								 );
+/*!
+ Helper Function to clear DCC bits in the CFGR Registers 
+ @return void	 
+ */
+void LTC681x_clear_discharge(uint8_t total_ic,//!< Number of ICs in the daisy chain
+                             cell_asic *ic //!< A two dimensional array that will store the data
+							 );
+
+/*!
+ Write the LTC681x PWM register
+ This command will write the pwm registers of the LTC681x connected in a daisy chain stack. 
+ The pwm is written in descending order so the last device's pwm is written first. 
+ @return void	 
+ */
+void LTC681x_wrpwm(uint8_t total_ic, //!< The number of ICs being written to
+                   uint8_t pwmReg,  //!< The PWM Register to be written
+                   cell_asic *ic //!< A two dimensional array that will store the data to be written 
+                  );
+
+/*!
+  Reads pwm registers of a LTC681x daisy chain
+  @return int8_t, pec_error PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC 
+ */
+int8_t LTC681x_rdpwm(uint8_t total_ic, //!< Number of ICs in the system
+                     uint8_t pwmReg, //!< The PWM Register to be written A or B
+                     cell_asic *ic //!< A two dimensional array that will store the read data
+                    );
+					
+/*!
+ Write the LTC681x Sctrl register
+ @return void	 
+ */ 					 
+void LTC681x_wrsctrl(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                     uint8_t sctrl_reg, //!< The Sctrl Register to be written A or B
+                     cell_asic *ic //!< A two dimensional array that will store the data to be written 
+                    );                  
+
+/*!
+ Reads sctrl registers of a LTC681x daisy chain    
+ @return int8_t, pec_error PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC	 
+ */				
+int8_t LTC681x_rdsctrl(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                       uint8_t sctrl_reg, //!< The Sctrl Register to be written A or B
+                       cell_asic *ic //!< A two dimensional array that the function stores the read data
+                      );					 
+
+/*!
+ Start Sctrl data communication       
+ This command will start the sctrl pulse communication over the spins	
+ @return void	 
+ */				  
+void LTC681x_stsctrl();
+
+/*! 
+ Clears the LTC681x SCTRL registers
+ The command clears the SCTRL registers and initializes all values to 0. 
+ The register will read back hexadecimal 0x00 after the command is sent.
+ @return void	
+ */
+void LTC681x_clrsctrl();
+								
+/*!
+ Write the LTC681x COMM register
+ This command will write the comm registers of the LTC681x connected in a daisy chain stack. 
+ The comm is written in descending order so the last device's configuration is written first.
+ @return void	 
+ */
+void LTC681x_wrcomm(uint8_t total_ic, //!<  The number of ICs being written to
+                    cell_asic *ic //!< A two dimensional array that will store the data to be written 
+                   );
+				   
+/*!
+ Reads comm registers of a LTC681x daisy chain
+ @return int8_t, pec_error PEC Status.
+  0: Data read back has matching PEC
+ -1: Data read back has incorrect PEC 
+ */
+int8_t LTC681x_rdcomm(uint8_t total_ic, //!< Number of ICs in the system
+                      cell_asic *ic //!< A two dimensional array that the function stores the read data
+                     );
+
+/*!
+ Issues a stcomm command and clocks data out of the COMM register  
+ @return void	 
+ */
+void LTC681x_stcomm(uint8_t len //!< Length of data to be transmitted 
+					);				 
 								 
-//! Helper Function that counts overall PEC errors and register/IC PEC errors
-//!@return void	 
-void LTC681x_check_pec(uint8_t total_ic, //!<  number of ICs in the daisy chain
+/*!
+ Helper Function that counts overall PEC errors and register/IC PEC errors
+ @return void	 
+ */ 
+void LTC681x_check_pec(uint8_t total_ic, //!< Number of ICs in the daisy chain
                        uint8_t reg, //!< Type of register
                        cell_asic *ic //!< A two dimensional array that will store the data
 					   );
 
-//! Helper Function that resets the PEC error counters
-//!@return void	  
-void LTC681x_reset_crc_count(uint8_t total_ic, //!<  number of ICs in the daisy chain
+/*!
+ Helper Function that resets the PEC error counters
+ @return void	 
+ */  
+void LTC681x_reset_crc_count(uint8_t total_ic, //!< Number of ICs in the daisy chain
                              cell_asic *ic //!< A two dimensional array that will store the data
 							 );
-							 
-//! Start GPIOs open wire ADC conversion
-//!@return void	
-void LTC681x_axow(uint8_t MD, //!<ADC Mode
-				  uint8_t PUP //!<Discharge Permit
-				 );
-				 
-//! Runs open wire for GPIOs
-//!@return void	
-void LTC681x_run_gpio_openwire(uint8_t total_ic, //!<  number of ICs in the daisy chain
-								cell_asic *ic //!< A two dimensional array that will store the data
-								);
+							 								
+/*!
+ Helper Function to initialize the CFGR data structures 
+ @return void 
+ */
+void LTC681x_init_cfg(uint8_t total_ic, //!< Number of ICs in the daisy chain
+                      cell_asic *ic //!< A two dimensional array that will store the data
+					  );
+
+/*!
+ Helper function to set appropriate bits in CFGR register based on bit function
+ @return void  
+ */
+void LTC681x_set_cfgr(uint8_t nIC, //!< Current IC
+                      cell_asic *ic, //!< A two dimensional array that will store the data
+                      bool refon,  //!< The REFON bit
+                      bool adcopt, //!< The ADCOPT bit
+                      bool gpio[5],//!< The GPIO bits
+                      bool dcc[12],//!< The DCC bits 
+					  bool dcto[4],//!< The Dcto bits
+					  uint16_t uv, //!< The UV value
+					  uint16_t ov  //!< The OV value
+					  );
+
+/*!
+ Helper function to turn the REFON bit HIGH or LOW 
+ @return void  
+ */
+void LTC681x_set_cfgr_refon(uint8_t nIC, //!< Current IC
+                            cell_asic *ic, //!< A two dimensional array that will store the data
+                            bool refon //!< The REFON bit
+							);
+
+/*!
+ Helper function to turn the ADCOPT bit HIGH or LOW 
+ @return void  
+ */
+void LTC681x_set_cfgr_adcopt(uint8_t nIC, //!< Current IC
+                             cell_asic *ic, //!< A two dimensional array that will store the data
+                             bool adcopt //!< The ADCOPT bit
+							 );
+
+/*!
+ Helper function to turn the GPIO bits HIGH or LOW 
+ @return void 
+ */
+void LTC681x_set_cfgr_gpio(uint8_t nIC, //!< Current IC
+                           cell_asic *ic, //!< A two dimensional array that will store the data
+                           bool gpio[] //!< The GPIO bits
+						   );
+
+/*!
+ Helper function to turn the DCC bits HIGH or LOW 
+ @return void  
+ */
+void LTC681x_set_cfgr_dis(uint8_t nIC, //!< Current IC
+                          cell_asic *ic, //!< A two dimensional array that will store the data
+                          bool dcc[] //!< The DCC bits 
+						  );
+						  
+/*!
+ Helper function to control discharge time value
+ @return void 
+ */
+void LTC681x_set_cfgr_dcto(uint8_t nIC,  //!< Current IC
+						   cell_asic *ic, //!< A two dimensional array that will store the data
+						   bool dcto[] //!< The Dcto bits
+						   );
+
+/*!
+ Helper function to set uv field in CFGRA register
+ @return void  
+ */
+void LTC681x_set_cfgr_uv(uint8_t nIC, //!< Current IC
+                         cell_asic *ic, //!< A two dimensional array that will store the data
+                         uint16_t uv //!< The UV value
+						 );
+
+/*!
+ Helper function to set ov field in CFGRA register
+ @return void   
+ */
+void LTC681x_set_cfgr_ov(uint8_t nIC, //!< Current IC
+                         cell_asic *ic, //!< A two dimensional array that will store the data
+                         uint16_t ov //!< The OV value
+						 );		
 						 
 #ifdef MBED
 //This needs a PROGMEM =  when using with a LINDUINO


### PR DESCRIPTION
LTC681x file changes
Added data length parameter in  LTC681x_stcomm(uint8_t len) 

LTC6811 file changes
Added data length parameter in  LTC6811_stcomm(uint8_t len)
 
DC2259.ino file changes
Changes in case 29 and case 30 for I2C communication via GPIO pins.
Added functions : 
	void check_mux_fail(void);
	void print_selftest_errors(uint8_t adc_reg ,int8_t error);
	void print_overlap_results(int8_t error);
	void print_digital_redundancy_errors(uint8_t adc_reg ,int8_t error);
	int8_t select_s_pin(void);
	void print_conv_time(uint32_t conv_time);
	void serial_print_text(char data[]);
