### PR TITLE
Improvements to read_68() for LTC681x libraries

### DIFF
--- a/LTSketchbook/libraries/LTC6810/LTC6810.cpp
+++ b/LTSketchbook/libraries/LTC6810/LTC6810.cpp
@@ -258,9 +258,7 @@ void LTC6810_rds_reg(uint8_t reg, //Determines which S voltage register is read 
                       uint8_t *data //An array of the unparsed cell codes
                      )
 {
-	const uint8_t REG_LEN = 8; //Number of bytes in each ICs register + 2 bytes for the PEC
-	uint8_t cmd[4];
-	uint16_t cmd_pec;
+	uint8_t cmd[2];
 
 	if (reg == 1)     // RDSA
 	{
@@ -586,7 +584,7 @@ uint8_t LTC6810_rdsid(uint8_t total_ic, // The number of ICs in the system
                      cell_asic *ic //A two dimensional array that the function stores the read data.
                     )
 {
-    uint8_t cmd[4];
+    uint8_t cmd[2];
     uint8_t read_buffer[256];
     int8_t pec_error = 0;
     uint16_t data_pec;

--- a/LTSketchbook/libraries/LTC6810/LTC6810.h
+++ b/LTSketchbook/libraries/LTC6810/LTC6810.h
@@ -388,7 +388,7 @@ void LTC6810_stcomm(uint8_t len //!< Length of data to be transmitted
    0: Data read back has matching PEC
  -1: Data read back has incorrect PEC 
  */
-uint8_t LTC6810_rdsid(uint8_t total_ic, //!< The number of ICs in the system
+int8_t LTC6810_rdsid(uint8_t total_ic, //!< The number of ICs in the system
                      cell_asic *ic //!< A two dimensional array that will store the read data 
                     );
 					

--- a/LTSketchbook/libraries/LTC6812/LTC6812.cpp
+++ b/LTSketchbook/libraries/LTC6812/LTC6812.cpp
@@ -534,12 +534,10 @@ int8_t LTC6812_rdpsb(uint8_t total_ic, //Number of ICs in the daisy chain
     uint16_t calc_pec;
     uint8_t c_ic = 0;
     
-   
-      cmd[0] = 0x00;
-      cmd[1] = 0x1E;
-	 
+    cmd[0] = 0x00;
+    cmd[1] = 0x1E; 
     
-    pec_error = read_68(total_ic, cmd, read_buffer);
+    read_68(total_ic, cmd, read_buffer);
 
     for(uint8_t current_ic =0; current_ic<total_ic; current_ic++)
     {	
@@ -564,6 +562,7 @@ int8_t LTC6812_rdpsb(uint8_t total_ic, //Number of ICs in the daisy chain
         data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
         if(calc_pec != data_pec )
         {
+            pec_error = -1;
             ic[c_ic].pwmb.rx_pec_match = 1;
 			ic[c_ic].sctrlb.rx_pec_match = 1;
         }

--- a/LTSketchbook/libraries/LTC6812/LTC6812.cpp
+++ b/LTSketchbook/libraries/LTC6812/LTC6812.cpp
@@ -527,7 +527,7 @@ int8_t LTC6812_rdpsb(uint8_t total_ic, //Number of ICs in the daisy chain
                        cell_asic *ic //A two dimensional array that the function stores the read data
                       )	
 {
-	uint8_t cmd[4];
+	uint8_t cmd[2];
     uint8_t read_buffer[256];
     int8_t pec_error = 0;
     uint16_t data_pec;
@@ -535,8 +535,8 @@ int8_t LTC6812_rdpsb(uint8_t total_ic, //Number of ICs in the daisy chain
     uint8_t c_ic = 0;
     
    
-      cmd[0] = 0x00;
-      cmd[1] = 0x1E;
+    cmd[0] = 0x00;
+    cmd[1] = 0x1E;
 	 
     
     pec_error = read_68(total_ic, cmd, read_buffer);

--- a/LTSketchbook/libraries/LTC6813/LTC6813.cpp
+++ b/LTSketchbook/libraries/LTC6813/LTC6813.cpp
@@ -530,7 +530,7 @@ void LTC6813_wrpsb(uint8_t total_ic, // Number of ICs in the system
 }
 
 /* Reading the 6813 PWM/Sctrl Register B */
-uint8_t LTC6813_rdpsb(uint8_t total_ic, //< number of ICs in the daisy chain
+int8_t LTC6813_rdpsb(uint8_t total_ic, //< number of ICs in the daisy chain
                       cell_asic *ic //< a two dimensional array that the function stores the read data
                       )	
 {
@@ -542,7 +542,7 @@ uint8_t LTC6813_rdpsb(uint8_t total_ic, //< number of ICs in the daisy chain
     uint8_t c_ic = 0;
 	cmd[0] = 0x00;
 	cmd[1] = 0x1E;
-    pec_error = read_68(total_ic, cmd, read_buffer);
+    read_68(total_ic, cmd, read_buffer);
 
     for(uint8_t current_ic =0; current_ic<total_ic; current_ic++)
     {	
@@ -568,15 +568,14 @@ uint8_t LTC6813_rdpsb(uint8_t total_ic, //< number of ICs in the daisy chain
         data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
         if(calc_pec != data_pec )
         {
+            pec_error = -1;
             ic[c_ic].pwmb.rx_pec_match = 1;
 			ic[c_ic].sctrlb.rx_pec_match = 1;
-			
         }
         else 
 		{
 			ic[c_ic].pwmb.rx_pec_match = 0;
 			ic[c_ic].sctrlb.rx_pec_match = 0;
-			
 		}
     }
     return(pec_error);

--- a/LTSketchbook/libraries/LTC6813/LTC6813.cpp
+++ b/LTSketchbook/libraries/LTC6813/LTC6813.cpp
@@ -534,7 +534,7 @@ uint8_t LTC6813_rdpsb(uint8_t total_ic, //< number of ICs in the daisy chain
                       cell_asic *ic //< a two dimensional array that the function stores the read data
                       )	
 {
-    uint8_t cmd[4];
+    uint8_t cmd[2];
     uint8_t read_buffer[256];
     int8_t pec_error = 0;
     uint16_t data_pec;

--- a/LTSketchbook/libraries/LTC6813/LTC6813.h
+++ b/LTSketchbook/libraries/LTC6813/LTC6813.h
@@ -424,7 +424,7 @@ void LTC6813_wrpsb(uint8_t total_ic, //!< Number of ICs in the system
    0: Data read back has matching PEC
   -1: Data read back has incorrect PEC 
   */
-uint8_t LTC6813_rdpsb(uint8_t total_ic, //!< Number of ICs in the daisy chain
+int8_t LTC6813_rdpsb(uint8_t total_ic, //!< Number of ICs in the daisy chain
                        cell_asic *ic //!< A two dimensional array that the function stores the read data
                       );	
 

--- a/LTSketchbook/libraries/LTC681x/LTC681x.cpp
+++ b/LTSketchbook/libraries/LTC681x/LTC681x.cpp
@@ -368,7 +368,7 @@ void LTC681x_adax(uint8_t MD, //ADC Mode
 				  uint8_t CHG //GPIO Channels to be measured
 				  )
 {
-	uint8_t cmd[4];
+	uint8_t cmd[2];
 	uint8_t md_bits;
 	
 	md_bits = (MD & 0x02) >> 1;
@@ -384,7 +384,7 @@ void LTC681x_adstat(uint8_t MD, //ADC Mode
 				    uint8_t CHST //Stat Channels to be measured
 				    )
 {
-	uint8_t cmd[4];
+	uint8_t cmd[2];
 	uint8_t md_bits;
 	
 	md_bits = (MD & 0x02) >> 1;
@@ -1039,7 +1039,7 @@ void LTC681x_adaxd(uint8_t MD, //ADC Mode
 				   uint8_t CHG //GPIO Channels to be measured
 				   )
 {
-	uint8_t cmd[4];
+	uint8_t cmd[2];
 	uint8_t md_bits;
 
 	md_bits = (MD & 0x02) >> 1;
@@ -1741,7 +1741,7 @@ int8_t LTC681x_rdpwm(uint8_t total_ic, //Number of ICs in the system
                     )
 {
 	const uint8_t BYTES_IN_REG = 8;
-	uint8_t cmd[4];
+	uint8_t cmd[2];
 	uint8_t read_buffer[256];
 	int8_t pec_error = 0;
 	uint16_t data_pec;
@@ -1829,7 +1829,7 @@ int8_t LTC681x_rdsctrl(uint8_t total_ic, // Number of ICs in the daisy chain
                        cell_asic *ic // A two dimensional array that the function stores the read data
                       )	
 {
-    uint8_t cmd[4];
+    uint8_t cmd[2];
     uint8_t read_buffer[256];
     int8_t pec_error = 0;
     uint16_t data_pec;
@@ -1878,7 +1878,7 @@ This command will start the sctrl pulse communication over the spins
 */
 void LTC681x_stsctrl()
 {
-	uint8_t cmd[4];
+    uint8_t cmd[4];
     uint16_t cmd_pec;
     
     cmd[0] = 0x00;

--- a/LTSketchbook/libraries/LTC681x/LTC681x.cpp
+++ b/LTSketchbook/libraries/LTC681x/LTC681x.cpp
@@ -137,17 +137,13 @@ void write_68(uint8_t total_ic, //Number of ICs to be written to
 }
 
 /* Generic function to write 68xx commands and read data. Function calculated PEC for tx_cmd data */
-int8_t read_68( uint8_t total_ic, // Number of ICs in the system 
+void read_68( uint8_t total_ic, // Number of ICs in the system 
 				uint8_t tx_cmd[2], // The command to be transmitted 
 				uint8_t *rx_data // Data to be read
 				)
 {
-	const uint8_t BYTES_IN_REG = 8;
 	uint8_t cmd[4];
-	int8_t pec_error = 0;
 	uint16_t cmd_pec;
-	uint16_t data_pec;
-	uint16_t received_pec;
 	
 	cmd[0] = tx_cmd[0];
 	cmd[1] = tx_cmd[1];
@@ -156,22 +152,8 @@ int8_t read_68( uint8_t total_ic, // Number of ICs in the system
 	cmd[3] = (uint8_t)(cmd_pec);
 	
 	cs_low(CS_PIN);
-	spi_write_read(cmd, 4, rx_data, (BYTES_IN_REG*total_ic));         //Transmits the command and reads the configuration data of all ICs on the daisy chain into rx_data[] array
+	spi_write_read(cmd, 4, rx_data, (NUM_RX_BYT*total_ic));         //Transmits the command and reads the configuration data of all ICs on the daisy chain into rx_data[] array
 	cs_high(CS_PIN);                                         
-
-	for (uint8_t current_ic = 0; current_ic < total_ic; current_ic++) // Executes for each LTC681x in the daisy chain
-	{								  // and check the received data for any bit errors
-		
-		received_pec = (rx_data[(current_ic*8)+6]<<8) + rx_data[(current_ic*8)+7];
-		data_pec = pec15_calc(6, &rx_data[current_ic*8]);
-		
-		if (received_pec != data_pec)
-		{
-		  pec_error = -1;
-		}
-	}
-	
-	return pec_error;
 }
 
 /* Calculates  and returns the CRC15 */
@@ -267,7 +249,7 @@ int8_t LTC681x_rdcfg(uint8_t total_ic, //Number of ICs in the system
 	uint16_t calc_pec;
 	uint8_t c_ic = 0;
 	
-	pec_error = read_68(total_ic, cmd, read_buffer);
+	read_68(total_ic, cmd, read_buffer);
 	
 	for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
 	{
@@ -289,6 +271,7 @@ int8_t LTC681x_rdcfg(uint8_t total_ic, //Number of ICs in the system
 		data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
 		if (calc_pec != data_pec )
 		{
+            pec_error = -1;
 			ic[c_ic].config.rx_pec_match = 1;
 		}
 		else ic[c_ic].config.rx_pec_match = 0;
@@ -310,7 +293,7 @@ int8_t LTC681x_rdcfgb(uint8_t total_ic, //Number of ICs in the system
 	uint16_t calc_pec;
 	uint8_t c_ic = 0;
 	
-	pec_error = read_68(total_ic, cmd, read_buffer);
+	read_68(total_ic, cmd, read_buffer);
 	
 	for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
 	{
@@ -332,6 +315,7 @@ int8_t LTC681x_rdcfgb(uint8_t total_ic, //Number of ICs in the system
 		data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
 		if (calc_pec != data_pec )
 		{
+            pec_error = -1;
 			ic[c_ic].configb.rx_pec_match = 1;
 		}
 		else ic[c_ic].configb.rx_pec_match = 0;
@@ -691,9 +675,7 @@ void LTC681x_rdcv_reg(uint8_t reg, //Determines which cell voltage register is r
                       uint8_t *data //An array of the unparsed cell codes
                      )
 {
-	const uint8_t REG_LEN = 8; //Number of bytes in each ICs register + 2 bytes for the PEC
-	uint8_t cmd[4];
-	uint16_t cmd_pec;
+	uint8_t cmd[2];
 
 	if (reg == 1)     //1: RDCVA
 	{
@@ -726,13 +708,7 @@ void LTC681x_rdcv_reg(uint8_t reg, //Determines which cell voltage register is r
 		cmd[0] = 0x00;
 	}
 
-	cmd_pec = pec15_calc(2, cmd);
-	cmd[2] = (uint8_t)(cmd_pec >> 8);
-	cmd[3] = (uint8_t)(cmd_pec);
-
-	cs_low(CS_PIN);
-	spi_write_read(cmd,4,data,(REG_LEN*total_ic));
-	cs_high(CS_PIN);
+    read_68(total_ic, cmd, data);
 }
 
 /*
@@ -745,9 +721,7 @@ void LTC681x_rdaux_reg(uint8_t reg, //Determines which GPIO voltage register is 
                        uint8_t *data //Array of the unparsed auxiliary codes
                       )
 {
-	const uint8_t REG_LEN = 8; // Number of bytes in the register + 2 bytes for the PEC
-	uint8_t cmd[4];
-	uint16_t cmd_pec;
+	uint8_t cmd[2];
 
 	if (reg == 1)     //Read back auxiliary group A
 	{
@@ -775,13 +749,7 @@ void LTC681x_rdaux_reg(uint8_t reg, //Determines which GPIO voltage register is 
 		cmd[0] = 0x00;
 	}
 
-	cmd_pec = pec15_calc(2, cmd);
-	cmd[2] = (uint8_t)(cmd_pec >> 8);
-	cmd[3] = (uint8_t)(cmd_pec);
-
-	cs_low(CS_PIN);
-	spi_write_read(cmd,4,data,(REG_LEN*total_ic));
-	cs_high(CS_PIN);
+    read_68(total_ic, cmd, data);
 }
 
 /*
@@ -794,9 +762,7 @@ void LTC681x_rdstat_reg(uint8_t reg, //Determines which stat register is read ba
                         uint8_t *data //Array of the unparsed stat codes
                        )
 {
-	const uint8_t REG_LEN = 8; // number of bytes in the register + 2 bytes for the PEC
-	uint8_t cmd[4];
-	uint16_t cmd_pec;
+	uint8_t cmd[2];
 
 	if (reg == 1)     //Read back status group A
 	{
@@ -815,13 +781,7 @@ void LTC681x_rdstat_reg(uint8_t reg, //Determines which stat register is read ba
 		cmd[0] = 0x00;
 	}
 
-	cmd_pec = pec15_calc(2, cmd);
-	cmd[2] = (uint8_t)(cmd_pec >> 8);
-	cmd[3] = (uint8_t)(cmd_pec);
-
-	cs_low(CS_PIN);
-	spi_write_read(cmd,4,data,(REG_LEN*total_ic));
-	cs_high(CS_PIN);
+    read_68(total_ic, cmd, data);
 }
 
 /* Helper function that parses voltage measurement registers */
@@ -1754,7 +1714,7 @@ int8_t LTC681x_rdpwm(uint8_t total_ic, //Number of ICs in the system
 		cmd[1] = 0x1E;
 	}
 	
-	pec_error = read_68(total_ic, cmd, read_buffer);
+	read_68(total_ic, cmd, read_buffer);
 	for (uint8_t current_ic =0; current_ic<total_ic; current_ic++)
 	{
 		if (ic->isospi_reverse == false)
@@ -1775,6 +1735,7 @@ int8_t LTC681x_rdpwm(uint8_t total_ic, //Number of ICs in the system
 		data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
 		if (calc_pec != data_pec )
 		{
+            pec_error = -1;
 			ic[c_ic].pwm.rx_pec_match = 1;
 		}
 		else ic[c_ic].pwm.rx_pec_match = 0;
@@ -1842,7 +1803,7 @@ int8_t LTC681x_rdsctrl(uint8_t total_ic, // Number of ICs in the daisy chain
       cmd[1] = 0x1E;
 	}
     
-    pec_error = read_68(total_ic, cmd, read_buffer);
+    read_68(total_ic, cmd, read_buffer);
 
     for(uint8_t current_ic =0; current_ic<total_ic; current_ic++)
     {	
@@ -1859,6 +1820,7 @@ int8_t LTC681x_rdsctrl(uint8_t total_ic, // Number of ICs in the daisy chain
         data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
         if(calc_pec != data_pec )
         {
+            pec_error = -1;
             ic[c_ic].sctrl.rx_pec_match = 1;
         }
         else ic[c_ic].sctrl.rx_pec_match = 0;
@@ -1939,7 +1901,7 @@ int8_t LTC681x_rdcomm(uint8_t total_ic, //Number of ICs in the system
 	uint16_t calc_pec;
 	uint8_t c_ic=0;
 	
-	pec_error = read_68(total_ic, cmd, read_buffer);
+	read_68(total_ic, cmd, read_buffer);
 	
 	for (uint8_t current_ic = 0; current_ic<total_ic; current_ic++)
 	{
@@ -1961,6 +1923,7 @@ int8_t LTC681x_rdcomm(uint8_t total_ic, //Number of ICs in the system
 		data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
 		if (calc_pec != data_pec )
 		{
+            pec_error = -1;
 			ic[c_ic].com.rx_pec_match = 1;
 		}
 		else ic[c_ic].com.rx_pec_match = 0;

--- a/LTSketchbook/libraries/LTC681x/LTC681x.cpp
+++ b/LTSketchbook/libraries/LTC681x/LTC681x.cpp
@@ -271,7 +271,7 @@ int8_t LTC681x_rdcfg(uint8_t total_ic, //Number of ICs in the system
 		data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
 		if (calc_pec != data_pec )
 		{
-            pec_error = -1;
+                        pec_error = -1;
 			ic[c_ic].config.rx_pec_match = 1;
 		}
 		else ic[c_ic].config.rx_pec_match = 0;
@@ -315,7 +315,7 @@ int8_t LTC681x_rdcfgb(uint8_t total_ic, //Number of ICs in the system
 		data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
 		if (calc_pec != data_pec )
 		{
-            pec_error = -1;
+                        pec_error = -1;
 			ic[c_ic].configb.rx_pec_match = 1;
 		}
 		else ic[c_ic].configb.rx_pec_match = 0;
@@ -708,7 +708,7 @@ void LTC681x_rdcv_reg(uint8_t reg, //Determines which cell voltage register is r
 		cmd[0] = 0x00;
 	}
 
-    read_68(total_ic, cmd, data);
+        read_68(total_ic, cmd, data);
 }
 
 /*
@@ -749,7 +749,7 @@ void LTC681x_rdaux_reg(uint8_t reg, //Determines which GPIO voltage register is 
 		cmd[0] = 0x00;
 	}
 
-    read_68(total_ic, cmd, data);
+        read_68(total_ic, cmd, data);
 }
 
 /*
@@ -781,7 +781,7 @@ void LTC681x_rdstat_reg(uint8_t reg, //Determines which stat register is read ba
 		cmd[0] = 0x00;
 	}
 
-    read_68(total_ic, cmd, data);
+        read_68(total_ic, cmd, data);
 }
 
 /* Helper function that parses voltage measurement registers */
@@ -1735,7 +1735,7 @@ int8_t LTC681x_rdpwm(uint8_t total_ic, //Number of ICs in the system
 		data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
 		if (calc_pec != data_pec )
 		{
-            pec_error = -1;
+                        pec_error = -1;
 			ic[c_ic].pwm.rx_pec_match = 1;
 		}
 		else ic[c_ic].pwm.rx_pec_match = 0;
@@ -1749,7 +1749,7 @@ void LTC681x_wrsctrl(uint8_t total_ic, // Number of ICs in the daisy chain
                      cell_asic *ic  // A two dimensional array that stores the data to be written
                     )
 {
-	uint8_t cmd[2];
+    uint8_t cmd[2];
     uint8_t write_buffer[256];
     uint8_t write_count = 0;
     uint8_t c_ic = 0;
@@ -1835,7 +1835,7 @@ This command will start the sctrl pulse communication over the spins
 */
 void LTC681x_stsctrl()
 {
-	uint8_t cmd[4];
+    uint8_t cmd[4];
     uint16_t cmd_pec;
     
     cmd[0] = 0x00;
@@ -1923,7 +1923,7 @@ int8_t LTC681x_rdcomm(uint8_t total_ic, //Number of ICs in the system
 		data_pec = read_buffer[7+(8*current_ic)] | (read_buffer[6+(8*current_ic)]<<8);
 		if (calc_pec != data_pec )
 		{
-            pec_error = -1;
+                        pec_error = -1;
 			ic[c_ic].com.rx_pec_match = 1;
 		}
 		else ic[c_ic].com.rx_pec_match = 0;

--- a/LTSketchbook/libraries/LTC681x/LTC681x.cpp
+++ b/LTSketchbook/libraries/LTC681x/LTC681x.cpp
@@ -144,7 +144,6 @@ int8_t read_68( uint8_t total_ic, // Number of ICs in the system
 {
 	const uint8_t BYTES_IN_REG = 8;
 	uint8_t cmd[4];
-	uint8_t data[256];
 	int8_t pec_error = 0;
 	uint16_t cmd_pec;
 	uint16_t data_pec;
@@ -157,15 +156,11 @@ int8_t read_68( uint8_t total_ic, // Number of ICs in the system
 	cmd[3] = (uint8_t)(cmd_pec);
 	
 	cs_low(CS_PIN);
-	spi_write_read(cmd, 4, data, (BYTES_IN_REG*total_ic));         //Transmits the command and reads the configuration data of all ICs on the daisy chain into rx_data[] array
+	spi_write_read(cmd, 4, rx_data, (BYTES_IN_REG*total_ic));         //Transmits the command and reads the configuration data of all ICs on the daisy chain into rx_data[] array
 	cs_high(CS_PIN);                                         
 
-	for (uint8_t current_ic = 0; current_ic < total_ic; current_ic++) //Executes for each LTC681x in the daisy chain and packs the data
-	{																//into the rx_data array as well as check the received data for any bit errors
-		for (uint8_t current_byte = 0; current_byte < BYTES_IN_REG; current_byte++)
-		{
-			rx_data[(current_ic*8)+current_byte] = data[current_byte + (current_ic*BYTES_IN_REG)];
-		}
+	for (uint8_t current_ic = 0; current_ic < total_ic; current_ic++) // Executes for each LTC681x in the daisy chain
+	{								  // and check the received data for any bit errors
 		
 		received_pec = (rx_data[(current_ic*8)+6]<<8) + rx_data[(current_ic*8)+7];
 		data_pec = pec15_calc(6, &rx_data[current_ic*8]);
@@ -176,7 +171,7 @@ int8_t read_68( uint8_t total_ic, // Number of ICs in the system
 		}
 	}
 	
-	return(pec_error);
+	return pec_error;
 }
 
 /* Calculates  and returns the CRC15 */

--- a/LTSketchbook/libraries/LTC681x/LTC681x.h
+++ b/LTSketchbook/libraries/LTC681x/LTC681x.h
@@ -214,12 +214,10 @@ void write_68(uint8_t total_ic , //!< Number of ICs in the daisy chain
              );
 			 
 /*!
- Issues a command onto the daisy chain and reads back 6*total_ic data in the rx_data array
- @return int8_t, PEC Status.
-  0: Data read back has matching PEC
- -1: Data read back has incorrect PEC  
+ Issues a command onto the daisy chain and reads back 8*total_ic data in the rx_data array
+ @return void 
  */
-int8_t read_68( uint8_t total_ic, //!< Number of ICs in the daisy chain
+void read_68( uint8_t total_ic, //!< Number of ICs in the daisy chain
                 uint8_t tx_cmd[2], //!< 2 byte array containing the BMS command to be sent
                 uint8_t *rx_data); //!< Array that the read back data will be stored in.
 				


### PR DESCRIPTION
I used DC2026C (ATmega328p) and DC2259A (LTC6811) for testing. 

* `read_68()` is much simpler and is used in more places within the library to reduce repeatability.
* Function is about 6% faster and code overall is 198 bytes smaller. 

Also included:
* Fix overflow when reading sid with LTC6810.
* Added PEC mismatch when reading sid with LTC6810. 
* Fix for `LTC6813_rdpsb()`. Now returns -1 as described in the header file. 
* Removed unused variables in `LTC6810_rds_reg()`
* ` LTC681x_rdaux_reg()` now uses `read_68()`
* `LTC681x_rdcv_reg` now uses `read_68()`
* `LTC681x_rdstat_reg` now uses `read_68()`