### PR TITLE
Change uint16_t* to uint8_t* so that ISP code ports to all platforms …

### DIFF
--- a/LTSketchbook/libraries/LTPSM_InFlightUpdate/hex_file_parser.cpp
+++ b/LTSketchbook/libraries/LTPSM_InFlightUpdate/hex_file_parser.cpp
@@ -224,7 +224,7 @@ pRecordHeaderLengthAndType parse_record(uint8_t (*get_data)(void))
 
   if (size > getMaxRecordSize())
   {
-    Serial.println(F("record_data size too samll"));
+    Serial.println(F("record_data size too big"));
     Serial.print(F("requires "));
     Serial.print(size, DEC);
     Serial.print(F(" has "));

--- a/LTSketchbook/libraries/LTPSM_InFlightUpdate/main_record_processor.cpp
+++ b/LTSketchbook/libraries/LTPSM_InFlightUpdate/main_record_processor.cpp
@@ -47,32 +47,60 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /** PRIVATE PROTOTYPES RELATING TO RECORD TYPE PARSING ************/
 uint8_t recordProcessor___0x01___processWriteByteOptionalPEC(t_RECORD_PMBUS_WRITE_BYTE *);
+uint8_t recordProcessor___0x8001___processExtendedWriteByteOptionalPEC(t_RECORD_PMBUS_EXTENDED_WRITE_BYTE *);
 uint8_t recordProcessor___0x02___processWriteWordOptionalPEC(t_RECORD_PMBUS_WRITE_WORD *);
+uint8_t recordProcessor___0x8002___processExtendedWriteWordOptionalPEC(t_RECORD_PMBUS_EXTENDED_WRITE_WORD *);
+uint8_t recordProcessor___0x03___processWriteBlockOptionalPEC(t_RECORD_PMBUS_WRITE_BLOCK *);
+uint8_t recordProcessor___0x8003___processExtendedWriteBlockOptionalPEC(t_RECORD_PMBUS_EXTENDED_WRITE_BLOCK *);
 uint8_t recordProcessor___0x04___processReadByteExpectOptionalPEC(t_RECORD_PMBUS_READ_BYTE_EXPECT *);
+uint8_t recordProcessor___0x8004___processExtendedReadByteExpectOptionalPEC(t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT *);
 uint8_t recordProcessor___0x05___processReadWordExpectOptionalPEC(t_RECORD_PMBUS_READ_WORD_EXPECT *);
+uint8_t recordProcessor___0x8005___processExtendedReadWordExpectOptionalPEC(t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT *);
+uint8_t recordProcessor___0x06___processReadBlockExpectOptionalPec(t_RECORD_PMBUS_READ_BLOCK_EXPECT *);
+uint8_t recordProcessor___0x8006___processExtendedReadBlockExpectOptionalPec(t_RECORD_PMBUS_EXTENDED_READ_BLOCK_EXPECT *);
 uint8_t recordProcessor___0x09___bufferNVMData(t_RECORD_NVM_DATA *);
 uint8_t recordProcessor___0x0A___processReadByteLoopMaskOptionalPEC(t_RECORD_PMBUS_READ_BYTE_LOOP_MASK *);
+uint8_t recordProcessor___0x800A___processExtendedReadByteLoopMaskOptionalPEC(t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK *);
 uint8_t recordProcessor___0x0B___processReadWordLoopMaskOptionalPEC(t_RECORD_PMBUS_READ_WORD_LOOP_MASK *);
+uint8_t recordProcessor___0x800B___processExtendedReadWordLoopMaskOptionalPEC(t_RECORD_PMBUS_EXTENDED_READ_WORD_LOOP_MASK *);
 uint8_t recordProcessor___0x0C___processPollReadByteUntilAckNoPEC(t_RECORD_PMBUS_POLL_READ_BYTE_UNTIL_ACK *);
 uint8_t recordProcessor___0x0D___processDelayMs(t_RECORD_DELAY_MS *);
 uint8_t recordProcessor___0x0E___processSendByteOptionalPEC(t_RECORD_PMBUS_SEND_BYTE *);
+uint8_t recordProcessor___0x800E___processExtendedSendByteOptionalPEC(t_RECORD_PMBUS_EXTENDED_SEND_BYTE *);
 uint8_t recordProcessor___0x0F___processWriteByteNoPEC(t_RECORD_PMBUS_WRITE_BYTE_NOPEC *);
+uint8_t recordProcessor___0x800F___processExtendedWriteByteNoPEC(t_RECORD_PMBUS_EXTENDED_WRITE_BYTE_NOPEC *);
 uint8_t recordProcessor___0x10___processWriteWordNoPEC(t_RECORD_PMBUS_WRITE_WORD_NOPEC *);
+uint8_t recordProcessor___0x8010___processExtendedWriteWordNoPEC(t_RECORD_PMBUS_EXTENDED_WRITE_WORD_NOPEC *);
+uint8_t recordProcessor___0x11___processWriteBlockNoPEC(t_RECORD_PMBUS_WRITE_BLOCK_NOPEC *);
+uint8_t recordProcessor___0x8011___processExtendedWriteBlockNoPEC(t_RECORD_PMBUS_EXTENDED_WRITE_BLOCK_NOPEC *);
 uint8_t recordProcessor___0x12___processReadByteExpectNoPEC(t_RECORD_PMBUS_READ_BYTE_EXPECT_NOPEC *);
+uint8_t recordProcessor___0x8012___processExtendedReadByteExpectNoPEC(t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_NOPEC *);
 uint8_t recordProcessor___0x13___processReadWordExpectNoPEC(t_RECORD_PMBUS_READ_WORD_EXPECT_NOPEC *);
+uint8_t recordProcessor___0x8013___processExtendedReadWordExpectNoPEC(t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT_NOPEC *);
+uint8_t recordProcessor___0x14___processReadBlockExpectNoPec(t_RECORD_PMBUS_READ_BLOCK_EXPECT_NOPEC *);
+uint8_t recordProcessor___0x8014___processExtendedReadBlockExpectNoPec(t_RECORD_PMBUS_EXTENDED_READ_BLOCK_EXPECT_NOPEC *);
 uint8_t recordProcessor___0x15___processReadByteLoopMaskNoPEC(t_RECORD_PMBUS_READ_BYTE_LOOP_MASK_NOPEC *);
+uint8_t recordProcessor___0x8015___processExtendedReadByteLoopMaskNoPEC(t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK_NOPEC *);
 uint8_t recordProcessor___0x16___processReadWordLoopMaskNoPEC(t_RECORD_PMBUS_READ_WORD_LOOP_MASK_NOPEC *);
+uint8_t recordProcessor___0x8016___processExtendedReadWordLoopMaskNoPEC(t_RECORD_PMBUS_EXTENDED_READ_WORD_LOOP_MASK_NOPEC *);
 uint8_t recordProcessor___0x17___processSendByteNoPEC(t_RECORD_PMBUS_SEND_BYTE_NOPEC *);
+uint8_t recordProcessor___0x8017___processExtendedSendByteNoPEC(t_RECORD_PMBUS_EXTENDED_SEND_BYTE_NOPEC *);
 uint8_t recordProcessor___0x18___processEvent(t_RECORD_EVENT *);
 uint8_t recordProcessor___0x19___processReadByteExpectMaskNoPEC(t_RECORD_PMBUS_READ_BYTE_EXPECT_MASK_NOPEC *);
+uint8_t recordProcessor___0x8019___processExtendedReadByteExpectMaskNoPEC(t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_MASK_NOPEC *);
 uint8_t recordProcessor___0x1A___processReadWordExpectMaskNoPEC(t_RECORD_PMBUS_READ_WORD_EXPECT_MASK_NOPEC *);
+uint8_t recordProcessor___0x801A___processExtendedReadWordExpectMaskNoPEC(t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT_MASK_NOPEC *);
 uint8_t recordProcessor___0x1B___processVariableMetaData(t_RECORD_VARIABLE_META_DATA *);
 uint8_t recordProcessor___0x1C___modifyWordNoPEC(t_RECORD_PMBUS_MODIFY_WORD_NO_PEC *);
+uint8_t recordProcessor___0x801C___extendedModifyWordNoPEC(t_RECORD_PMBUS_EXTENDED_MODIFY_WORD_NO_PEC *);
 uint8_t recordProcessor___0x1D___modifyByteNoPEC(t_RECORD_PMBUS_MODIFY_BYTE_NO_PEC *);
+uint8_t recordProcessor___0x801D___extendedModifyByteNoPEC(t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE_NO_PEC *);
 uint8_t recordProcessor___0x1E___writeNvmData(t_RECORD_NVM_DATA *);
 uint8_t recordProcessor___0x1F___read_then_verifyNvmData(t_RECORD_NVM_DATA *);
 uint8_t recordProcessor___0x20___modifyByteOptionalPEC(t_RECORD_PMBUS_MODIFY_BYTE *);
+uint8_t recordProcessor___0x8020___extendedModifyByteOptionalPEC(t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE *);
 uint8_t recordProcessor___0x21___modifyWordOptionalPEC(t_RECORD_PMBUS_MODIFY_WORD *);
+uint8_t recordProcessor___0x8021___extendedModifyWordOptionalPEC(t_RECORD_PMBUS_EXTENDED_MODIFY_WORD *);
 
 /** VARIABLES ******************************************************/
 static bool verification_in_progress = false;
@@ -104,20 +132,38 @@ uint8_t processRecordsOnDemand(pRecordHeaderLengthAndType (*getRecord)(void))
       case RECORD_TYPE_PMBUS_WRITE_BYTE: // 0x01
         successful_parse_of_record_type = recordProcessor___0x01___processWriteByteOptionalPEC( (t_RECORD_PMBUS_WRITE_BYTE *) record_to_process);
         break;
+      case RECORD_TYPE_PMBUS_EXTENDED_WRITE_BYTE: // 0x8001
+        successful_parse_of_record_type = recordProcessor___0x8001___processExtendedWriteByteOptionalPEC( (t_RECORD_PMBUS_EXTENDED_WRITE_BYTE *) record_to_process);
+        break;
       case RECORD_TYPE_PMBUS_WRITE_WORD: // 0x02
         successful_parse_of_record_type = recordProcessor___0x02___processWriteWordOptionalPEC( (t_RECORD_PMBUS_WRITE_WORD *) record_to_process);
         break;
+      case RECORD_TYPE_PMBUS_EXTENDED_WRITE_WORD: // 0x8002
+        successful_parse_of_record_type = recordProcessor___0x8002___processExtendedWriteWordOptionalPEC( (t_RECORD_PMBUS_EXTENDED_WRITE_WORD *) record_to_process);
+        break;
       case RECORD_TYPE_PMBUS_WRITE_BLOCK: // 0x03
-        successful_parse_of_record_type = FAILURE; // Unsupported Record Type
+        successful_parse_of_record_type = recordProcessor___0x03___processWriteBlockOptionalPEC( (t_RECORD_PMBUS_WRITE_BLOCK *) record_to_process);
+        break;
+      case RECORD_TYPE_PMBUS_EXTENDED_WRITE_BLOCK: // 0x8003
+        successful_parse_of_record_type = recordProcessor___0x8003___processExtendedWriteBlockOptionalPEC( (t_RECORD_PMBUS_EXTENDED_WRITE_BLOCK *) record_to_process);
         break;
       case RECORD_TYPE_PMBUS_READ_BYTE_EXPECT: // 0x04
         successful_parse_of_record_type = recordProcessor___0x04___processReadByteExpectOptionalPEC( (t_RECORD_PMBUS_READ_BYTE_EXPECT *) record_to_process);
         break;
+      case RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_EXPECT: // 0x8004
+        successful_parse_of_record_type = recordProcessor___0x8004___processExtendedReadByteExpectOptionalPEC( (t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT *) record_to_process);
+        break;
       case RECORD_TYPE_PMBUS_READ_WORD_EXPECT: // 0x05
         successful_parse_of_record_type = recordProcessor___0x05___processReadWordExpectOptionalPEC( (t_RECORD_PMBUS_READ_WORD_EXPECT *) record_to_process);
         break;
+      case RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_EXPECT: // 0x8005
+        successful_parse_of_record_type = recordProcessor___0x8005___processExtendedReadWordExpectOptionalPEC( (t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT *) record_to_process);
+        break;
       case RECORD_TYPE_PMBUS_READ_BLOCK_EXPECT: // 0x06
-        successful_parse_of_record_type = FAILURE; // Unsupported Record Type
+        successful_parse_of_record_type = recordProcessor___0x06___processReadBlockExpectOptionalPec( (t_RECORD_PMBUS_READ_BLOCK_EXPECT *) record_to_process);
+        break;
+      case RECORD_TYPE_PMBUS_EXTENDED_READ_BLOCK_EXPECT: // 0x8006
+        successful_parse_of_record_type = recordProcessor___0x8006___processExtendedReadBlockExpectOptionalPec( (t_RECORD_PMBUS_EXTENDED_READ_BLOCK_EXPECT *) record_to_process);
         break;
       case RECORD_TYPE_DEVICE_ADDRESS: // 0x07 -- OBSOLETED
         successful_parse_of_record_type = SUCCESS; // Do nothing for this record type, but do not fail
@@ -131,8 +177,14 @@ uint8_t processRecordsOnDemand(pRecordHeaderLengthAndType (*getRecord)(void))
       case RECORD_TYPE_PMBUS_READ_BYTE_LOOP_MASK: // 0x0A
         successful_parse_of_record_type = recordProcessor___0x0A___processReadByteLoopMaskOptionalPEC( (t_RECORD_PMBUS_READ_BYTE_LOOP_MASK *) record_to_process);
         break;
+      case RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK: // 0x800A
+        successful_parse_of_record_type = recordProcessor___0x800A___processExtendedReadByteLoopMaskOptionalPEC( (t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK *) record_to_process);
+        break;
       case RECORD_TYPE_PMBUS_READ_WORD_LOOP_MASK: //0x0B
         successful_parse_of_record_type = recordProcessor___0x0B___processReadWordLoopMaskOptionalPEC( (t_RECORD_PMBUS_READ_WORD_LOOP_MASK *) record_to_process);
+        break;
+      case RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_LOOP_MASK: //0x800B
+        successful_parse_of_record_type = recordProcessor___0x800B___processExtendedReadWordLoopMaskOptionalPEC( (t_RECORD_PMBUS_EXTENDED_READ_WORD_LOOP_MASK *) record_to_process);
         break;
       case RECORD_TYPE_PMBUS_POLL_UNTIL_ACK_NOPEC: // 0x0C
         successful_parse_of_record_type = recordProcessor___0x0C___processPollReadByteUntilAckNoPEC( (t_RECORD_PMBUS_POLL_READ_BYTE_UNTIL_ACK *) record_to_process);
@@ -143,32 +195,62 @@ uint8_t processRecordsOnDemand(pRecordHeaderLengthAndType (*getRecord)(void))
       case RECORD_TYPE_PMBUS_SEND_BYTE: //0x0E
         successful_parse_of_record_type = recordProcessor___0x0E___processSendByteOptionalPEC( (t_RECORD_PMBUS_SEND_BYTE *) record_to_process);
         break;
+      case RECORD_TYPE_PMBUS_EXTENDED_SEND_BYTE: //0x800E
+        successful_parse_of_record_type = recordProcessor___0x800E___processExtendedSendByteOptionalPEC( (t_RECORD_PMBUS_EXTENDED_SEND_BYTE *) record_to_process);
+        break;
       case RECORD_TYPE_PMBUS_WRITE_BYTE_NOPEC: // 0x0F
         successful_parse_of_record_type = recordProcessor___0x0F___processWriteByteNoPEC( (t_RECORD_PMBUS_WRITE_BYTE_NOPEC *) record_to_process);
+        break;
+      case RECORD_TYPE_PMBUS_EXTENDED_WRITE_BYTE_NOPEC: // 0x800F
+        successful_parse_of_record_type = recordProcessor___0x800F___processExtendedWriteByteNoPEC( (t_RECORD_PMBUS_EXTENDED_WRITE_BYTE_NOPEC *) record_to_process);
         break;
       case RECORD_TYPE_PMBUS_WRITE_WORD_NOPEC: // 0x10
         successful_parse_of_record_type = recordProcessor___0x10___processWriteWordNoPEC( (t_RECORD_PMBUS_WRITE_WORD_NOPEC *) record_to_process);
         break;
+      case RECORD_TYPE_PMBUS_EXTENDED_WRITE_WORD_NOPEC: // 0x8010
+        successful_parse_of_record_type = recordProcessor___0x8010___processExtendedWriteWordNoPEC( (t_RECORD_PMBUS_EXTENDED_WRITE_WORD_NOPEC *) record_to_process);
+        break;
       case RECORD_TYPE_PMBUS_WRITE_BLOCK_NOPEC: // 0x11
-        successful_parse_of_record_type = FAILURE; // Unsupported Record Type
+        successful_parse_of_record_type = recordProcessor___0x11___processWriteBlockNoPEC( (t_RECORD_PMBUS_WRITE_BLOCK_NOPEC *) record_to_process);
+        break;
+      case RECORD_TYPE_PMBUS_EXTENDED_WRITE_BLOCK_NOPEC: // 0x8011
+        successful_parse_of_record_type = recordProcessor___0x8011___processExtendedWriteBlockNoPEC( (t_RECORD_PMBUS_EXTENDED_WRITE_BLOCK_NOPEC *) record_to_process);
         break;
       case RECORD_TYPE_PMBUS_READ_BYTE_EXPECT_NOPEC: // 0x12
         successful_parse_of_record_type = recordProcessor___0x12___processReadByteExpectNoPEC( (t_RECORD_PMBUS_READ_BYTE_EXPECT_NOPEC *) record_to_process);
         break;
+      case RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_EXPECT_NOPEC: // 0x8012
+        successful_parse_of_record_type = recordProcessor___0x8012___processExtendedReadByteExpectNoPEC( (t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_NOPEC *) record_to_process);
+        break;
       case RECORD_TYPE_PMBUS_READ_WORD_EXPECT_NOPEC: // 0x13
         successful_parse_of_record_type = recordProcessor___0x13___processReadWordExpectNoPEC( (t_RECORD_PMBUS_READ_WORD_EXPECT_NOPEC *) record_to_process);
         break;
+      case RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_EXPECT_NOPEC: // 0x8013
+        successful_parse_of_record_type = recordProcessor___0x8013___processExtendedReadWordExpectNoPEC( (t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT_NOPEC *) record_to_process);
+        break;
       case RECORD_TYPE_PMBUS_READ_BLOCK_EXPECT_NOPEC: // 0x14
-        successful_parse_of_record_type = FAILURE; // Unsupported Record Type
+        successful_parse_of_record_type = recordProcessor___0x14___processReadBlockExpectNoPec( (t_RECORD_PMBUS_READ_BLOCK_EXPECT_NOPEC *) record_to_process);
+        break;
+      case RECORD_TYPE_PMBUS_EXTENDED_READ_BLOCK_EXPECT_NOPEC: // 0x8014
+        successful_parse_of_record_type = recordProcessor___0x8014___processExtendedReadBlockExpectNoPec( (t_RECORD_PMBUS_EXTENDED_READ_BLOCK_EXPECT_NOPEC *) record_to_process);
         break;
       case RECORD_TYPE_PMBUS_READ_BYTE_LOOP_MASK_NOPEC: // 0x15
         successful_parse_of_record_type = recordProcessor___0x15___processReadByteLoopMaskNoPEC( (t_RECORD_PMBUS_READ_BYTE_LOOP_MASK_NOPEC *) record_to_process);
         break;
+      case RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK_NOPEC: // 0x8015
+        successful_parse_of_record_type = recordProcessor___0x8015___processExtendedReadByteLoopMaskNoPEC( (t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK_NOPEC *) record_to_process);
+        break;
       case RECORD_TYPE_PMBUS_READ_WORD_LOOP_MASK_NOPEC: // 0x16
         successful_parse_of_record_type = recordProcessor___0x16___processReadWordLoopMaskNoPEC( (t_RECORD_PMBUS_READ_WORD_LOOP_MASK_NOPEC *) record_to_process);
         break;
+      case RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_LOOP_MASK_NOPEC: // 0x8016
+        successful_parse_of_record_type = recordProcessor___0x8016___processExtendedReadWordLoopMaskNoPEC( (t_RECORD_PMBUS_EXTENDED_READ_WORD_LOOP_MASK_NOPEC *) record_to_process);
+        break;
       case RECORD_TYPE_PMBUS_SEND_BYTE_NOPEC: // 0x17
         successful_parse_of_record_type = recordProcessor___0x17___processSendByteNoPEC( (t_RECORD_PMBUS_SEND_BYTE_NOPEC *) record_to_process);
+        break;
+      case RECORD_TYPE_PMBUS_EXTENDED_SEND_BYTE_NOPEC: // 0x8017
+        successful_parse_of_record_type = recordProcessor___0x8017___processExtendedSendByteNoPEC( (t_RECORD_PMBUS_EXTENDED_SEND_BYTE_NOPEC *) record_to_process);
         break;
       case RECORD_TYPE_EVENT: // 0x18
         successful_parse_of_record_type = recordProcessor___0x18___processEvent( (t_RECORD_EVENT *) record_to_process);
@@ -176,8 +258,14 @@ uint8_t processRecordsOnDemand(pRecordHeaderLengthAndType (*getRecord)(void))
       case RECORD_TYPE_PMBUS_READ_BYTE_EXPECT_MASK_NOPEC: // 0x19
         successful_parse_of_record_type = recordProcessor___0x19___processReadByteExpectMaskNoPEC( (t_RECORD_PMBUS_READ_BYTE_EXPECT_MASK_NOPEC *) record_to_process);
         break;
+      case RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_EXPECT_MASK_NOPEC: // 0x8019
+        successful_parse_of_record_type = recordProcessor___0x8019___processExtendedReadByteExpectMaskNoPEC( (t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_MASK_NOPEC *) record_to_process);
+        break;
       case RECORD_TYPE_PMBUS_READ_WORD_EXPECT_MASK_NOPEC: //0x1A
         successful_parse_of_record_type = recordProcessor___0x1A___processReadWordExpectMaskNoPEC( (t_RECORD_PMBUS_READ_WORD_EXPECT_MASK_NOPEC *) record_to_process);
+        break;
+      case RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_EXPECT_MASK_NOPEC: //0x801A
+        successful_parse_of_record_type = recordProcessor___0x801A___processExtendedReadWordExpectMaskNoPEC( (t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT_MASK_NOPEC *) record_to_process);
         break;
       case RECORD_TYPE_VARIABLE_META_DATA: // 0x1B
         successful_parse_of_record_type = recordProcessor___0x1B___processVariableMetaData( (t_RECORD_VARIABLE_META_DATA *) record_to_process);
@@ -185,8 +273,14 @@ uint8_t processRecordsOnDemand(pRecordHeaderLengthAndType (*getRecord)(void))
       case RECORD_TYPE_MODIFY_WORD_NOPEC: // 0x1C
         successful_parse_of_record_type = recordProcessor___0x1C___modifyWordNoPEC( (t_RECORD_PMBUS_MODIFY_WORD_NO_PEC *) record_to_process);
         break;
+      case RECORD_TYPE_EXTENDED_MODIFY_WORD_NOPEC: // 0x801C
+        successful_parse_of_record_type = recordProcessor___0x801C___extendedModifyWordNoPEC( (t_RECORD_PMBUS_EXTENDED_MODIFY_WORD_NO_PEC *) record_to_process);
+        break;
       case RECORD_TYPE_MODIFY_BYTE_NOPEC: // 0x1D
         successful_parse_of_record_type = recordProcessor___0x1D___modifyByteNoPEC( (t_RECORD_PMBUS_MODIFY_BYTE_NO_PEC *) record_to_process);
+        break;
+      case RECORD_TYPE_EXTENDED_MODIFY_BYTE_NOPEC: // 0x801D
+        successful_parse_of_record_type = recordProcessor___0x801D___extendedModifyByteNoPEC( (t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE_NO_PEC *) record_to_process);
         break;
       case RECORD_TYPE_PMBUS_WRITE_EE_DATA: // 0x1E
         successful_parse_of_record_type = recordProcessor___0x1E___writeNvmData( (t_RECORD_NVM_DATA *) record_to_process);
@@ -197,8 +291,14 @@ uint8_t processRecordsOnDemand(pRecordHeaderLengthAndType (*getRecord)(void))
       case RECORD_TYPE_PMBUS_MODIFY_BYTE: // 0x20
         successful_parse_of_record_type = recordProcessor___0x20___modifyByteOptionalPEC( (t_RECORD_PMBUS_MODIFY_BYTE *) record_to_process);
         break;
+      case RECORD_TYPE_PMBUS_EXTENDED_MODIFY_BYTE: // 0x8020
+        successful_parse_of_record_type = recordProcessor___0x8020___extendedModifyByteOptionalPEC( (t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE *) record_to_process);
+        break;
       case RECORD_TYPE_PMBUS_MODIFY_WORD: // 0x21
         successful_parse_of_record_type = recordProcessor___0x21___modifyWordOptionalPEC( (t_RECORD_PMBUS_MODIFY_WORD *) record_to_process);
+        break;
+      case RECORD_TYPE_PMBUS_EXTENDED_MODIFY_WORD: // 0x8021
+        successful_parse_of_record_type = recordProcessor___0x8021___extendedModifyWordOptionalPEC( (t_RECORD_PMBUS_EXTENDED_MODIFY_WORD *) record_to_process);
         break;
       case RECORD_TYPE_END_OF_RECORDS: // 0x22
         return SUCCESS;
@@ -242,20 +342,41 @@ uint8_t verifyRecordsOnDemand(pRecordHeaderLengthAndType (*getRecord)(void))
           else
             smbusPec__->writeByte((uint8_t) ((t_RECORD_PMBUS_WRITE_BYTE *)record_to_process)->detailedRecordHeader.DeviceAddress, 0xBD, 0);
           break;
+        case RECORD_TYPE_PMBUS_EXTENDED_WRITE_BYTE: // 0x8001
+          if (((t_RECORD_PMBUS_EXTENDED_WRITE_BYTE *) record_to_process)->detailedRecordHeader.CommandCode != 0xBE)
+            successful_parse_of_record_type = recordProcessor___0x8001___processExtendedWriteByteOptionalPEC( (t_RECORD_PMBUS_EXTENDED_WRITE_BYTE *) record_to_process);
+          else
+            smbusPec__->extendedWriteByte((uint8_t) ((t_RECORD_PMBUS_EXTENDED_WRITE_BYTE *)record_to_process)->detailedRecordHeader.DeviceAddress, 0xBD, 0);
+          break;
         case RECORD_TYPE_PMBUS_WRITE_WORD: // 0x02
           successful_parse_of_record_type = recordProcessor___0x02___processWriteWordOptionalPEC( (t_RECORD_PMBUS_WRITE_WORD *) record_to_process);
           break;
+        case RECORD_TYPE_PMBUS_EXTENDED_WRITE_WORD: // 0x8002
+          successful_parse_of_record_type = recordProcessor___0x8002___processExtendedWriteWordOptionalPEC( (t_RECORD_PMBUS_EXTENDED_WRITE_WORD *) record_to_process);
+          break;
         case RECORD_TYPE_PMBUS_WRITE_BLOCK: // 0x03
-          successful_parse_of_record_type = FAILURE; // Unsupported Record Type
+          successful_parse_of_record_type = recordProcessor___0x11___processWriteBlockNoPEC( (t_RECORD_PMBUS_WRITE_BLOCK_NOPEC *) record_to_process);
+          break;
+        case RECORD_TYPE_PMBUS_EXTENDED_WRITE_BLOCK: // 0x8003
+          successful_parse_of_record_type = recordProcessor___0x8003___processExtendedWriteBlockOptionalPEC( (t_RECORD_PMBUS_EXTENDED_WRITE_BLOCK *) record_to_process);
           break;
         case RECORD_TYPE_PMBUS_READ_BYTE_EXPECT: // 0x04
           successful_parse_of_record_type = recordProcessor___0x04___processReadByteExpectOptionalPEC( (t_RECORD_PMBUS_READ_BYTE_EXPECT *) record_to_process);
           break;
+        case RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_EXPECT: // 0x8004
+          successful_parse_of_record_type = recordProcessor___0x8004___processExtendedReadByteExpectOptionalPEC( (t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT *) record_to_process);
+          break;
         case RECORD_TYPE_PMBUS_READ_WORD_EXPECT: // 0x05
           successful_parse_of_record_type = recordProcessor___0x05___processReadWordExpectOptionalPEC( (t_RECORD_PMBUS_READ_WORD_EXPECT *) record_to_process);
           break;
+        case RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_EXPECT: // 0x8005
+          successful_parse_of_record_type = recordProcessor___0x8005___processExtendedReadWordExpectOptionalPEC( (t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT *) record_to_process);
+          break;
         case RECORD_TYPE_PMBUS_READ_BLOCK_EXPECT: // 0x06
-          successful_parse_of_record_type = FAILURE; // Unsupported Record Type
+          successful_parse_of_record_type = recordProcessor___0x14___processReadBlockExpectNoPec( (t_RECORD_PMBUS_READ_BLOCK_EXPECT_NOPEC *) record_to_process);
+          break;
+        case RECORD_TYPE_PMBUS_EXTENDED_READ_BLOCK_EXPECT: // 0x8006
+          successful_parse_of_record_type = recordProcessor___0x8006___processExtendedReadBlockExpectOptionalPec( (t_RECORD_PMBUS_EXTENDED_READ_BLOCK_EXPECT *) record_to_process);
           break;
         case RECORD_TYPE_DEVICE_ADDRESS: // 0x07 -- OBSOLETED
           successful_parse_of_record_type = SUCCESS; // Do nothing for this record type, but do not fail
@@ -266,8 +387,14 @@ uint8_t verifyRecordsOnDemand(pRecordHeaderLengthAndType (*getRecord)(void))
         case RECORD_TYPE_PMBUS_READ_BYTE_LOOP_MASK: // 0x0A
           successful_parse_of_record_type = recordProcessor___0x0A___processReadByteLoopMaskOptionalPEC( (t_RECORD_PMBUS_READ_BYTE_LOOP_MASK *) record_to_process);
           break;
+        case RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK: // 0x800A
+          successful_parse_of_record_type = recordProcessor___0x800A___processExtendedReadByteLoopMaskOptionalPEC( (t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK *) record_to_process);
+          break;
         case RECORD_TYPE_PMBUS_READ_WORD_LOOP_MASK: //0x0B
           successful_parse_of_record_type = recordProcessor___0x0B___processReadWordLoopMaskOptionalPEC( (t_RECORD_PMBUS_READ_WORD_LOOP_MASK *) record_to_process);
+          break;
+        case RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_LOOP_MASK: //0x800B
+          successful_parse_of_record_type = recordProcessor___0x800B___processExtendedReadWordLoopMaskOptionalPEC( (t_RECORD_PMBUS_EXTENDED_READ_WORD_LOOP_MASK *) record_to_process);
           break;
         case RECORD_TYPE_PMBUS_POLL_UNTIL_ACK_NOPEC: // 0x0C
           successful_parse_of_record_type = recordProcessor___0x0C___processPollReadByteUntilAckNoPEC( (t_RECORD_PMBUS_POLL_READ_BYTE_UNTIL_ACK *) record_to_process);
@@ -278,38 +405,74 @@ uint8_t verifyRecordsOnDemand(pRecordHeaderLengthAndType (*getRecord)(void))
         case RECORD_TYPE_PMBUS_SEND_BYTE: //0x0E
           successful_parse_of_record_type = recordProcessor___0x0E___processSendByteOptionalPEC( (t_RECORD_PMBUS_SEND_BYTE *) record_to_process);
           break;
+        case RECORD_TYPE_PMBUS_EXTENDED_SEND_BYTE: //0x800E
+          successful_parse_of_record_type = recordProcessor___0x800E___processExtendedSendByteOptionalPEC( (t_RECORD_PMBUS_EXTENDED_SEND_BYTE *) record_to_process);
+          break;
         case RECORD_TYPE_PMBUS_WRITE_BYTE_NOPEC: // 0x0F
           successful_parse_of_record_type = recordProcessor___0x0F___processWriteByteNoPEC( (t_RECORD_PMBUS_WRITE_BYTE_NOPEC *) record_to_process);
+          break;
+        case RECORD_TYPE_PMBUS_EXTENDED_WRITE_BYTE_NOPEC: // 0x800F
+          successful_parse_of_record_type = recordProcessor___0x800F___processExtendedWriteByteNoPEC( (t_RECORD_PMBUS_EXTENDED_WRITE_BYTE_NOPEC *) record_to_process);
           break;
         case RECORD_TYPE_PMBUS_WRITE_WORD_NOPEC: // 0x10
           successful_parse_of_record_type = recordProcessor___0x10___processWriteWordNoPEC( (t_RECORD_PMBUS_WRITE_WORD_NOPEC *) record_to_process);
           break;
+        case RECORD_TYPE_PMBUS_EXTENDED_WRITE_WORD_NOPEC: // 0x8010
+          successful_parse_of_record_type = recordProcessor___0x8010___processExtendedWriteWordNoPEC( (t_RECORD_PMBUS_EXTENDED_WRITE_WORD_NOPEC *) record_to_process);
+          break;
         case RECORD_TYPE_PMBUS_WRITE_BLOCK_NOPEC: // 0x11
-          successful_parse_of_record_type = FAILURE; // Unsupported Record Type
+          successful_parse_of_record_type = recordProcessor___0x11___processWriteBlockNoPEC( (t_RECORD_PMBUS_WRITE_BLOCK_NOPEC *) record_to_process);
+          break;
+        case RECORD_TYPE_PMBUS_EXTENDED_WRITE_BLOCK_NOPEC: // 0x8011
+          successful_parse_of_record_type = recordProcessor___0x8011___processExtendedWriteBlockNoPEC( (t_RECORD_PMBUS_EXTENDED_WRITE_BLOCK_NOPEC *) record_to_process);
           break;
         case RECORD_TYPE_PMBUS_READ_BYTE_EXPECT_NOPEC: // 0x12
           successful_parse_of_record_type = recordProcessor___0x12___processReadByteExpectNoPEC( (t_RECORD_PMBUS_READ_BYTE_EXPECT_NOPEC *) record_to_process);
           break;
+        case RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_EXPECT_NOPEC: // 0x8012
+          successful_parse_of_record_type = recordProcessor___0x8012___processExtendedReadByteExpectNoPEC( (t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_NOPEC *) record_to_process);
+          break;
         case RECORD_TYPE_PMBUS_READ_WORD_EXPECT_NOPEC: // 0x13
           successful_parse_of_record_type = recordProcessor___0x13___processReadWordExpectNoPEC( (t_RECORD_PMBUS_READ_WORD_EXPECT_NOPEC *) record_to_process);
           break;
+        case RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_EXPECT_NOPEC: // 0x8013
+          successful_parse_of_record_type = recordProcessor___0x8013___processExtendedReadWordExpectNoPEC( (t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT_NOPEC *) record_to_process);
+          break;
         case RECORD_TYPE_PMBUS_READ_BLOCK_EXPECT_NOPEC: // 0x14
-          successful_parse_of_record_type = FAILURE; // Unsupported Record Type
+          successful_parse_of_record_type = recordProcessor___0x14___processReadBlockExpectNoPec( (t_RECORD_PMBUS_READ_BLOCK_EXPECT_NOPEC *) record_to_process);
+          break;
+        case RECORD_TYPE_PMBUS_EXTENDED_READ_BLOCK_EXPECT_NOPEC: // 0x8014
+          successful_parse_of_record_type = recordProcessor___0x8014___processExtendedReadBlockExpectNoPec( (t_RECORD_PMBUS_EXTENDED_READ_BLOCK_EXPECT_NOPEC *) record_to_process);
           break;
         case RECORD_TYPE_PMBUS_READ_BYTE_LOOP_MASK_NOPEC: // 0x15
           successful_parse_of_record_type = recordProcessor___0x15___processReadByteLoopMaskNoPEC( (t_RECORD_PMBUS_READ_BYTE_LOOP_MASK_NOPEC *) record_to_process);
           break;
+        case RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK_NOPEC: // 0x8015
+          successful_parse_of_record_type = recordProcessor___0x8015___processExtendedReadByteLoopMaskNoPEC( (t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK_NOPEC *) record_to_process);
+          break;
         case RECORD_TYPE_PMBUS_READ_WORD_LOOP_MASK_NOPEC: // 0x16
           successful_parse_of_record_type = recordProcessor___0x16___processReadWordLoopMaskNoPEC( (t_RECORD_PMBUS_READ_WORD_LOOP_MASK_NOPEC *) record_to_process);
+          break;
+        case RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_LOOP_MASK_NOPEC: // 0x8016
+          successful_parse_of_record_type = recordProcessor___0x8016___processExtendedReadWordLoopMaskNoPEC( (t_RECORD_PMBUS_EXTENDED_READ_WORD_LOOP_MASK_NOPEC *) record_to_process);
           break;
         case RECORD_TYPE_PMBUS_SEND_BYTE_NOPEC: // 0x17
           successful_parse_of_record_type = recordProcessor___0x17___processSendByteNoPEC( (t_RECORD_PMBUS_SEND_BYTE_NOPEC *) record_to_process);
           break;
+        case RECORD_TYPE_PMBUS_EXTENDED_SEND_BYTE_NOPEC: // 0x8017
+          successful_parse_of_record_type = recordProcessor___0x8017___processExtendedSendByteNoPEC( (t_RECORD_PMBUS_EXTENDED_SEND_BYTE_NOPEC *) record_to_process);
+          break;
         case RECORD_TYPE_PMBUS_READ_BYTE_EXPECT_MASK_NOPEC: // 0x19
           successful_parse_of_record_type = recordProcessor___0x19___processReadByteExpectMaskNoPEC( (t_RECORD_PMBUS_READ_BYTE_EXPECT_MASK_NOPEC *) record_to_process);
           break;
+        case RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_EXPECT_MASK_NOPEC: // 0x8019
+          successful_parse_of_record_type = recordProcessor___0x8019___processExtendedReadByteExpectMaskNoPEC( (t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_MASK_NOPEC *) record_to_process);
+          break;
         case RECORD_TYPE_PMBUS_READ_WORD_EXPECT_MASK_NOPEC: //0x1A
           successful_parse_of_record_type = recordProcessor___0x1A___processReadWordExpectMaskNoPEC( (t_RECORD_PMBUS_READ_WORD_EXPECT_MASK_NOPEC *) record_to_process);
+          break;
+        case RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_EXPECT_MASK_NOPEC: //0x801A
+          successful_parse_of_record_type = recordProcessor___0x801A___processExtendedReadWordExpectMaskNoPEC( (t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT_MASK_NOPEC *) record_to_process);
           break;
         case RECORD_TYPE_VARIABLE_META_DATA: // 0x1B
           successful_parse_of_record_type = recordProcessor___0x1B___processVariableMetaData( (t_RECORD_VARIABLE_META_DATA *) record_to_process);
@@ -317,8 +480,14 @@ uint8_t verifyRecordsOnDemand(pRecordHeaderLengthAndType (*getRecord)(void))
         case RECORD_TYPE_MODIFY_WORD_NOPEC: // 0x1C
           successful_parse_of_record_type = recordProcessor___0x1C___modifyWordNoPEC( (t_RECORD_PMBUS_MODIFY_WORD_NO_PEC *) record_to_process);
           break;
+        case RECORD_TYPE_EXTENDED_MODIFY_WORD_NOPEC: // 0x801C
+          successful_parse_of_record_type = recordProcessor___0x801C___extendedModifyWordNoPEC( (t_RECORD_PMBUS_EXTENDED_MODIFY_WORD_NO_PEC *) record_to_process);
+          break;
         case RECORD_TYPE_MODIFY_BYTE_NOPEC: // 0x1D
           successful_parse_of_record_type = recordProcessor___0x1D___modifyByteNoPEC( (t_RECORD_PMBUS_MODIFY_BYTE_NO_PEC *) record_to_process);
+          break;
+        case RECORD_TYPE_EXTENDED_MODIFY_BYTE_NOPEC: // 0x801D
+          successful_parse_of_record_type = recordProcessor___0x801D___extendedModifyByteNoPEC( (t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE_NO_PEC *) record_to_process);
           break;
         case RECORD_TYPE_PMBUS_WRITE_EE_DATA: // 0x1E
           //successful_parse_of_record_type = recordProcessor___0x1E___writeNvmData( (t_RECORD_NVM_DATA *) record_to_process);
@@ -330,8 +499,14 @@ uint8_t verifyRecordsOnDemand(pRecordHeaderLengthAndType (*getRecord)(void))
         case RECORD_TYPE_PMBUS_MODIFY_BYTE: // 0x20
           successful_parse_of_record_type = recordProcessor___0x20___modifyByteOptionalPEC( (t_RECORD_PMBUS_MODIFY_BYTE *) record_to_process);
           break;
+        case RECORD_TYPE_PMBUS_EXTENDED_MODIFY_BYTE: // 0x8020
+          successful_parse_of_record_type = recordProcessor___0x8020___extendedModifyByteOptionalPEC( (t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE *) record_to_process);
+          break;
         case RECORD_TYPE_PMBUS_MODIFY_WORD: // 0x21
           successful_parse_of_record_type = recordProcessor___0x21___modifyWordOptionalPEC( (t_RECORD_PMBUS_MODIFY_WORD *) record_to_process);
+          break;
+        case RECORD_TYPE_PMBUS_EXTENDED_MODIFY_WORD: // 0x8021
+          successful_parse_of_record_type = recordProcessor___0x8021___extendedModifyWordOptionalPEC( (t_RECORD_PMBUS_EXTENDED_MODIFY_WORD *) record_to_process);
           break;
         default:
           successful_parse_of_record_type = FAILURE; // Unknown Instruction, report a failure
@@ -366,7 +541,7 @@ uint8_t verifyRecordsOnDemand(pRecordHeaderLengthAndType (*getRecord)(void))
  *******************************************************************/
 uint8_t recordProcessor___0x01___processWriteByteOptionalPEC(t_RECORD_PMBUS_WRITE_BYTE *pRecord)
 {
-#if DEBUG_SILENT == 1
+#if DEBUG_SILENT == 10
   return SUCCESS;
 #else
 #if DEBUG_PROCESSING == 1
@@ -395,6 +570,64 @@ uint8_t recordProcessor___0x01___processWriteByteOptionalPEC(t_RECORD_PMBUS_WRIT
     smbusNoPec__->writeByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
                             pRecord->detailedRecordHeader.CommandCode,
                             pRecord->dataByte);
+#endif
+#endif
+  return SUCCESS;
+}
+
+/********************************************************************
+ * Function:        uint8_t recordProcessor___0x8001___processExtendedWriteByteOptionalPEC(t_RECORD_PMBUS_EXTENDED_WRITE_BYTE*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_WRITE_BYTE pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_WRITE_BYTE record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x8001___processExtendedWriteByteOptionalPEC(t_RECORD_PMBUS_EXTENDED_WRITE_BYTE *pRecord)
+{
+#if DEBUG_SILENT == 1
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING == 1
+  Serial.print(F("ExtendedWriteByteOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->dataByte, HEX);
+#else
+#if DEBUG_PRINT == 1
+  Serial.print(F("ExtendedWriteByteOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(" ");
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->dataByte, HEX);
+#endif
+
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      smbusPec__->extendedWriteByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode,
+                            pRecord->dataByte);
+    else
+      smbusNoPec__->extendedWriteByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                              pRecord->detailedRecordHeader.CommandCode,
+                              pRecord->dataByte);
+  }
+  else
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      smbusPec__->writeByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                            pRecord->dataByte);
+    else
+      smbusNoPec__->writeByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                              pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                              pRecord->dataByte);
+  }
 #endif
 #endif
   return SUCCESS;
@@ -444,12 +677,179 @@ uint8_t recordProcessor___0x02___processWriteWordOptionalPEC(t_RECORD_PMBUS_WRIT
 }
 
 /********************************************************************
- * Function:        uint8_t recordProcessor___0x04___processReadByteExpectOptionalPEC(t_RECORD_smbus_read_byte_EXPECT*);
+ * Function:        uint8_t recordProcessor___0x8002___processExtendedWriteWordOptionalPEC(t_RECORD_PMBUS_EXTENDED_WRITE_WORD*);
  *
  * PreCondition:    None
- * Input:           A t_RECORD_smbus_read_byte_EXPECT pointer reference
+ * Input:           A t_RECORD_PMBUS_EXTENDED_WRITE_WORD pointer reference
  * Output:          A 1 is returned on success and a 0 is returned on failure
- * Overview:        Processes the t_RECORD_smbus_read_byte_EXPECT record type
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_WRITE_WORD record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x8002___processExtendedWriteWordOptionalPEC(t_RECORD_PMBUS_EXTENDED_WRITE_WORD *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("WriteWordOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->dataWord, HEX);
+#else
+#if DEBUG_PRINT
+  Serial.print(F("WriteWordOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->dataWord, HEX);
+#endif
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      smbusPec__->extendedWriteWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode,
+                            pRecord->dataWord);
+    else
+      smbusNoPec__->extendedWriteWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                              pRecord->detailedRecordHeader.CommandCode,
+                              pRecord->dataWord);
+  }
+  else
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      smbusPec__->writeWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                            pRecord->dataWord);
+    else
+      smbusNoPec__->writeWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                              pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                              pRecord->dataWord);
+  }
+#endif
+#endif
+  return SUCCESS;
+}
+
+uint8_t recordProcessor___0x03___processWriteBlockOptionalPEC(t_RECORD_PMBUS_WRITE_BLOCK *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("processWriteBlockOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+
+  uint8_t nBytes = (uint8_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *bytes = (uint8_t *) ((uint8_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+
+  for (int i = 0; i < nBytes; i++)
+    Serial.println(bytes[i], HEX); // Change (UINT16) to the size of an address on the target machine.
+
+  return SUCCESS;
+#else
+#if DEBUG_PRINT
+  Serial.print(F("processWriteBlockOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+#endif
+  uint8_t count = (uint8_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *data = (uint8_t *) ((uint16_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+  if (pRecord->detailedRecordHeader.UsePec)
+    smbusPec__->writeBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                          pRecord->detailedRecordHeader.CommandCode,
+                          data,
+                          count);
+  else
+    smbusNoPec__->writeBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode,
+                            data,
+                            count);
+#endif
+#endif
+  return SUCCESS;
+}
+
+uint8_t recordProcessor___0x8003___processExtendedWriteBlockOptionalPEC(t_RECORD_PMBUS_EXTENDED_WRITE_BLOCK *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("processExtendedWriteBlockOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+
+  uint8_t nBytes = (uint8_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *bytes = (uint8_t *) ((uint16_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+
+  for (int i = 0; i < nBytes; i++)
+    Serial.println(bytes[i], HEX); // Change (UINT16) to the size of an address on the target machine.
+
+  return SUCCESS;
+#else
+#if DEBUG_PRINT
+  Serial.print(F("processExtendedWriteBlockOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+#endif
+  uint8_t count = (uint8_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *data = (uint8_t *) ((uint8_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      smbusPec__->extendedWriteBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode,
+                            data,
+                            count);
+    else
+      smbusNoPec__->extendedWriteBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                              pRecord->detailedRecordHeader.CommandCode,
+                              data,
+                              count);
+  }
+  else
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      smbusPec__->writeBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                            data,
+                            count);
+    else
+      smbusNoPec__->writeBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                              pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                              data,
+                              count); 
+  }
+#endif
+#endif
+  return SUCCESS;
+}
+
+
+/********************************************************************
+ * Function:        uint8_t recordProcessor___0x04___processReadByteExpectOptionalPEC(t_RECORD_PMBUS_READ_BYTE_EXPECT*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_READ_BYTE_EXPECT pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_READ_BYTE_EXPECT record type
  * Note:            More detailed information may be available in the PDF
  *******************************************************************/
 uint8_t recordProcessor___0x04___processReadByteExpectOptionalPEC(t_RECORD_PMBUS_READ_BYTE_EXPECT *pRecord)
@@ -474,6 +874,64 @@ uint8_t recordProcessor___0x04___processReadByteExpectOptionalPEC(t_RECORD_PMBUS
 
 #if DEBUG_PRINT
   Serial.print(F("ReadByteExpectOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.print(actualByteValue, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->expectedDataByte, HEX);
+#endif
+
+  return (actualByteValue != pRecord->expectedDataByte) ? FAILURE : SUCCESS;
+#endif
+#endif
+}
+
+/********************************************************************
+ * Function:        uint8_t recordProcessor___0x8004___processExtendedReadByteExpectOptionalPEC(t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x8004___processExtendedReadByteExpectOptionalPEC(t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedReadByteExpectOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->detailedRecordHeader.CommandCode, HEX);
+  return SUCCESS;
+#else
+  uint8_t actualByteValue;
+
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      actualByteValue = smbusPec__->extendedReadByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                                             pRecord->detailedRecordHeader.CommandCode);
+    else
+      actualByteValue = smbusNoPec__->extendedReadByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                        pRecord->detailedRecordHeader.CommandCode);
+  }
+  else
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      actualByteValue = smbusPec__->readByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                                             pRecord->detailedRecordHeader.CommandCode & 0xFF);
+    else
+      actualByteValue = smbusNoPec__->readByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                        pRecord->detailedRecordHeader.CommandCode & 0xFF);    
+  }
+
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedReadByteExpectOptionalPEC "));
   Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
   Serial.print(F(" "));
   Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
@@ -534,6 +992,191 @@ uint8_t recordProcessor___0x05___processReadWordExpectOptionalPEC(t_RECORD_PMBUS
 }
 
 /********************************************************************
+ * Function:        uint8_t recordProcessor___0x8005___processExtendedReadWordExpectOptionalPEC(t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x8005___processExtendedReadWordExpectOptionalPEC(t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedReadWordExpectOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->detailedRecordHeader.CommandCode, HEX);
+  return SUCCESS;
+#else
+  uint16_t actualWordValue;
+
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      actualWordValue = smbusPec__->extendedReadWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                                             pRecord->detailedRecordHeader.CommandCode);
+    else
+      actualWordValue = smbusNoPec__->extendedReadWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                        pRecord->detailedRecordHeader.CommandCode);
+  }
+  else
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      actualWordValue = smbusPec__->readWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                                             pRecord->detailedRecordHeader.CommandCode & 0xFF);
+    else
+      actualWordValue = smbusNoPec__->readWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                        pRecord->detailedRecordHeader.CommandCode & 0xFF);    
+  }
+
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedReadWordExpectOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.print(actualWordValue, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->expectedDataWord, HEX);
+#endif
+
+  return (actualWordValue != pRecord->expectedDataWord) ? FAILURE : SUCCESS;
+#endif
+#endif
+}
+
+uint8_t recordProcessor___0x06___processReadBlockExpectOptionalPec(t_RECORD_PMBUS_READ_BLOCK_EXPECT *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ReadBlockExpectOptionalPec "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+
+  uint16_t nBytes = (uint16_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *bytes = (uint8_t *) ((uint8_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+
+  for (int i = 0; i < nBytes; i++)
+    Serial.println(bytes[i], HEX); // Change (UINT16) to the size of an address on the target machine.
+
+  return SUCCESS;
+#else
+#if DEBUG_PRINT
+  Serial.print(F("ReadBlockExpectOptionalPec "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+#endif
+  uint16_t count = (uint16_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *bytes = (uint8_t *) ((uint8_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+  uint8_t *data = (uint8_t *) malloc(count); // Change (UINT16) to the size of an address on the target machine.
+  uint8_t ret = SUCCESS;
+
+  if (pRecord->detailedRecordHeader.UsePec)
+    smbusPec__->readBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                          pRecord->detailedRecordHeader.CommandCode,
+                          data,
+                          count);
+  else
+    smbusNoPec__->readBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode,
+                            data,
+                            count); 
+
+  for (int i = 0; i < count; i++)
+    if (bytes[i] != data[i])
+    {
+      ret = FAILURE;
+    }
+  delete data;
+  return ret;
+#endif
+#endif
+}
+
+uint8_t recordProcessor___0x8006___processExtendedReadBlockExpectOptionalPec(t_RECORD_PMBUS_EXTENDED_READ_BLOCK_EXPECT *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedReadBlockExpectOptionalPec "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+
+  uint16_t nBytes = (uint16_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *bytes = (uint8_t *) ((uint8_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+
+  for (int i = 0; i < nBytes; i++)
+    Serial.println(bytes[i], HEX); // Change (UINT16) to the size of an address on the target machine.
+
+  return SUCCESS;
+#else
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedReadBlockExpectOptionalPec "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+#endif
+  uint16_t count = (uint16_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *bytes = (uint8_t *) ((uint8_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+  uint8_t *data = (uint8_t *) malloc(count); // Change (UINT16) to the size of an address on the target machine.
+  uint8_t ret = SUCCESS;
+
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      smbusPec__->extendedReadBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode,
+                            data,
+                            count);
+    else
+      smbusNoPec__->extendedReadBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                              pRecord->detailedRecordHeader.CommandCode,
+                              data,
+                              count);
+  }
+  else
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      smbusPec__->readBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                            data,
+                            count);
+    else
+      smbusNoPec__->readBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                              pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                              data,
+                              count); 
+  }
+  for (int i = 0; i < count; i++)
+    if (bytes[i] != data[i])
+    {
+      ret = FAILURE;
+    }
+  delete data;
+  return ret;
+#endif
+#endif
+}
+
+/********************************************************************
  * Function:        uint8_t recordProcessor___0x09___bufferNVMData(t_RECORD_NVM_DATA*);
  *
  * PreCondition:    None
@@ -576,12 +1219,12 @@ uint8_t recordProcessor___0x09___bufferNVMData(t_RECORD_NVM_DATA *pRecord)
 }
 
 /********************************************************************
- * Function:        uint8_t recordProcessor___0x0A___processReadByteLoopMaskOptionalPEC(t_RECORD_smbus_read_byte_LOOP_MASK*);
+ * Function:        uint8_t recordProcessor___0x0A___processReadByteLoopMaskOptionalPEC(t_RECORD_PMBUS_READ_BYTE_LOOP_MASK*);
  *
  * PreCondition:    None
- * Input:           A t_RECORD_smbus_read_byte_LOOP_MASK pointer reference
+ * Input:           A t_RECORD_PMBUS_READ_BYTE_LOOP_MASK pointer reference
  * Output:          A 1 is returned on success and a 0 is returned on failure
- * Overview:        Processes the t_RECORD_smbus_read_byte_LOOP_MASK record type
+ * Overview:        Processes the t_RECORD_PMBUS_READ_BYTE_LOOP_MASK record type
  * Note:            More detailed information may be available in the PDF
  *******************************************************************/
 uint8_t recordProcessor___0x0A___processReadByteLoopMaskOptionalPEC(t_RECORD_PMBUS_READ_BYTE_LOOP_MASK *pRecord)
@@ -615,6 +1258,77 @@ uint8_t recordProcessor___0x0A___processReadByteLoopMaskOptionalPEC(t_RECORD_PMB
     success = (actualByteValueWithMask == expectedByteValueWithMask);
 #if DEBUG_PRINT
     Serial.print(F("ReadByteLoopMaskOptionalPEC "));
+    Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+    Serial.print(F(" "));
+    Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+    Serial.print(F(" "));
+    Serial.print(pRecord->byteMask, HEX);
+    Serial.print(F(" "));
+    Serial.print(actualByteValueWithMask, HEX);
+    Serial.print(F(" "));
+    Serial.println(expectedByteValueWithMask, HEX);
+#endif
+  }
+  while (success == FAILURE);
+#endif
+#endif
+
+  return SUCCESS;
+
+}
+
+/********************************************************************
+ * Function:        uint8_t recordProcessor___0x800A___processExtendedReadByteLoopMaskOptionalPEC(t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x800A___processExtendedReadByteLoopMaskOptionalPEC(t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedReadByteLoopMaskOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->byteMask, HEX);
+#else
+  uint8_t actualByteValue;
+  uint8_t actualByteValueWithMask;
+  uint8_t expectedByteValueWithMask;
+  uint8_t success = FAILURE;
+  do
+  {
+    if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+    {
+      if (pRecord->detailedRecordHeader.UsePec)
+        actualByteValue = smbusPec__->extendedReadByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                                               pRecord->detailedRecordHeader.CommandCode);
+      else
+        actualByteValue = smbusNoPec__->extendedReadByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                          pRecord->detailedRecordHeader.CommandCode);
+    }
+    else
+    {
+      if (pRecord->detailedRecordHeader.UsePec)
+        actualByteValue = smbusPec__->readByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                                               pRecord->detailedRecordHeader.CommandCode & 0xFF);
+      else
+        actualByteValue = smbusNoPec__->readByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                          pRecord->detailedRecordHeader.CommandCode & 0xFF);      
+    }
+
+    actualByteValueWithMask = (actualByteValue & pRecord->byteMask);
+    expectedByteValueWithMask = (pRecord->expectedDataByte & pRecord->byteMask);
+    success = (actualByteValueWithMask == expectedByteValueWithMask);
+#if DEBUG_PRINT
+    Serial.print(F("ExtendedReadByteLoopMaskOptionalPEC "));
     Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
     Serial.print(F(" "));
     Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
@@ -674,6 +1388,75 @@ uint8_t recordProcessor___0x0B___processReadWordLoopMaskOptionalPEC(t_RECORD_PMB
     success = (actualWordValueWithMask == expectedWordValueWithMask);
 #if DEBUG_PRINT
     Serial.print(F("WriteWordLoopMaskOptionalPEC "));
+    Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+    Serial.print(F(" "));
+    Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+    Serial.print(F(" "));
+    Serial.print(pRecord->wordMask, HEX);
+    Serial.print(F(" "));
+    Serial.print(actualWordValueWithMask, HEX);
+    Serial.print(F(" "));
+    Serial.println(expectedWordValueWithMask, HEX);
+#endif
+  }
+  while (success == FAILURE);
+#endif
+#endif
+  return SUCCESS;
+}
+
+/********************************************************************
+ * Function:        uint8_t recordProcessor___0x800B___processExtendedReadWordLoopMaskOptionalPEC(t_RECORD_PMBUS_EXTENDED_READ_WORD_LOOP_MASK*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_READ_EXTENDED_WORD_LOOP_MASK pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_READ_WORD_LOOP_MASK record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x800B___processExtendedReadWordLoopMaskOptionalPEC(t_RECORD_PMBUS_EXTENDED_READ_WORD_LOOP_MASK *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedWriteWordLoopMaskOptionalPEC %x "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->wordMask, HEX);
+#else
+  uint16_t actualWordValue;
+  uint16_t actualWordValueWithMask;
+  uint16_t expectedWordValueWithMask;
+  uint8_t success = FAILURE;
+  do
+  {
+    if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+    {
+      if (pRecord->detailedRecordHeader.UsePec)
+        actualWordValue = smbusPec__->extendedReadWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                                               pRecord->detailedRecordHeader.CommandCode);
+      else
+        actualWordValue = smbusNoPec__->extendedReadWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                          pRecord->detailedRecordHeader.CommandCode);
+    }
+    else
+    {
+      if (pRecord->detailedRecordHeader.UsePec)
+        actualWordValue = smbusPec__->readWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                                               pRecord->detailedRecordHeader.CommandCode & 0xFF);
+      else
+        actualWordValue = smbusNoPec__->readWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                          pRecord->detailedRecordHeader.CommandCode & 0xFF);
+    }
+
+    actualWordValueWithMask = (actualWordValue & pRecord->wordMask);
+    expectedWordValueWithMask = (pRecord->expectedDataWord & pRecord->wordMask);
+    success = (actualWordValueWithMask == expectedWordValueWithMask);
+#if DEBUG_PRINT
+    Serial.print(F("ExtendedWriteWordLoopMaskOptionalPEC "));
     Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
     Serial.print(F(" "));
     Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
@@ -808,6 +1591,55 @@ uint8_t recordProcessor___0x0E___processSendByteOptionalPEC(t_RECORD_PMBUS_SEND_
 }
 
 /********************************************************************
+ * Function:        uint8_t recordProcessor___0x800E___processExtendedSendByteOptionalPEC(t_RECORD_PMBUS_EXTENDED_SEND_BYTE*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_SEND_BYTE pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_SEND_BYTE record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x800E___processExtendedSendByteOptionalPEC(t_RECORD_PMBUS_EXTENDED_SEND_BYTE *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedSendByteOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->detailedRecordHeader.CommandCode, HEX);
+#else
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedSendByteOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->detailedRecordHeader.CommandCode, HEX);
+#endif
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      smbusPec__->extendedSendByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                           pRecord->detailedRecordHeader.CommandCode);
+    else
+      smbusNoPec__->extendedSendByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                             pRecord->detailedRecordHeader.CommandCode);
+    }
+    else
+    {
+    if (pRecord->detailedRecordHeader.UsePec)
+      smbusPec__->sendByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                           pRecord->detailedRecordHeader.CommandCode & 0xFF);
+    else
+      smbusNoPec__->sendByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                             pRecord->detailedRecordHeader.CommandCode & 0xFF);      
+    }
+#endif
+#endif
+  return SUCCESS;
+}
+
+/********************************************************************
  * Function:        uint8_t recordProcessor___0x0F___processWriteByteNoPEC(t_RECORD_PMBUS_WRITE_BYTE_NOPEC*);
  *
  * PreCondition:    None
@@ -841,6 +1673,50 @@ uint8_t recordProcessor___0x0F___processWriteByteNoPEC(t_RECORD_PMBUS_WRITE_BYTE
                           pRecord->detailedRecordHeader.CommandCode,
                           pRecord->dataByte);
 #endif
+#endif
+  return SUCCESS;
+}
+
+/********************************************************************
+ * Function:        uint8_t recordProcessor___0x800F___processExtendedWriteByteNoPEC(t_RECORD_PMBUS_EXTENDED_WRITE_BYTE_NOPEC*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_WRITE_BYTE_NOPEC pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_WRITE_BYTE_NOPEC record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x800F___processExtendedWriteByteNoPEC(t_RECORD_PMBUS_EXTENDED_WRITE_BYTE_NOPEC *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedWriteByteNoPec "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->dataByte, HEX);
+#else
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedWriteByteNoPec %x "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->dataByte, HEX);
+#endif
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+    smbusNoPec__->extendedWriteByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode,
+                            pRecord->dataByte);
+  else
+    smbusNoPec__->writeByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                            pRecord->dataByte);
+
+  #endif
 #endif
   return SUCCESS;
 }
@@ -884,12 +1760,148 @@ uint8_t recordProcessor___0x10___processWriteWordNoPEC(t_RECORD_PMBUS_WRITE_WORD
 }
 
 /********************************************************************
- * Function:        uint8_t recordProcessor___0x12___processReadByteExpectNoPEC(t_RECORD_smbus_read_byte_EXPECT_NOPEC*);
+ * Function:        uint8_t recordProcessor___0x8010___processExtendedWriteWordNoPEC(t_RECORD_PMBUS_EXTENDED_WRITE_WORD_NOPEC*);
  *
  * PreCondition:    None
- * Input:           A t_RECORD_smbus_read_byte_EXPECT_NOPEC pointer reference
+ * Input:           A t_RECORD_PMBUS_EXTENDED_WRITE_WORD_NOPEC pointer reference
  * Output:          A 1 is returned on success and a 0 is returned on failure
- * Overview:        Processes the t_RECORD_smbus_read_byte_EXPECT_NOPEC record type
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_WRITE_WORD_NOPEC record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x8010___processExtendedWriteWordNoPEC(t_RECORD_PMBUS_EXTENDED_WRITE_WORD_NOPEC *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedWriteWordNoPec "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->dataWord, HEX);
+#else
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedWriteWordNoPec %x "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->dataWord, HEX);
+#endif
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+    smbusNoPec__->extendedWriteWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode,
+                            pRecord->dataWord);
+  else
+    smbusNoPec__->writeWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                            pRecord->dataWord);
+
+#endif
+#endif
+  return SUCCESS;
+}
+
+uint8_t recordProcessor___0x11___processWriteBlockNoPEC(t_RECORD_PMBUS_WRITE_BLOCK_NOPEC *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("WriteBlockNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+
+  uint8_t nBytes = (uint8_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *bytes = (uint8_t *) ((uint8_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+
+  for (int i = 0; i < nBytes; i++)
+    Serial.println(bytes[i], HEX); // Change (UINT16) to the size of an address on the target machine.
+
+  return SUCCESS;
+#else
+#if DEBUG_PRINT
+  Serial.print(F("WriteBlockNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+#endif
+  uint8_t count = (uint8_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *data = (uint8_t *) ((uint8_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+
+  smbusNoPec__->writeBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                          pRecord->detailedRecordHeader.CommandCode,
+                          data,
+                          count);
+#endif
+#endif
+  return SUCCESS;
+}
+
+uint8_t recordProcessor___0x8011___processExtendedWriteBlockNoPEC(t_RECORD_PMBUS_EXTENDED_WRITE_BLOCK_NOPEC *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedWriteBlockNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+
+  uint8_t nBytes = (uint8_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *bytes = (uint8_t *) ((uint8_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+
+  for (int i = 0; i < nBytes; i++)
+    Serial.println(bytes[i], HEX); // Change (UINT16) to the size of an address on the target machine.
+
+  return SUCCESS;
+#else
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedWriteBlockNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+#endif
+  uint8_t count = (uint8_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *data = (uint8_t *) ((uint8_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+  {
+    smbusNoPec__->extendedWriteBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode,
+                            data,
+                            count);
+  }
+  else
+  {
+    smbusNoPec__->writeBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                            data,
+                            count); 
+  }
+#endif
+#endif
+  return SUCCESS;
+}
+
+/********************************************************************
+ * Function:        uint8_t recordProcessor___0x12___processReadByteExpectNoPEC(t_RECORD_PMBUS_READ_BYTE_EXPECT_NOPEC*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_READ_BYTE_EXPECT_NOPEC pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_READ_BYTE_EXPECT_NOPEC record type
  * Note:            More detailed information may be available in the PDF
  *******************************************************************/
 uint8_t recordProcessor___0x12___processReadByteExpectNoPEC(t_RECORD_PMBUS_READ_BYTE_EXPECT_NOPEC *pRecord)
@@ -909,6 +1921,50 @@ uint8_t recordProcessor___0x12___processReadByteExpectNoPEC(t_RECORD_PMBUS_READ_
                     pRecord->detailedRecordHeader.CommandCode);
 #if DEBUG_PRINT
   Serial.print(F("ReadByteExpectNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.print(actualByteValue, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->expectedDataByte, HEX);
+#endif
+  return (actualByteValue != pRecord->expectedDataByte) ? FAILURE : SUCCESS;
+#endif
+#endif
+}
+
+/********************************************************************
+ * Function:        uint8_t recordProcessor___0x8012___processExtendedReadByteExpectNoPEC(t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_NOPEC*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_NOPEC pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_NOPEC record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x8012___processExtendedReadByteExpectNoPEC(t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_NOPEC *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedReadByteExpectNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->detailedRecordHeader.CommandCode, HEX);
+  return SUCCESS;
+#else
+  uint8_t actualByteValue;
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+    actualByteValue = smbusNoPec__->extendedReadByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                      pRecord->detailedRecordHeader.CommandCode);
+  else
+    actualByteValue = smbusNoPec__->readByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                      pRecord->detailedRecordHeader.CommandCode & 0xFF);
+
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedReadByteExpectNoPEC "));
   Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
   Serial.print(F(" "));
   Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
@@ -963,12 +2019,165 @@ uint8_t recordProcessor___0x13___processReadWordExpectNoPEC(t_RECORD_PMBUS_READ_
 }
 
 /********************************************************************
- * Function:        uint8_t recordProcessor___0x15___processReadByteLoopMaskNoPEC(t_RECORD_smbus_read_byte_LOOP_MASK_NOPEC*);
+ * Function:        uint8_t recordProcessor___0x8013___processExtendedReadWordExpectNoPEC(t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT_NOPEC*);
  *
  * PreCondition:    None
- * Input:           A t_RECORD_smbus_read_byte_LOOP_MASK_NOPEC pointer reference
+ * Input:           A t_RECORD_PMBUS_READ_EXTENDED_WORD_EXPECT_NOPEC pointer reference
  * Output:          A 1 is returned on success and a 0 is returned on failure
- * Overview:        Processes the t_RECORD_smbus_read_byte_LOOP_MASK_NOPEC record type
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT_NOPEC record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x8013___processExtendedReadWordExpectNoPEC(t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT_NOPEC *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedReadWordEx[ectNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->detailedRecordHeader.CommandCode, HEX);
+  return SUCCESS;
+#else
+  uint16_t actualWordValue;
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+    actualWordValue = smbusNoPec__->extendedReadWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                      pRecord->detailedRecordHeader.CommandCode);
+  else
+    actualWordValue = smbusNoPec__->readWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                      pRecord->detailedRecordHeader.CommandCode & 0xFF);
+
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedReadWordExpectNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.print(actualWordValue, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->expectedDataWord, HEX);
+#endif
+  return (actualWordValue != pRecord->expectedDataWord) ? FAILURE : SUCCESS;
+#endif
+#endif
+}
+
+uint8_t recordProcessor___0x14___processReadBlockExpectNoPec(t_RECORD_PMBUS_READ_BLOCK_EXPECT_NOPEC *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ReadBlockExpectNoPec "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+
+  uint16_t nBytes = (uint16_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *bytes = (uint8_t *) ((uint8_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+
+  for (int i = 0; i < nBytes; i++)
+    Serial.println(bytes[i], HEX); // Change (UINT16) to the size of an address on the target machine.
+
+  return SUCCESS;
+#else
+#if DEBUG_PRINT
+  Serial.print(F("ReadBlockExpectNoPec "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+#endif
+  uint16_t count = (uint16_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *bytes = (uint8_t *) ((uint8_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+  uint8_t *data = (uint8_t *) malloc(count); // Change (UINT16) to the size of an address on the target machine.
+  uint8_t ret = SUCCESS;
+
+  smbusNoPec__->readBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                          pRecord->detailedRecordHeader.CommandCode,
+                          data,
+                          count); 
+
+  for (int i = 0; i < count; i++)
+    if (bytes[i] != data[i])
+    {
+      ret = FAILURE;
+    }
+  delete data;
+  return ret;
+#endif
+#endif
+}
+
+uint8_t recordProcessor___0x8014___processExtendedReadBlockExpectNoPec(t_RECORD_PMBUS_EXTENDED_READ_BLOCK_EXPECT_NOPEC *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedReadBlockExpectNoPec "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+
+  uint16_t nBytes = (uint16_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *bytes = (uint8_t *) ((uint8_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+
+  for (int i = 0; i < nBytes; i++)
+    Serial.println(bytes[i], HEX); // Change (UINT16) to the size of an address on the target machine.
+
+  return SUCCESS;
+#else
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedReadBlockExpectNoPec "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->baseRecordHeader.Length, HEX);
+#endif
+  uint16_t count = (uint16_t)((pRecord->baseRecordHeader.Length-8));
+  uint8_t *bytes = (uint8_t *) ((uint8_t)pRecord+8); // Change (UINT16) to the size of an address on the target machine.
+  uint8_t *data = (uint8_t *) malloc(count); // Change (UINT16) to the size of an address on the target machine.
+  uint8_t ret = SUCCESS;
+
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+  {
+    smbusNoPec__->extendedReadBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode,
+                            data,
+                            count);
+  }
+  else
+  {
+    smbusNoPec__->readBlock((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                            data,
+                            count); 
+  }
+  for (int i = 0; i < count; i++)
+    if (bytes[i] != data[i])
+    {
+      ret = FAILURE;
+    }
+  delete data;
+  return ret;
+#endif
+#endif
+}
+
+/********************************************************************
+ * Function:        uint8_t recordProcessor___0x15___processReadByteLoopMaskNoPEC(t_RECORD_PMBUS_READ_BYTE_LOOP_MASK_NOPEC*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_READ_BYTE_LOOP_MASK_NOPEC pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_READ_BYTE_LOOP_MASK_NOPEC record type
  * Note:            More detailed information may be available in the PDF
  *******************************************************************/
 uint8_t recordProcessor___0x15___processReadByteLoopMaskNoPEC(t_RECORD_PMBUS_READ_BYTE_LOOP_MASK_NOPEC *pRecord)
@@ -998,6 +2207,63 @@ uint8_t recordProcessor___0x15___processReadByteLoopMaskNoPEC(t_RECORD_PMBUS_REA
     success = (actualByteValueWithMask == expectedByteValueWithMask);
 #if DEBUG_PRINT
     Serial.print(F("ReadByteLoopMaskNoPEC "));
+    Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+    Serial.print(F(" "));
+    Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+    Serial.print(F(" "));
+    Serial.print(pRecord->byteMask, HEX);
+    Serial.print(F(" "));
+    Serial.print(actualByteValueWithMask, HEX);
+    Serial.print(F(" "));
+    Serial.println(expectedByteValueWithMask, HEX);
+#endif
+  }
+  while (success == FAILURE);
+#endif
+#endif
+  return SUCCESS;
+}
+
+/********************************************************************
+ * Function:        uint8_t recordProcessor___0x15___processExtendedReadByteLoopMaskNoPEC(t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK_NOPEC*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK_NOPEC pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK_NOPEC record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x8015___processExtendedReadByteLoopMaskNoPEC(t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK_NOPEC *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedReadByteLoopMaskNoPEC  "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->byteMask, HEX);
+#else
+  uint8_t actualByteValue;
+  uint8_t actualByteValueWithMask;
+  uint8_t expectedByteValueWithMask;
+  uint8_t success = FAILURE;
+  do
+  {
+    if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+      actualByteValue = smbusNoPec__->extendedReadByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                        pRecord->detailedRecordHeader.CommandCode);
+    else
+      actualByteValue = smbusNoPec__->readByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                        pRecord->detailedRecordHeader.CommandCode & 0xFF);
+
+    actualByteValueWithMask = (actualByteValue & pRecord->byteMask);
+    expectedByteValueWithMask = (pRecord->expectedDataByte & pRecord->byteMask);
+    success = (actualByteValueWithMask == expectedByteValueWithMask);
+#if DEBUG_PRINT
+    Serial.print(F("ExtendedReadByteLoopMaskNoPEC "));
     Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
     Serial.print(F(" "));
     Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
@@ -1070,6 +2336,64 @@ uint8_t recordProcessor___0x16___processReadWordLoopMaskNoPEC(t_RECORD_PMBUS_REA
 }
 
 /********************************************************************
+ * Function:        uint8_t recordProcessor___0x8016___processExtendedReadWordLoopMaskNoPEC(t_RECORD_PMBUS_EXTENDED_READ_WORD_LOOP_MASK_NOPEC*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_READ_WORD_LOOP_MASK_NOPEC pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_READ_WORD_LOOP_MASK_NOPEC record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x8016___processExtendedReadWordLoopMaskNoPEC(t_RECORD_PMBUS_EXTENDED_READ_WORD_LOOP_MASK_NOPEC *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedReadWordLoopMaskNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->wordMask, HEX);
+#else
+  uint16_t actualWordValue;
+  uint16_t actualWordValueWithMask;
+  uint16_t expectedWordValueWithMask;
+  uint8_t success = FAILURE;
+  do
+  {
+    if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+      actualWordValue = smbusNoPec__->extendedReadWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                        pRecord->detailedRecordHeader.CommandCode);
+    else
+      actualWordValue = smbusNoPec__->readWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                        pRecord->detailedRecordHeader.CommandCode & 0xFF);
+
+
+    actualWordValueWithMask = (actualWordValue & pRecord->wordMask);
+    expectedWordValueWithMask = (pRecord->expectedDataWord & pRecord->wordMask);
+    success = (actualWordValueWithMask == expectedWordValueWithMask);
+#if DEBUG_PRINT
+    Serial.print(F("ExtendedReadWordLoopMaskNoPEC "));
+    Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+    Serial.print(F(" "));
+    Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+    Serial.print(F(" "));
+    Serial.print(pRecord->wordMask, HEX);
+    Serial.print(F(" "));
+    Serial.print(actualWordValueWithMask, HEX);
+    Serial.print(F(" "));
+    Serial.println(expectedWordValueWithMask, HEX);
+#endif
+  }
+  while (success == FAILURE);
+#endif
+#endif
+  return SUCCESS;
+}
+
+/********************************************************************
  * Function:        uint8_t recordProcessor___0x17___processSendByteNoPEC(t_RECORD_PMBUS_SEND_BYTE_NOPEC*);
  *
  * PreCondition:    None
@@ -1101,6 +2425,44 @@ uint8_t recordProcessor___0x17___processSendByteNoPEC(t_RECORD_PMBUS_SEND_BYTE_N
 #endif
   return SUCCESS;
 }
+
+/********************************************************************
+ * Function:        uint8_t recordProcessor___0x8017___processExtendedSendByteNoPEC(t_RECORD_PMBUS_EXTENDED_SEND_BYTE_NOPEC*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_SEND_BYTE_NOPEC pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_SEND_BYTE_NOPEC record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x8017___processExtendedSendByteNoPEC(t_RECORD_PMBUS_EXTENDED_SEND_BYTE_NOPEC *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedSendByteNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->detailedRecordHeader.CommandCode, HEX);
+#else
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedSendByteNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->detailedRecordHeader.CommandCode, HEX);
+#endif
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+    smbusNoPec__->extendedSendByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                           pRecord->detailedRecordHeader.CommandCode);
+  else
+    smbusNoPec__->sendByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                           pRecord->detailedRecordHeader.CommandCode & 0xFF);
+#endif
+#endif
+  return SUCCESS;
+}
+
 
 /********************************************************************
  * Function:        uint8_t recordProcessor___0x18___processEvent(t_RECORD_EVENT*);
@@ -1151,7 +2513,7 @@ uint8_t recordProcessor___0x18___processEvent(t_RECORD_EVENT *pRecord)
       return SUCCESS;
     case SYSTEM_BEFORE_VERIFY:
       if (verification_in_progress)
-        ignore_records = true;
+        ignore_records = false;
       // This event is fired after programming the system before any commands are issued to verify the NVM
       // Potentially do something in your system that needs doing before any programming has started
       // Tell the user the chip was programmed without error and now it needs verification?
@@ -1198,12 +2560,12 @@ uint8_t recordProcessor___0x18___processEvent(t_RECORD_EVENT *pRecord)
 }
 
 /********************************************************************
- * Function:        uint8_t recordProcessor___0x19___processReadByteExpectMaskNoPEC(t_RECORD_smbus_read_byte_EXPECT_MASK_NOPEC*);
+ * Function:        uint8_t recordProcessor___0x19___processReadByteExpectMaskNoPEC(t_RECORD_PMBUS_READ_BYTE_EXPECT_MASK_NOPEC*);
  *
  * PreCondition:    None
- * Input:           A t_RECORD_smbus_read_byte_EXPECT_MASK_NOPEC pointer reference
+ * Input:           A t_RECORD_PMBUS_READ_BYTE_EXPECT_MASK_NOPEC pointer reference
  * Output:          A 1 is returned on success and a 0 is returned on failure
- * Overview:        Processes the t_RECORD_smbus_read_byte_EXPECT_MASK_NOPEC record type
+ * Overview:        Processes the t_RECORD_PMBUS_READ_BYTE_EXPECT_MASK_NOPEC record type
  * Note:            More detailed information may be available in the PDF
  *******************************************************************/
 uint8_t recordProcessor___0x19___processReadByteExpectMaskNoPEC(t_RECORD_PMBUS_READ_BYTE_EXPECT_MASK_NOPEC *pRecord)
@@ -1229,6 +2591,57 @@ uint8_t recordProcessor___0x19___processReadByteExpectMaskNoPEC(t_RECORD_PMBUS_R
   expectedByteValueWithMask = (pRecord->expectedDataByte & pRecord->byteMask);
 #if DEBUG_PRINT
   Serial.print(F("ReadByteExpectMaskNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->byteMask, HEX);
+  Serial.print(F(" "));
+  Serial.print(actualByteValueWithMask, HEX);
+  Serial.print(F(" "));
+  Serial.println(expectedByteValueWithMask, HEX);
+#endif
+  return (actualByteValueWithMask != expectedByteValueWithMask) ? FAILURE : SUCCESS;
+#endif
+#endif
+}
+
+/********************************************************************
+ * Function:        uint8_t recordProcessor___0x8019___processExtendedReadByteExpectMaskNoPEC(t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_MASK_NOPEC*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_MASK_NOPEC pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_MASK_NOPEC record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x8019___processExtendedReadByteExpectMaskNoPEC(t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_MASK_NOPEC *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedReadByteExpectMaskNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->byteMask, HEX);
+  return SUCCESS;
+#else
+  uint8_t actualByteValue;
+  uint8_t actualByteValueWithMask;
+  uint8_t expectedByteValueWithMask;
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+    actualByteValue = smbusNoPec__->extendedReadByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                      pRecord->detailedRecordHeader.CommandCode);
+  else
+    actualByteValue = smbusNoPec__->readByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                      pRecord->detailedRecordHeader.CommandCode & 0xFF);
+  actualByteValueWithMask = (actualByteValue & pRecord->byteMask);
+  expectedByteValueWithMask = (pRecord->expectedDataByte & pRecord->byteMask);
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedReadByteExpectMaskNoPEC "));
   Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
   Serial.print(F(" "));
   Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
@@ -1279,6 +2692,64 @@ uint8_t recordProcessor___0x1A___processReadWordExpectMaskNoPEC(t_RECORD_PMBUS_R
   expectedWordValueWithMask = (pRecord->expectedDataWord & pRecord->wordMask);
 #if DEBUG_PRINT
   Serial.print(F("ReadWordExpectMaskNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->expectedDataWord, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->wordMask, HEX);
+  Serial.print(F(" "));
+  Serial.print(actualWordValue, HEX);
+  Serial.print(F(" "));
+  Serial.print(actualWordValueWithMask, HEX);
+  Serial.print(F(" "));
+  Serial.println(expectedWordValueWithMask, HEX);
+#endif
+  return (actualWordValueWithMask != expectedWordValueWithMask) ? FAILURE : SUCCESS;
+#endif
+#endif
+}
+
+/********************************************************************
+ * Function:        uint8_t recordProcessor___0x801A___processReadWordExpectMaskNoPEC(t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT_MASK_NOPEC*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT_MASK_NOPEC pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT_MASK_NOPEC record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x801A___processExtendedReadWordExpectMaskNoPEC(t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT_MASK_NOPEC *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedReadWordExpectMaskNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->expectedDataWord, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->wordMask, HEX);
+  return SUCCESS;
+#else
+  uint16_t actualWordValue;
+  uint16_t actualWordValueWithMask;
+  uint16_t expectedWordValueWithMask;
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+    actualWordValue = smbusNoPec__->extendedReadWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                      pRecord->detailedRecordHeader.CommandCode);
+  else
+    actualWordValue = smbusNoPec__->readWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                      pRecord->detailedRecordHeader.CommandCode & 0xFF);
+
+  actualWordValueWithMask = (actualWordValue & pRecord->wordMask);
+  expectedWordValueWithMask = (pRecord->expectedDataWord & pRecord->wordMask);
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedReadWordExpectMaskNoPEC "));
   Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
   Serial.print(F(" "));
   Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
@@ -1428,6 +2899,55 @@ uint8_t recordProcessor___0x1C___modifyWordNoPEC(t_RECORD_PMBUS_MODIFY_WORD_NO_P
 }
 
 /********************************************************************
+ * Function:        uint8_t recordProcessor___0x801C___extendedModifyWordNoPEC(t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE_NO_PEC*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE_NO_PEC pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE_NO_PEC record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x801C___extendedModifyWordNoPEC(t_RECORD_PMBUS_EXTENDED_MODIFY_WORD_NO_PEC *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedModifyWordNoPec "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->desiredDataWord, HEX);
+#else
+  uint16_t actualWordValue;
+  uint16_t modifiedWordValue;
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedModifyWordNoPec %x "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->desiredDataWord, HEX);
+#endif
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+    actualWordValue = smbusNoPec__->extendedReadWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                      pRecord->detailedRecordHeader.CommandCode);
+  else
+    actualWordValue = smbusNoPec__->readWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                      pRecord->detailedRecordHeader.CommandCode & 0xFF);
+
+  modifiedWordValue = (actualWordValue & (~pRecord->wordMask));
+  smbusNoPec__->writeWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                          pRecord->detailedRecordHeader.CommandCode,
+                          modifiedWordValue | (pRecord->desiredDataWord & pRecord->wordMask));
+#endif
+#endif
+  return SUCCESS;
+}
+
+
+/********************************************************************
  * Function:        uint8_t recordProcessor___0x1D___modifyByteNoPEC(t_RECORD_PMBUS_MODIFY_BYTE*);
  *
  * PreCondition:    None
@@ -1471,6 +2991,53 @@ uint8_t recordProcessor___0x1D___modifyByteNoPEC(t_RECORD_PMBUS_MODIFY_BYTE_NO_P
   return SUCCESS;
 }
 
+/********************************************************************
+ * Function:        uint8_t recordProcessor___0x801D___extendedModifyByteNoPEC(t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x801D___extendedModifyByteNoPEC(t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE_NO_PEC *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedModifyByteNoPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->desiredDataByte, HEX);
+#else
+  uint8_t actualByteValue;
+  uint8_t modifiedByteValue;
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedModifyByteNoPEC %x "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->desiredDataByte, HEX);
+#endif
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+    actualByteValue = smbusNoPec__->extendedReadByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                      pRecord->detailedRecordHeader.CommandCode);
+  else
+    actualByteValue = smbusNoPec__->readByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                      pRecord->detailedRecordHeader.CommandCode & 0xFF);
+
+  modifiedByteValue = (actualByteValue & (~pRecord->byteMask));
+  smbusNoPec__->writeByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                          pRecord->detailedRecordHeader.CommandCode,
+                          modifiedByteValue | (pRecord->desiredDataByte & pRecord->byteMask));
+#endif
+#endif
+  return SUCCESS;
+}
 /********************************************************************
  * Function:        uint8_t recordProcessor___0x1E___writeNvmData(t_RECORD_NVM_DATA*);
  *
@@ -1577,6 +3144,84 @@ uint8_t recordProcessor___0x20___modifyByteOptionalPEC(t_RECORD_PMBUS_MODIFY_BYT
 }
 
 /********************************************************************
+ * Function:        uint8_t recordProcessor___0x8020___modifyByteOptionalPEC(t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x8020___extendedModifyByteOptionalPEC(t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("ExtendedModifyByteOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->desiredDataByte, HEX);
+#else
+  uint8_t actualByteValue;
+  uint8_t modifiedByteValue;
+#if DEBUG_PRINT
+  Serial.print(F("ExtendedModifyByteOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->desiredDataByte, HEX);
+#endif
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      actualByteValue = smbusPec__->extendedReadByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                                             pRecord->detailedRecordHeader.CommandCode);
+    else
+      actualByteValue = smbusNoPec__->extendedReadByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                        pRecord->detailedRecordHeader.CommandCode);
+  }
+  else
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      actualByteValue = smbusPec__->readByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                                             pRecord->detailedRecordHeader.CommandCode & 0xFF);
+    else
+      actualByteValue = smbusNoPec__->readByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                        pRecord->detailedRecordHeader.CommandCode & 0xFF);    
+  }
+  modifiedByteValue = (actualByteValue & (~pRecord->byteMask));
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      smbusPec__->extendedWriteByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode,
+                            modifiedByteValue | (pRecord->desiredDataByte & pRecord->byteMask));
+    else
+      smbusNoPec__->extendedWriteByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                              pRecord->detailedRecordHeader.CommandCode,
+                              modifiedByteValue | (pRecord->desiredDataByte & modifiedByteValue));
+  }
+  else
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      smbusPec__->writeByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                            modifiedByteValue | (pRecord->desiredDataByte & pRecord->byteMask));
+    else
+      smbusNoPec__->writeByte((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                              pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                              modifiedByteValue | (pRecord->desiredDataByte & modifiedByteValue));    
+  }
+#endif
+#endif
+  return SUCCESS;
+}
+
+/********************************************************************
  * Function:        uint8_t recordProcessor___0x21___modifyWordOptionalPEC(t_RECORD_PMBUS_MODIFY_WORD*);
  *
  * PreCondition:    None
@@ -1624,6 +3269,85 @@ uint8_t recordProcessor___0x21___modifyWordOptionalPEC(t_RECORD_PMBUS_MODIFY_WOR
     smbusNoPec__->writeWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
                             pRecord->detailedRecordHeader.CommandCode,
                             modifiedWordValue | (pRecord->desiredDataWord & pRecord->wordMask));
+#endif
+#endif
+  return SUCCESS;
+}
+
+/********************************************************************
+ * Function:        uint8_t recordProcessor___0x8021___extendedModifyWordOptionalPEC(t_RECORD_PMBUS_EXTENDED_MODIFY_WORD*);
+ *
+ * PreCondition:    None
+ * Input:           A t_RECORD_PMBUS_EXTENDED_MODIFY_WORD pointer reference
+ * Output:          A 1 is returned on success and a 0 is returned on failure
+ * Overview:        Processes the t_RECORD_PMBUS_EXTENDED_MODIFY_WORD record type
+ * Note:            More detailed information may be available in the PDF
+ *******************************************************************/
+uint8_t recordProcessor___0x8021___extendedModifyWordOptionalPEC(t_RECORD_PMBUS_EXTENDED_MODIFY_WORD *pRecord)
+{
+#if DEBUG_SILENT
+  return SUCCESS;
+#else
+#if DEBUG_PROCESSING
+  Serial.print(F("extendedModifyWordOptionalPEC "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->desiredDataWord, HEX);
+#else
+  uint16_t actualWordValue;
+  uint16_t modifiedWordValue;
+#if DEBUG_PRINT
+  Serial.print(F("extendedModifyWordOptionalPEC %x "));
+  Serial.print(pRecord->detailedRecordHeader.DeviceAddress, HEX);
+  Serial.print(F(" "));
+  Serial.print(pRecord->detailedRecordHeader.CommandCode, HEX);
+  Serial.print(F(" "));
+  Serial.println(pRecord->desiredDataWord, HEX);
+#endif
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      actualWordValue = smbusPec__->extendedReadWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                                             pRecord->detailedRecordHeader.CommandCode);
+    else
+      actualWordValue = smbusNoPec__->extendedReadWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                        pRecord->detailedRecordHeader.CommandCode);
+  }
+  else
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      actualWordValue = smbusPec__->readWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                                             pRecord->detailedRecordHeader.CommandCode & 0xFF);
+    else
+      actualWordValue = smbusNoPec__->readWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                        pRecord->detailedRecordHeader.CommandCode & 0xFF);    
+  }
+
+  modifiedWordValue = (actualWordValue & (~pRecord->wordMask));
+  if ((pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFE) || (pRecord->detailedRecordHeader.CommandCode >> 8 == 0xFF))
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      smbusPec__->extendedWriteWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode,
+                            modifiedWordValue | (pRecord->desiredDataWord & pRecord->wordMask));
+    else
+      smbusNoPec__->extendedWriteWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                              pRecord->detailedRecordHeader.CommandCode,
+                              modifiedWordValue | (pRecord->desiredDataWord & pRecord->wordMask));
+  }
+  else
+  {
+    if (pRecord->detailedRecordHeader.UsePec)
+      smbusPec__->writeWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                            pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                            modifiedWordValue | (pRecord->desiredDataWord & pRecord->wordMask));
+    else
+      smbusNoPec__->writeWord((uint8_t) pRecord->detailedRecordHeader.DeviceAddress,
+                              pRecord->detailedRecordHeader.CommandCode & 0xFF,
+                              modifiedWordValue | (pRecord->desiredDataWord & pRecord->wordMask));    
+  }
 #endif
 #endif
   return SUCCESS;

--- a/LTSketchbook/libraries/LTPSM_InFlightUpdate/nvm.cpp
+++ b/LTSketchbook/libraries/LTPSM_InFlightUpdate/nvm.cpp
@@ -48,7 +48,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define DEBUG_FLASH 0
 
-const unsigned char  *icpFile;
+const unsigned char *icpFile;
+const unsigned char *icpPosition;
 uint32_t flashLocation = 0;
 
 LT_SMBusNoPec *smbusNoPec__;
@@ -87,6 +88,17 @@ pRecordHeaderLengthAndType get_record(void)
   return parse_record(get_record_data);
 }
 
+uint8_t get_record_raw_data(void)
+{
+  return *(icpPosition++);
+}
+
+pRecordHeaderLengthAndType get_raw_record(void)
+{
+  pRecordHeaderLengthAndType record = parse_record(get_record_raw_data);
+  return record;
+}
+
 NVM::NVM(LT_SMBusNoPec *smbusNoPec, LT_SMBusPec *smbusPec)
 {
   smbusNoPec__ = smbusNoPec;
@@ -120,5 +132,30 @@ bool NVM::verifyWithData(const unsigned char *data)
     return 0;
   }
   reset_parse_hex();
+  return 1;
+}
+
+bool NVM::programWithRawData(const unsigned char *data)
+{
+  icpFile = data;
+  icpPosition = icpFile;
+
+  if (processRecordsOnDemand(get_raw_record) == 0)
+  {
+    return 0;
+  }
+  return 1;
+}
+
+bool NVM::verifyWithRawData(const unsigned char *data)
+{
+  icpFile = data;
+  icpPosition = icpFile;
+
+  if (verifyRecordsOnDemand(get_raw_record) == 0)
+  {
+    return 0;
+  }
+
   return 1;
 }

--- a/LTSketchbook/libraries/LTPSM_InFlightUpdate/nvm_create.cpp
+++ b/LTSketchbook/libraries/LTPSM_InFlightUpdate/nvm_create.cpp
@@ -1,0 +1,289 @@
+/*!
+
+Copyright 2020(c) Analog Devices, Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ - Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ - Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+ - Neither the name of Analog Devices, Inc. nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+ - The use of this software may or may not infringe the patent rights
+   of one or more patent holders.  This license does not release you
+   from the requirement that you obtain separate licenses from these
+   patent holders to use this software.
+ - Use of the software either in source or binary form, must be run
+   on or directly connected to an Analog Devices Inc. component.
+
+THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*! @file
+    @ingroup LTPSM_InFlightUpdate
+    Library File
+*/
+
+#include "nvm_create.h"
+#include <Arduino.h>
+#include <stdlib.h>
+#include <record_type_definitions.h>
+
+uint8_t *create_event(uint16_t id)
+{
+  t_RECORD_EVENT *record = malloc(sizeof(t_RECORD_EVENT));
+  record->baseRecordHeader.RecordType = RECORD_TYPE_EVENT;
+  record->eventId = id;
+
+  record->baseRecordHeader.Length = sizeof(*record);
+  
+  return (uint8_t *) record;
+}
+
+uint8_t *create_meta_data(uint16_t data)
+{
+  t_RECORD_VARIABLE_META_DATA *record = malloc(sizeof(t_RECORD_VARIABLE_META_DATA));
+  record->baseRecordHeader.RecordType = RECORD_TYPE_VARIABLE_META_DATA;
+  record->metaDataType = data;
+  
+  record->baseRecordHeader.Length = sizeof(*record);
+
+  return (uint8_t *) record;
+}
+
+uint8_t *create_delay_ms(uint16_t delay)
+{
+  t_RECORD_DELAY_MS *record = malloc(sizeof(t_RECORD_DELAY_MS));
+  record->baseRecordHeader.RecordType = RECORD_TYPE_DELAY_MS;
+  record->numMs = delay;
+
+  record->baseRecordHeader.Length = sizeof(*record);
+
+  return (uint8_t *) record;
+}
+
+uint8_t *create_send_byte(uint16_t address, uint8_t command, bool pec = false)
+{ 
+  t_RECORD_PMBUS_SEND_BYTE *record = malloc(sizeof(t_RECORD_PMBUS_SEND_BYTE));
+  record->baseRecordHeader.RecordType = RECORD_TYPE_PMBUS_SEND_BYTE;
+  record->detailedRecordHeader.DeviceAddress = address;
+  record->detailedRecordHeader.CommandCode = command;
+  record->detailedRecordHeader.UsePec = pec ? 1 : 0;
+
+  record->baseRecordHeader.Length = sizeof(*record);
+
+  return (uint8_t *) record;
+}
+
+uint8_t *create_write_byte(uint16_t address, uint8_t command, uint8_t data, bool pec = false)
+{ 
+  t_RECORD_PMBUS_WRITE_BYTE *record = malloc(sizeof(t_RECORD_PMBUS_WRITE_BYTE));
+  record->baseRecordHeader.RecordType = RECORD_TYPE_PMBUS_WRITE_BYTE;
+  record->detailedRecordHeader.DeviceAddress = address;
+  record->detailedRecordHeader.CommandCode = command;
+  record->detailedRecordHeader.UsePec = pec ? 1 : 0;
+  record->dataByte = data;
+
+  record->baseRecordHeader.Length = sizeof(*record);
+
+  return (uint8_t *) record;
+}
+
+uint8_t *create_extended_write_byte(uint16_t address, uint16_t command, uint8_t data, bool pec = false)
+{ 
+  t_RECORD_PMBUS_EXTENDED_WRITE_BYTE *record = malloc(sizeof(t_RECORD_PMBUS_EXTENDED_WRITE_BYTE));
+  record->baseRecordHeader.RecordType = RECORD_TYPE_PMBUS_EXTENDED_WRITE_BYTE;
+  record->detailedRecordHeader.DeviceAddress = address;
+  record->detailedRecordHeader.CommandCode = command;
+  record->detailedRecordHeader.UsePec = pec ? 1 : 0;
+  record->dataByte = data;
+
+  record->baseRecordHeader.Length = sizeof(*record);
+
+  return (uint8_t *) record;
+}
+
+uint8_t *create_write_word(uint16_t address, uint8_t command, uint16_t data, bool pec = false)
+{ 
+  t_RECORD_PMBUS_WRITE_WORD *record = malloc(sizeof(t_RECORD_PMBUS_WRITE_WORD));
+  record->baseRecordHeader.RecordType = RECORD_TYPE_PMBUS_WRITE_WORD;
+  record->detailedRecordHeader.DeviceAddress = address;
+  record->detailedRecordHeader.CommandCode = command;
+  record->detailedRecordHeader.UsePec = pec ? 1 : 0;
+  record->dataWord = data;
+
+  record->baseRecordHeader.Length = sizeof(*record);
+
+  return (uint8_t *) record;
+}
+
+uint8_t *create_extended_write_word(uint16_t address, uint16_t command, uint16_t data, bool pec = false)
+{ 
+  t_RECORD_PMBUS_EXTENDED_WRITE_WORD *record = malloc(sizeof(t_RECORD_PMBUS_EXTENDED_WRITE_WORD));
+  record->baseRecordHeader.RecordType = RECORD_TYPE_PMBUS_EXTENDED_WRITE_WORD;
+  record->detailedRecordHeader.DeviceAddress = address;
+  record->detailedRecordHeader.CommandCode = command;
+  record->detailedRecordHeader.UsePec = pec ? 1 : 0;
+  record->dataWord = data;
+
+  record->baseRecordHeader.Length = sizeof(*record);
+
+  return (uint8_t *) record;
+}
+
+uint8_t *create_write_block(uint16_t address, uint8_t command, uint8_t *data, int size, bool pec = false)
+{ 
+  t_RECORD_PMBUS_WRITE_BLOCK *record = malloc(sizeof(t_RECORD_PMBUS_WRITE_BLOCK));
+  record->baseRecordHeader.RecordType = RECORD_TYPE_PMBUS_WRITE_BLOCK;
+  record->detailedRecordHeader.DeviceAddress = address;
+  record->detailedRecordHeader.CommandCode = command;
+  record->detailedRecordHeader.UsePec = pec ? 1 : 0;
+  record->baseRecordHeader.Length = sizeof(*record) + size;
+
+  uint8_t *block = malloc(sizeof(*record) + size);
+  memcpy (block, record, sizeof(*record));
+  uint8_t *blockData = block + sizeof(*record);
+  memcpy (blockData, data, size); 
+
+  delete record;
+  return block;
+}
+
+uint8_t *create_read_byte_expect(uint16_t address, uint8_t command, uint8_t data, bool pec = false)
+{
+  t_RECORD_PMBUS_READ_BYTE_EXPECT *record = malloc(sizeof(t_RECORD_PMBUS_READ_BYTE_EXPECT));
+  record->baseRecordHeader.RecordType = RECORD_TYPE_PMBUS_READ_BYTE_EXPECT;
+  record->detailedRecordHeader.DeviceAddress = address;
+  record->detailedRecordHeader.CommandCode = command;
+  record->detailedRecordHeader.UsePec = pec ? 1 : 0;
+  record->expectedDataByte = data;
+
+  record->baseRecordHeader.Length = sizeof(*record);
+
+  return (uint8_t *) record;
+}
+
+uint8_t *create_extended_read_byte_expect(uint16_t address, uint16_t command, uint8_t data, bool pec = false)
+{
+  t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT *record = malloc(sizeof(t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT));
+  record->baseRecordHeader.RecordType = RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_EXPECT;
+  record->detailedRecordHeader.DeviceAddress = address;
+  record->detailedRecordHeader.CommandCode = command;
+  record->detailedRecordHeader.UsePec = pec ? 1 : 0;
+  record->expectedDataByte = data;
+
+  record->baseRecordHeader.Length = sizeof(*record);
+
+  return (uint8_t *) record;
+}
+
+
+uint8_t *create_read_word_expect(uint16_t address, uint8_t command, uint16_t data, bool pec = false)
+{
+  t_RECORD_PMBUS_READ_WORD_EXPECT *record = malloc(sizeof(t_RECORD_PMBUS_READ_WORD_EXPECT));
+  record->baseRecordHeader.RecordType = RECORD_TYPE_PMBUS_READ_WORD_EXPECT;
+  record->detailedRecordHeader.DeviceAddress = address;
+  record->detailedRecordHeader.CommandCode = command;
+  record->detailedRecordHeader.UsePec = pec ? 1 : 0;
+  record->expectedDataWord = data;
+
+  record->baseRecordHeader.Length = sizeof(*record);
+
+  return (uint8_t *) record;
+}
+
+uint8_t *create_extended_read_word_expect(uint16_t address, uint16_t command, uint16_t data, bool pec = false)
+{
+  t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT *record = malloc(sizeof(t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT));
+  record->baseRecordHeader.RecordType = RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_EXPECT;
+  record->detailedRecordHeader.DeviceAddress = address;
+  record->detailedRecordHeader.CommandCode = command;
+  record->detailedRecordHeader.UsePec = pec ? 1 : 0;
+  record->expectedDataWord = data;
+
+  record->baseRecordHeader.Length = sizeof(*record);
+
+  return (uint8_t *) record;
+}
+
+uint8_t *create_termination()
+{
+  tRecordHeaderLengthAndType *record = malloc(sizeof(tRecordHeaderLengthAndType));
+  record->Length = 4;
+  record->RecordType = 0x22;
+  return (uint8_t *) record;
+}
+
+uint8_t *pack_records(uint8_t **records)
+{
+  uint8_t **working_records;
+  uint8_t *working_record;
+  uint16_t block_size = 0;
+  tRecordHeaderLengthAndType *header;
+  uint8_t *data;
+  uint8_t *pos;
+
+//  Serial.println("pack_records");
+  working_records = records;
+
+  while (*working_records != 0)
+  {
+    working_record = *working_records;
+    working_records += 1;
+
+    header = (pRecordHeaderLengthAndType) working_record;
+    block_size += header->Length;
+
+//    Serial.print("block_size "); Serial.println(block_size, DEC);
+
+  }
+
+  working_records = records;
+  data = (uint8_t *) malloc(block_size);
+  pos = data;
+
+  while (*working_records != 0)
+  {
+    working_record = *working_records;
+    working_records += 1;
+        
+    header = (pRecordHeaderLengthAndType) working_record;
+//    Serial.print("header->Length "); Serial.println(header->Length, DEC);
+
+    memcpy(pos, working_record, header->Length);
+    pos += header->Length;
+
+//    Serial.print("pos "); Serial.println(header->Length, DEC);
+
+
+  }
+
+  working_records = records;
+  while (*working_records != 0)
+  {
+    working_record = *working_records;
+    free(working_record);
+    working_records += 1;
+
+  }
+  
+  Serial.print("Block size: ");
+  Serial.println(block_size, DEC);
+//  Serial.println("exit pack_records");
+  return data;
+}

--- a/LTSketchbook/libraries/LTPSM_InFlightUpdate/nvm_create.h
+++ b/LTSketchbook/libraries/LTPSM_InFlightUpdate/nvm_create.h
@@ -1,6 +1,6 @@
 /*!
 
-Copyright 2018(c) Analog Devices, Inc.
+Copyright 2020(c) Analog Devices, Inc.
 
 All rights reserved.
 
@@ -35,56 +35,28 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 /*! @file
     @ingroup LTPSM_InFlightUpdate
-    Library Header File for NVM
+    Library Header File
 */
 
+#ifndef NVM_CREATE_H_
+#define NVM_CREATE_H_
 
-#ifndef NVM_H_
-#define NVM_H_
-
-#include <stdbool.h>
 #include <stdint.h>
-#include <avr/pgmspace.h>
-#include "../LT_PMBUS/LT_PMBus.h"
-#include "../LT_SMBUS/LT_SMBusNoPec.h"
-#include "../LT_SMBUS/LT_SMBusPec.h"
-#include "../LT_SMBUS/LT_I2CBus.h"
-#include "main_record_processor.h"
-#include "hex_file_parser.h"
 
-// Give access to c code used by this class
-extern LT_SMBusNoPec *smbusNoPec__;
-extern LT_SMBusPec *smbusPec__;
+extern uint8_t *create_event(uint16_t id);
+extern uint8_t *create_meta_data(uint16_t data);
+extern uint8_t *create_delay_ms(uint16_t delay);
+extern uint8_t *create_send_byte(uint16_t address, uint8_t command, bool pec = false);
+extern uint8_t *create_write_byte(uint16_t address, uint8_t command, uint8_t data, bool pec = false);
+extern uint8_t *create_extended_write_byte(uint16_t address, uint16_t command, uint8_t data, bool pec = false);
+extern uint8_t *create_write_word(uint16_t address, uint8_t command, uint16_t data, bool pec = false);
+extern uint8_t *create_extended_write_word(uint16_t address, uint16_t command, uint16_t data, bool pec = false);
+extern uint8_t *create_write_block(uint16_t address, uint8_t command, uint8_t *data, int size, bool pec = false);
+extern uint8_t *create_read_byte_expect(uint16_t address, uint8_t command, uint8_t data, bool pec = false);
+extern uint8_t *create_extended_read_byte_expect(uint16_t address, uint16_t command, uint8_t data, bool pec = false);
+extern uint8_t *create_read_word_expect(uint16_t address, uint8_t command, uint16_t data, bool pec = false);
+extern uint8_t *create_extended_read_word_expect(uint16_t address, uint16_t command, uint16_t data, bool pec = false);
+extern uint8_t *create_termination();
+extern uint8_t *pack_records(uint8_t **records);
 
-class NVM
-{
-  private:
-    uint8_t numAddrs;
-
-  public:
-    //! Constructor.
-    NVM(LT_SMBusNoPec *,    //!< reference to no pec smbus object
-        LT_SMBusPec *       //!< reference to pec smbus object
-       );
-
-    //! Program with hex data.
-    //! @return true if data loaded.
-    bool programWithData(const unsigned char * //!< array of hex data
-                        );
-
-    //! Verifies board NVM with hex data..
-    //! @return true if NVM configuration matches the hex data.
-    bool verifyWithData(const unsigned char *);
-
-    //! Program with raw data records.
-    //! @return true if data loaded.
-    bool programWithRawData(const unsigned char * //!< array of records
-                        );
-
-    //! Verifies board NVM with raw data records..
-    //! @return true if NVM configuration matches the records.
-    bool verifyWithRawData(const unsigned char *);
-
-};
-
-#endif /* NVM_H_ */
+#endif /* NVM_CREATE_H_ */

--- a/LTSketchbook/libraries/LTPSM_InFlightUpdate/nvm_data_helpers.cpp
+++ b/LTSketchbook/libraries/LTPSM_InFlightUpdate/nvm_data_helpers.cpp
@@ -122,8 +122,8 @@ uint8_t bufferNvmData(t_RECORD_NVM_DATA *pRecord)
   nvram_somethingToVerify = 1;
 
   nWords = (uint16_t)((pRecord->baseRecordHeader.Length-8)/2);
-  words = (uint16_t *) ((uint16_t)(holdRecord()+8)); // Change (UINT16) to the size of an address on the target machine.
-
+  words = (uint16_t*) ((uint8_t *)holdRecord()+8); // Change (UINT32) to the size of an address on the target machine.
+  
   return 1;
 }
 

--- a/LTSketchbook/libraries/LTPSM_InFlightUpdate/record_type_basic_definitions.h
+++ b/LTSketchbook/libraries/LTPSM_InFlightUpdate/record_type_basic_definitions.h
@@ -65,7 +65,21 @@ typedef struct
 typedef struct
 {
   uint16_t DeviceAddress;
+  uint16_t CommandCode;
+  uint8_t UsePec;
+} tRecordHeaderAddressAndExtendedCommandWithOptionalPEC;
+
+typedef struct
+{
+  uint16_t DeviceAddress;
   uint8_t CommandCode;
 } tRecordHeaderAddressAndCommandWithoutPEC;
+
+typedef struct
+{
+  uint16_t DeviceAddress;
+  uint16_t CommandCode;
+} tRecordHeaderAddressAndExtendedCommandWithoutPEC;
+
 #pragma pack(pop)
 #endif

--- a/LTSketchbook/libraries/LTPSM_InFlightUpdate/record_type_definitions.h
+++ b/LTSketchbook/libraries/LTPSM_InFlightUpdate/record_type_definitions.h
@@ -44,6 +44,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 #include "record_type_basic_definitions.h"  /* Basic Record Type Definitions that the following specific record types are built upon */
 
+#define EXTENDED_CMD(X) (0x8000 | (X))
+
 /*******************************************************************/
 /******** Record Type Definitions at a Glance **********************/
 /*******************************************************************/
@@ -107,7 +109,13 @@ typedef struct
   uint8_t dataByte;
 } t_RECORD_PMBUS_WRITE_BYTE;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_WRITE_BYTE  (EXTENDED_CMD(RECORD_TYPE_PMBUS_WRITE_BYTE))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithOptionalPEC detailedRecordHeader;
+  uint8_t dataByte;
+} t_RECORD_PMBUS_EXTENDED_WRITE_BYTE;
 
 
 
@@ -125,7 +133,13 @@ typedef struct
   uint16_t dataWord;
 } t_RECORD_PMBUS_WRITE_WORD;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_WRITE_WORD (EXTENDED_CMD(RECORD_TYPE_PMBUS_WRITE_WORD))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithOptionalPEC detailedRecordHeader;
+  uint16_t dataWord;
+} t_RECORD_PMBUS_EXTENDED_WRITE_WORD;
 
 
 
@@ -137,9 +151,18 @@ typedef struct
  *          RECORD TYPE NOT USED AND NOT DEFINED
  *******************************************************************/
 #define RECORD_TYPE_PMBUS_WRITE_BLOCK (3)
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndCommandWithOptionalPEC detailedRecordHeader;
+} t_RECORD_PMBUS_WRITE_BLOCK;
 
-
-
+#define RECORD_TYPE_PMBUS_EXTENDED_WRITE_BLOCK (EXTENDED_CMD(RECORD_TYPE_PMBUS_WRITE_BLOCK))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithOptionalPEC detailedRecordHeader;
+} t_RECORD_PMBUS_EXTENDED_WRITE_BLOCK;
 
 
 /********************************************************************
@@ -156,7 +179,13 @@ typedef struct
   uint8_t expectedDataByte;
 } t_RECORD_PMBUS_READ_BYTE_EXPECT;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_EXPECT (EXTENDED_CMD(RECORD_TYPE_PMBUS_READ_BYTE_EXPECT))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithOptionalPEC detailedRecordHeader;
+  uint8_t expectedDataByte;
+} t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT;
 
 
 
@@ -174,7 +203,13 @@ typedef struct
   uint16_t expectedDataWord;
 } t_RECORD_PMBUS_READ_WORD_EXPECT;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_EXPECT (EXTENDED_CMD(RECORD_TYPE_PMBUS_READ_WORD_EXPECT))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithOptionalPEC detailedRecordHeader;
+  uint16_t expectedDataWord;
+} t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT;
 
 
 
@@ -186,8 +221,18 @@ typedef struct
  *          RECORD TYPE NOT USED AND NOT DEFINED
  *******************************************************************/
 #define RECORD_TYPE_PMBUS_READ_BLOCK_EXPECT (6)
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndCommandWithOptionalPEC detailedRecordHeader;
+} t_RECORD_PMBUS_READ_BLOCK_EXPECT;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_READ_BLOCK_EXPECT (EXTENDED_CMD(RECORD_TYPE_PMBUS_READ_BLOCK_EXPECT))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithOptionalPEC detailedRecordHeader;
+} t_RECORD_PMBUS_EXTENDED_READ_BLOCK_EXPECT;
 
 
 
@@ -253,7 +298,14 @@ typedef struct
   uint8_t expectedDataByte;
 } t_RECORD_PMBUS_READ_BYTE_LOOP_MASK;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK (EXTENDED_CMD(RECORD_TYPE_PMBUS_READ_BYTE_LOOP_MASK))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithOptionalPEC detailedRecordHeader;
+  uint8_t byteMask;
+  uint8_t expectedDataByte;
+} t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK;
 
 
 
@@ -272,7 +324,14 @@ typedef struct
   uint16_t expectedDataWord;
 } t_RECORD_PMBUS_READ_WORD_LOOP_MASK;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_LOOP_MASK (EXTENDED_CMD(RECORD_TYPE_PMBUS_READ_WORD_LOOP_MASK))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithOptionalPEC detailedRecordHeader;
+  uint16_t wordMask;
+  uint16_t expectedDataWord;
+} t_RECORD_PMBUS_EXTENDED_READ_WORD_LOOP_MASK;
 
 
 
@@ -337,7 +396,12 @@ typedef struct
   tRecordHeaderAddressAndCommandWithOptionalPEC detailedRecordHeader;
 } t_RECORD_PMBUS_SEND_BYTE;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_SEND_BYTE (EXTENDED_CMD(RECORD_TYPE_PMBUS_SEND_BYTE))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithOptionalPEC detailedRecordHeader;
+} t_RECORD_PMBUS_EXTENDED_SEND_BYTE;
 
 
 
@@ -355,7 +419,13 @@ typedef struct
   uint8_t dataByte;
 } t_RECORD_PMBUS_WRITE_BYTE_NOPEC;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_WRITE_BYTE_NOPEC (EXTENDED_CMD(RECORD_TYPE_PMBUS_WRITE_BYTE_NOPEC))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithoutPEC detailedRecordHeader;
+  uint8_t dataByte;
+} t_RECORD_PMBUS_EXTENDED_WRITE_BYTE_NOPEC;
 
 
 
@@ -373,7 +443,13 @@ typedef struct
   uint16_t dataWord;
 } t_RECORD_PMBUS_WRITE_WORD_NOPEC;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_WRITE_WORD_NOPEC (EXTENDED_CMD(RECORD_TYPE_PMBUS_WRITE_WORD_NOPEC))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithoutPEC detailedRecordHeader;
+  uint16_t dataWord;
+} t_RECORD_PMBUS_EXTENDED_WRITE_WORD_NOPEC;
 
 
 
@@ -384,11 +460,19 @@ typedef struct
  * Note:            RECORD_TYPE_PMBUS_WRITE_BLOCK_NOPEC with value of 0x11 would use this struct
  *          RECORD TYPE NOT USED AND NOT DEFINED
  *******************************************************************/
-/* RECORD TYPE NOT USED AND NOT DEFINED */
 #define RECORD_TYPE_PMBUS_WRITE_BLOCK_NOPEC (0x11)
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndCommandWithoutPEC detailedRecordHeader;
+} t_RECORD_PMBUS_WRITE_BLOCK_NOPEC;
 
-
-
+#define RECORD_TYPE_PMBUS_EXTENDED_WRITE_BLOCK_NOPEC (EXTENDED_CMD(RECORD_TYPE_PMBUS_WRITE_BLOCK_NOPEC))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithoutPEC detailedRecordHeader;
+} t_RECORD_PMBUS_EXTENDED_WRITE_BLOCK_NOPEC;
 
 
 /********************************************************************
@@ -405,7 +489,13 @@ typedef struct
   uint8_t expectedDataByte;
 } t_RECORD_PMBUS_READ_BYTE_EXPECT_NOPEC;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_EXPECT_NOPEC (EXTENDED_CMD(RECORD_TYPE_PMBUS_READ_BYTE_EXPECT_NOPEC))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithoutPEC detailedRecordHeader;
+  uint8_t expectedDataByte;
+} t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_NOPEC;
 
 
 
@@ -423,7 +513,13 @@ typedef struct
   uint16_t expectedDataWord;
 } t_RECORD_PMBUS_READ_WORD_EXPECT_NOPEC;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_EXPECT_NOPEC (EXTENDED_CMD(RECORD_TYPE_PMBUS_READ_WORD_EXPECT_NOPEC))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithoutPEC detailedRecordHeader;
+  uint16_t expectedDataWord;
+} t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT_NOPEC;
 
 
 
@@ -435,9 +531,18 @@ typedef struct
  *          RECORD TYPE NOT USED AND NOT DEFINED
  *******************************************************************/
 #define RECORD_TYPE_PMBUS_READ_BLOCK_EXPECT_NOPEC (0x14)
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndCommandWithoutPEC detailedRecordHeader;
+} t_RECORD_PMBUS_READ_BLOCK_EXPECT_NOPEC;
 
-
-
+#define RECORD_TYPE_PMBUS_EXTENDED_READ_BLOCK_EXPECT_NOPEC (EXTENDED_CMD(RECORD_TYPE_PMBUS_READ_BLOCK_EXPECT_NOPEC))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithoutPEC detailedRecordHeader;
+} t_RECORD_PMBUS_EXTENDED_READ_BLOCK_EXPECT_NOPEC;
 
 
 /********************************************************************
@@ -457,7 +562,14 @@ typedef struct
   uint8_t expectedDataByte;
 } t_RECORD_PMBUS_READ_BYTE_LOOP_MASK_NOPEC;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK_NOPEC (EXTENDED_CMD(RECORD_TYPE_PMBUS_READ_BYTE_LOOP_MASK_NOPEC))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithoutPEC detailedRecordHeader;
+  uint8_t byteMask;
+  uint8_t expectedDataByte;
+} t_RECORD_PMBUS_EXTENDED_READ_BYTE_LOOP_MASK_NOPEC;
 
 
 
@@ -478,6 +590,14 @@ typedef struct
   uint16_t expectedDataWord;
 } t_RECORD_PMBUS_READ_WORD_LOOP_MASK_NOPEC;
 
+#define RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_LOOP_MASK_NOPEC (EXTENDED_CMD(RECORD_TYPE_PMBUS_READ_WORD_LOOP_MASK_NOPEC))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithoutPEC detailedRecordHeader;
+  uint16_t wordMask;
+  uint16_t expectedDataWord;
+} t_RECORD_PMBUS_EXTENDED_READ_WORD_LOOP_MASK_NOPEC;
 
 
 
@@ -495,7 +615,12 @@ typedef struct
   tRecordHeaderAddressAndCommandWithoutPEC detailedRecordHeader;
 } t_RECORD_PMBUS_SEND_BYTE_NOPEC;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_SEND_BYTE_NOPEC (EXTENDED_CMD(RECORD_TYPE_PMBUS_SEND_BYTE_NOPEC))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithoutPEC detailedRecordHeader;
+} t_RECORD_PMBUS_EXTENDED_SEND_BYTE_NOPEC;
 
 
 
@@ -558,7 +683,14 @@ typedef struct
   uint8_t byteMask;
 } t_RECORD_PMBUS_READ_BYTE_EXPECT_MASK_NOPEC;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_READ_BYTE_EXPECT_MASK_NOPEC (EXTENDED_CMD(RECORD_TYPE_PMBUS_READ_BYTE_EXPECT_MASK_NOPEC))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithoutPEC detailedRecordHeader;
+  uint8_t expectedDataByte;
+  uint8_t byteMask;
+} t_RECORD_PMBUS_EXTENDED_READ_BYTE_EXPECT_MASK_NOPEC;
 
 
 
@@ -580,7 +712,14 @@ typedef struct
   uint16_t wordMask;
 } t_RECORD_PMBUS_READ_WORD_EXPECT_MASK_NOPEC;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_READ_WORD_EXPECT_MASK_NOPEC (EXTENDED_CMD(RECORD_TYPE_PMBUS_READ_WORD_EXPECT_MASK_NOPEC))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithoutPEC detailedRecordHeader;
+  uint16_t expectedDataWord;
+  uint16_t wordMask;
+} t_RECORD_PMBUS_EXTENDED_READ_WORD_EXPECT_MASK_NOPEC;
 
 
 
@@ -647,7 +786,14 @@ typedef struct
   uint16_t desiredDataWord;
 } t_RECORD_PMBUS_MODIFY_WORD_NO_PEC;
 
-
+#define RECORD_TYPE_EXTENDED_MODIFY_WORD_NOPEC (EXTENDED_CMD(RECORD_TYPE_MODIFY_WORD_NOPEC))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithOptionalPEC detailedRecordHeader;
+  uint16_t wordMask;
+  uint16_t desiredDataWord;
+} t_RECORD_PMBUS_EXTENDED_MODIFY_WORD_NO_PEC;
 
 
 
@@ -671,7 +817,14 @@ typedef struct
   uint8_t desiredDataByte;
 } t_RECORD_PMBUS_MODIFY_BYTE_NO_PEC;
 
-
+#define RECORD_TYPE_EXTENDED_MODIFY_BYTE_NOPEC (EXTENDED_CMD(RECORD_TYPE_MODIFY_BYTE_NOPEC))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithOptionalPEC detailedRecordHeader;
+  uint8_t byteMask;
+  uint8_t desiredDataByte;
+} t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE_NO_PEC;
 
 
 
@@ -735,7 +888,14 @@ typedef struct
   uint8_t desiredDataByte;
 } t_RECORD_PMBUS_MODIFY_BYTE;
 
-
+#define RECORD_TYPE_PMBUS_EXTENDED_MODIFY_BYTE (EXTENDED_CMD(RECORD_TYPE_PMBUS_MODIFY_BYTE))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithOptionalPEC detailedRecordHeader;
+  uint8_t byteMask;
+  uint8_t desiredDataByte;
+} t_RECORD_PMBUS_EXTENDED_MODIFY_BYTE;
 
 
 
@@ -758,6 +918,15 @@ typedef struct
   uint16_t wordMask;
   uint16_t desiredDataWord;
 } t_RECORD_PMBUS_MODIFY_WORD;
+
+#define RECORD_TYPE_PMBUS_EXTENDED_MODIFY_WORD (EXTENDED_CMD(RECORD_TYPE_PMBUS_MODIFY_WORD))
+typedef struct
+{
+  tRecordHeaderLengthAndType baseRecordHeader;
+  tRecordHeaderAddressAndExtendedCommandWithOptionalPEC detailedRecordHeader;
+  uint16_t wordMask;
+  uint16_t desiredDataWord;
+} t_RECORD_PMBUS_EXTENDED_MODIFY_WORD;
 
 /********************************************************************
  * Struct:          t_RECORD_TYPE_END_OF_RECORDS

--- a/LTSketchbook/libraries/LT_SMBUS/LT_I2CBus.h
+++ b/LTSketchbook/libraries/LT_SMBUS/LT_I2CBus.h
@@ -76,12 +76,25 @@ class LT_I2CBus
                      uint8_t value    //!< Byte to be written
                     );
 
+    //! Write "value" byte to device at "address"
+    //! @return 0 on success, 1 on failure
+    int8_t extendedWriteByte(uint8_t address, //!< 7-bit I2C address
+                             uint16_t value   //!< Byte to be written
+                            );
+
     //! Read a byte of data at register specified by "command", store in "value"
     //! @return 0 on success, 1 on failure
     int8_t readByteData(uint8_t address,     //!< 7-bit I2C address
                         uint8_t command,     //!< Command byte
                         uint8_t *value       //!< Byte to be read
                        );
+
+    //! Read a byte of data at register specified by "command", store in "value"
+    //! @return 0 on success, 1 on failure
+    int8_t extendedReadByteData(uint8_t address,     //!< 7-bit I2C address
+                                uint16_t command,    //!< Command word
+                                uint8_t *value       //!< Byte to be read
+                               );
 
     //! Write a byte of data to register specified by "command"
     //! @return 0 on success, 1 on failure
@@ -90,12 +103,26 @@ class LT_I2CBus
                          uint8_t value       //!< Byte to be written
                         );
 
+    //! Write a byte of data to register specified by "command"
+    //! @return 0 on success, 1 on failure
+    int8_t extendedWriteByteData(uint8_t address,    //!< 7-bit I2C address
+                                 uint16_t command,   //!< Command word
+                                 uint8_t value       //!< Byte to be written
+                                );
+
     //! Read a 16-bit word of data from register specified by "command"
     //! @return 0 on success, 1 on failure
     int8_t readWordData(uint8_t address,     //!< 7-bit I2C address
                         uint8_t command,     //!< Command byte
                         uint16_t *value      //!< Word to be read
                        );
+
+    //! Read a 16-bit word of data from register specified by "command"
+    //! @return 0 on success, 1 on failure
+    int8_t extendedReadWordData(uint8_t address,     //!< 7-bit I2C address
+                                uint16_t command,    //!< Command word
+                                uint16_t *value      //!< Word to be read
+                               );
 
     //! Write a 16-bit word of data to register specified by "command"
     //! @return 0 on success, 1 on failure
@@ -104,6 +131,13 @@ class LT_I2CBus
                          uint16_t value      //!< Word to be written
                         );
 
+    //! Write a 16-bit word of data to register specified by "command"
+    //! @return 0 on success, 1 on failure
+    int8_t extendedWriteWordData(uint8_t address,    //!< 7-bit I2C address
+                                 uint16_t command,   //!< Command word
+                                 uint16_t value      //!< Word to be written
+                                );
+
     //! Read a block of data, starting at register specified by "command" and ending at (command + length - 1)
     //! @return 0 on success, 1 on failure
     int8_t readBlockData(uint8_t address,     //!< 7-bit I2C address
@@ -111,6 +145,15 @@ class LT_I2CBus
                          uint16_t length,     //!< Length of array
                          uint8_t *values      //!< Byte array to be read
                         );
+
+    //! Read a block of data, starting at register specified by "command" and ending at (command + length - 1)
+    //! @return 0 on success, 1 on failure
+    int8_t extendedReadBlockData(uint8_t address,     //!< 7-bit I2C address
+                                 uint16_t command,    //!< Command word
+                                 uint16_t length,     //!< Length of array
+                                 uint8_t *values      //!< Byte array to be read
+                                );
+
 
     //! Read a block of data, starting at register specified by "command" and ending at (command + length - 1)
     //! @return 0 on success, 1 on failure
@@ -134,8 +177,6 @@ class LT_I2CBus
                             uint8_t *values      //!< Byte array to be read
                            );
 
-
-
     //! Write a block of data, starting at register specified by "command" and ending at (command + length - 1)
     //! @return 0 on success, 1 on failure
     int8_t writeBlockData(uint8_t address,       //!< 7-bit I2C address
@@ -143,6 +184,14 @@ class LT_I2CBus
                           uint16_t length,       //!< Length of array
                           uint8_t *values        //!< Byte array to be written
                          );
+
+    //! Write a block of data, starting at register specified by "command" and ending at (command + length - 1)
+    //! @return 0 on success, 1 on failure
+    int8_t extendedWriteBlockData(uint8_t address,       //!< 7-bit I2C address
+                                  uint16_t command,      //!< Command word
+                                  uint16_t length,       //!< Length of array
+                                  uint8_t *values        //!< Byte array to be written
+                                 );
 
     //! Write a two command bytes, then receive a block of data
     //! @return 0 on success, 1 on failure

--- a/LTSketchbook/libraries/LT_SMBUS/LT_SMBus.h
+++ b/LTSketchbook/libraries/LT_SMBUS/LT_SMBus.h
@@ -135,6 +135,13 @@ class LT_SMBus
                            uint8_t data       //!< Data to send
                           ) = 0;
 
+    //! SMBus write byte command
+    //! @return void
+    virtual void extendedWriteByte(uint8_t address,   //!< Slave address
+                                   uint16_t command,   //!< Command word
+                                   uint8_t data       //!< Data to send
+                                  ) = 0;
+
     //! SMBus write byte command for a list of addresses
     //! @return void
     virtual void writeBytes(uint8_t *addresses,     //!< Slave Addresses
@@ -149,6 +156,12 @@ class LT_SMBus
                              uint8_t command      //!< Command byte
                             ) = 0;
 
+    //! SMBus read byte command
+    //! @return byte
+    virtual uint8_t extendedReadByte(uint8_t address,     //!< Slave Address
+                                     uint16_t command     //!< Command word
+                                    ) = 0;
+
     //! SMBus write word command
     //! @return void
     virtual void writeWord(uint8_t address,   //!< Slave Address
@@ -156,11 +169,24 @@ class LT_SMBus
                            uint16_t data      //!< Data to send
                           ) = 0;
 
+    //! SMBus write word command
+    //! @return void
+    virtual void extendedWriteWord(uint8_t address,   //!< Slave Address
+                                   uint16_t command,  //!< Command word
+                                   uint16_t data      //!< Data to send
+                                  ) = 0;
+
     //! SMBus read word command
     //! @return word
     virtual uint16_t readWord(uint8_t address,    //!< Slave Address
                               uint8_t command     //!< Command byte
                              ) = 0;
+
+    //! SMBus read word command
+    //! @return word
+    virtual uint16_t extendedReadWord(uint8_t address,    //!< Slave Address
+                                      uint16_t command    //!< Command word
+                                     ) = 0;
 
     //! SMBus write block command
     //! @return void
@@ -169,6 +195,14 @@ class LT_SMBus
                             uint8_t *block,     //!< Data to send
                             uint16_t block_size
                            ) = 0;
+
+    //! SMBus write block command
+    //! @return void
+    virtual void extendedWriteBlock(uint8_t address,    //!< Slave Address
+                                    uint16_t command,   //!< Command bword
+                                    uint8_t *block,     //!< Data to send
+                                    uint16_t block_size
+                                   ) = 0;
 
     //! SMBus write then read block command
     //! @return actual value
@@ -188,11 +222,26 @@ class LT_SMBus
                               uint16_t block_size  //!< Size of receive data memory
                              ) = 0;
 
+    //! SMBus read block command
+    //! @return actual size
+    virtual uint8_t extendedReadBlock(uint8_t address,     //!< Slave Address
+                                      uint16_t command,    //!< Command word
+                                      uint8_t *block,      //!< Memory to receive data
+                                      uint16_t block_size  //!< Size of receive data memory
+                                     ) = 0;
+
+
     //! SMBus send byte command
     //! @return void
     virtual void sendByte(uint8_t address,    //!< Slave Address
                           uint8_t command     //!< Command byte
                          ) = 0;
+
+    //! SMBus send byte command
+    //! @return void
+    virtual void extendedSendByte(uint8_t address,    //!< Slave Address
+                                  uint16_t command    //!< Command word
+                                 ) = 0;
 
     //! Read with the address and command in loop until ack, then issue stop
     //! @return void

--- a/LTSketchbook/libraries/LT_SMBUS/LT_SMBusBase.h
+++ b/LTSketchbook/libraries/LT_SMBUS/LT_SMBusBase.h
@@ -87,6 +87,13 @@ class LT_SMBusBase : public LT_SMBus
                    uint8_t data         //!< Data to send
                   );
 
+    //! SMBus write byte command
+    //! @return void
+    void extendedWriteByte(uint8_t address,     //!< Slave address
+                           uint16_t command,    //!< Command word
+                           uint8_t data         //!< Data to send
+                          );
+
     //! SMBus write byte command for a list of addresses
     //! @return void
     void writeBytes(uint8_t *addresses,         //!< Slave Addresses
@@ -101,6 +108,12 @@ class LT_SMBusBase : public LT_SMBus
                      uint8_t command         //!< Command byte
                     );
 
+    //! SMBus read byte command
+    //! @return byte
+    uint8_t extendedReadByte(uint8_t address,        //!< Slave Address
+                             uint16_t command        //!< Command word
+                            );
+
     //! SMBus write word command
     //! @return void
     void writeWord(uint8_t address,     //!< Slave Address
@@ -108,11 +121,24 @@ class LT_SMBusBase : public LT_SMBus
                    uint16_t data        //!< Data to send
                   );
 
+    //! SMBus write word command
+    //! @return void
+    void extendedWriteWord(uint8_t address,     //!< Slave Address
+                           uint16_t command,    //!< Command word
+                           uint16_t data        //!< Data to send
+                          );
+
     //! SMBus read word command
     //! @return word
     uint16_t readWord(uint8_t address,      //!< Slave Address
                       uint8_t command       //!< Command byte
                      );
+
+    //! SMBus read word command
+    //! @return word
+    uint16_t extendedReadWord(uint8_t address,      //!< Slave Address
+                              uint16_t command      //!< Command word
+                             );
 
     //! SMBus write block command
     //! @return void
@@ -121,6 +147,14 @@ class LT_SMBusBase : public LT_SMBus
                     uint8_t *block,         //!< Data to send
                     uint16_t block_size
                    );
+
+    //! SMBus write block command
+    //! @return void
+    void extendedWriteBlock(uint8_t address,        //!< Slave Address
+                            uint16_t command,       //!< Command word
+                            uint8_t *block,         //!< Data to send
+                            uint16_t block_size
+                           );
 
     //! SMBus write then read block command
     //! @return actual size
@@ -140,11 +174,26 @@ class LT_SMBusBase : public LT_SMBus
                       uint16_t block_size      //!< Size of receive data memory
                      );
 
+    //! SMBus read block command
+    //! @return actual size
+    uint8_t extendedReadBlock(uint8_t address,         //!< Slave Address
+                              uint16_t command,        //!< Command word
+                              uint8_t *block,          //!< Memory to receive data
+                              uint16_t block_size      //!< Size of receive data memory
+                             );
+
+
     //! SMBus send byte command
     //! @return void
     void sendByte(uint8_t address,      //!< Slave Address
                   uint8_t command       //!< Command byte
                  );
+
+    //! SMBus send byte command
+    //! @return void
+    void extendedSendByte(uint8_t address,      //!< Slave Address
+                          uint16_t command      //!< Command word
+                         );
 
     //! Perform ARA
     //! @return address

--- a/LTSketchbook/libraries/LT_SMBUS/LT_SMBusGroup.cpp
+++ b/LTSketchbook/libraries/LT_SMBUS/LT_SMBusGroup.cpp
@@ -80,6 +80,14 @@ void LT_SMBusGroup::writeByte(uint8_t address, uint8_t command, uint8_t data)
     executor->writeByte(address, command, data);
 }
 
+void LT_SMBusGroup::extendedWriteByte(uint8_t address, uint16_t command, uint8_t data)
+{
+  if (queueing)
+    addToQueue(new ExtendedWriteByte(executor, address, command, data));
+  else
+    executor->extendedWriteByte(address, command, data);
+}
+
 void LT_SMBusGroup::writeBytes(uint8_t *addresses, uint8_t *commands, uint8_t *data, uint8_t no_addresses)
 {
   if (queueing)
@@ -96,12 +104,28 @@ uint8_t LT_SMBusGroup::readByte(uint8_t address, uint8_t command)
     return executor->readByte(address, command);
 }
 
+uint8_t LT_SMBusGroup::extendedReadByte(uint8_t address, uint16_t command)
+{
+  if (queueing)
+    return executor->extendedReadByte(address, command);
+  else
+    return executor->extendedReadByte(address, command);
+}
+
 void LT_SMBusGroup::writeWord(uint8_t address, uint8_t command, uint16_t data)
 {
   if (queueing)
     addToQueue(new WriteWord(executor, address, command, data));
   else
     executor->writeWord(address, command, data);
+}
+
+void LT_SMBusGroup::extendedWriteWord(uint8_t address, uint16_t command, uint16_t data)
+{
+  if (queueing)
+    addToQueue(new ExtendedWriteWord(executor, address, command, data));
+  else
+    executor->extendedWriteWord(address, command, data);
 }
 
 uint16_t LT_SMBusGroup::readWord(uint8_t address, uint8_t command)
@@ -112,6 +136,14 @@ uint16_t LT_SMBusGroup::readWord(uint8_t address, uint8_t command)
     return executor->readWord(address, command);
 }
 
+uint16_t LT_SMBusGroup::extendedReadWord(uint8_t address, uint16_t command)
+{
+  if (queueing)
+    return executor->extendedReadWord(address, command);
+  else
+    return executor->extendedReadWord(address, command);
+}
+
 void LT_SMBusGroup::writeBlock(uint8_t address, uint8_t command,
                                uint8_t *block, uint16_t block_size)
 {
@@ -119,6 +151,15 @@ void LT_SMBusGroup::writeBlock(uint8_t address, uint8_t command,
     addToQueue(new WriteBlock(executor, address, command, block, block_size));
   else
     executor->writeBlock(address, command, block, block_size);
+}
+
+void LT_SMBusGroup::extendedWriteBlock(uint8_t address, uint16_t command,
+                               uint8_t *block, uint16_t block_size)
+{
+  if (queueing)
+    addToQueue(new ExtendedWriteBlock(executor, address, command, block, block_size));
+  else
+    executor->extendedWriteBlock(address, command, block, block_size);
 }
 
 uint8_t LT_SMBusGroup::writeReadBlock(uint8_t address, uint8_t command,
@@ -139,6 +180,15 @@ uint8_t LT_SMBusGroup::readBlock(uint8_t address, uint8_t command,
     return executor->readBlock(address, command, block, block_size);
 }
 
+uint8_t LT_SMBusGroup::extendedReadBlock(uint8_t address, uint16_t command,
+                                 uint8_t *block, uint16_t block_size)
+{
+  if (queueing)
+    return 0;
+  else
+    return executor->extendedReadBlock(address, command, block, block_size);
+}
+
 void LT_SMBusGroup::sendByte(uint8_t address, uint8_t command)
 {
   if (queueing)
@@ -147,6 +197,13 @@ void LT_SMBusGroup::sendByte(uint8_t address, uint8_t command)
     executor->sendByte(address, command);
 }
 
+void LT_SMBusGroup::extendedSendByte(uint8_t address, uint16_t command)
+{
+  if (queueing)
+    addToQueue(new ExtendedSendByte(executor, address, command));
+  else
+    executor->extendedSendByte(address, command);
+}
 
 void LT_SMBusGroup::beginStoring()
 {
@@ -210,6 +267,17 @@ void LT_SMBusGroup::WriteByte::execute()
   executor->writeByte(address, command, data);
 }
 
+LT_SMBusGroup::ExtendedWriteByte::ExtendedWriteByte(LT_SMBus *e, uint8_t a, uint16_t c, uint8_t d) : Executable(e)
+{
+  address = a;
+  command = c;
+  data = d;
+}
+void LT_SMBusGroup::ExtendedWriteByte::execute()
+{
+  executor->extendedWriteByte(address, command, data);
+}
+
 LT_SMBusGroup::WriteBytes::WriteBytes(LT_SMBus *e, uint8_t *a, uint8_t *c, uint8_t *d, uint8_t n) : Executable(e)
 {
   addresses = a;
@@ -233,6 +301,17 @@ void LT_SMBusGroup::WriteWord::execute()
   executor->writeWord(address, command, data);
 };
 
+LT_SMBusGroup::ExtendedWriteWord::ExtendedWriteWord(LT_SMBus *e, uint8_t a, uint16_t c, uint16_t d) : Executable(e)
+{
+  address = a;
+  command = c;
+  data = d;
+}
+void LT_SMBusGroup::ExtendedWriteWord::execute()
+{
+  executor->extendedWriteWord(address, command, data);
+};
+
 LT_SMBusGroup::WriteBlock::WriteBlock(LT_SMBus *e, uint8_t a, uint8_t c, uint8_t *b, uint16_t bl) : Executable(e)
 {
   address = a;
@@ -245,6 +324,18 @@ void LT_SMBusGroup::WriteBlock::execute()
   executor->writeBlock(address, command, block, block_size);
 };
 
+LT_SMBusGroup::ExtendedWriteBlock::ExtendedWriteBlock(LT_SMBus *e, uint8_t a, uint16_t c, uint8_t *b, uint16_t bl) : Executable(e)
+{
+  address = a;
+  command = c;
+  block = b;
+  block_size = bl;
+}
+void LT_SMBusGroup::ExtendedWriteBlock::execute()
+{
+  executor->extendedWriteBlock(address, command, block, block_size);
+};
+
 LT_SMBusGroup::SendByte::SendByte(LT_SMBus *e, uint8_t a, uint8_t c) : Executable(e)
 {
   address = a;
@@ -253,4 +344,14 @@ LT_SMBusGroup::SendByte::SendByte(LT_SMBus *e, uint8_t a, uint8_t c) : Executabl
 void LT_SMBusGroup::SendByte::execute()
 {
   executor->sendByte(address, command);
+};
+
+LT_SMBusGroup::ExtendedSendByte::ExtendedSendByte(LT_SMBus *e, uint8_t a, uint16_t c) : Executable(e)
+{
+  address = a;
+  command = c;
+};
+void LT_SMBusGroup::ExtendedSendByte::execute()
+{
+  executor->extendedSendByte(address, command);
 };

--- a/LTSketchbook/libraries/LT_SMBUS/LT_SMBusGroup.h
+++ b/LTSketchbook/libraries/LT_SMBUS/LT_SMBusGroup.h
@@ -83,6 +83,17 @@ class LT_SMBusGroup : public LT_SMBusBase
         void execute();
     };
 
+    class ExtendedWriteByte : public Executable
+    {
+        uint8_t address;
+        uint16_t command;
+        uint8_t data;
+
+      public:
+        ExtendedWriteByte(LT_SMBus *e, uint8_t a, uint16_t c, uint8_t d);
+        void execute();
+    };
+
     class WriteBytes : public Executable
     {
         uint8_t *addresses;
@@ -106,6 +117,17 @@ class LT_SMBusGroup : public LT_SMBusBase
         void execute();
     };
 
+    class ExtendedWriteWord : public Executable
+    {
+        uint8_t address;
+        uint16_t command;
+        uint16_t data;
+
+      public:
+        ExtendedWriteWord(LT_SMBus *e, uint8_t a, uint16_t c, uint16_t d);
+        void execute();
+    };
+
     class WriteBlock : public Executable
     {
         uint8_t address;
@@ -118,6 +140,18 @@ class LT_SMBusGroup : public LT_SMBusBase
         void execute();
     };
 
+    class ExtendedWriteBlock : public Executable
+    {
+        uint8_t address;
+        uint16_t command;
+        uint8_t *block;
+        uint16_t block_size;
+
+      public:
+        ExtendedWriteBlock(LT_SMBus *e, uint8_t a, uint16_t c, uint8_t *b, uint16_t bl);
+        void execute();
+    };
+
     class SendByte : public Executable
     {
         uint8_t address;
@@ -125,6 +159,16 @@ class LT_SMBusGroup : public LT_SMBusBase
 
       public:
         SendByte(LT_SMBus *e, uint8_t a, uint8_t c);
+        void execute();
+    };
+
+    class ExtendedSendByte : public Executable
+    {
+        uint8_t address;
+        uint16_t command;
+
+      public:
+        ExtendedSendByte(LT_SMBus *e, uint8_t a, uint16_t c);
         void execute();
     };
 
@@ -157,6 +201,13 @@ class LT_SMBusGroup : public LT_SMBusBase
                    uint8_t data       //!< Data to send
                   );
 
+    //! SMBus write byte command
+    //! @return void
+    void extendedWriteByte(uint8_t address,   //!< Slave address
+                           uint16_t command,  //!< Command word
+                           uint8_t data       //!< Data to send
+                          );
+
     //! SMBus write byte command for a list of addresses
     //! @return void
     void writeBytes(uint8_t *addresses,     //!< Slave Addresses
@@ -171,6 +222,12 @@ class LT_SMBusGroup : public LT_SMBusBase
                      uint8_t command      //!< Command byte
                     );
 
+    //! SMBus read byte command
+    //! @return byte
+    uint8_t extendedReadByte(uint8_t address,     //!< Slave Address
+                             uint16_t command     //!< Command word
+                            );
+
     //! SMBus write word command
     //! @return void
     void writeWord(uint8_t address,   //!< Slave Address
@@ -178,11 +235,24 @@ class LT_SMBusGroup : public LT_SMBusBase
                    uint16_t data      //!< Data to send
                   );
 
+    //! SMBus write word command
+    //! @return void
+    void extendedWriteWord(uint8_t address,   //!< Slave Address
+                           uint16_t command,  //!< Command word
+                           uint16_t data      //!< Data to send
+                          );
+
     //! SMBus read word command
     //! @return word
     uint16_t readWord(uint8_t address,    //!< Slave Address
                       uint8_t command     //!< Command byte
                      );
+
+    //! SMBus read word command
+    //! @return word
+    uint16_t extendedReadWord(uint8_t address,    //!< Slave Address
+                              uint16_t command    //!< Command word
+                             );
 
     //! SMBus write block command
     //! @return void
@@ -191,6 +261,14 @@ class LT_SMBusGroup : public LT_SMBusBase
                     uint8_t *block,     //!< Data to send
                     uint16_t block_size
                    );
+
+    //! SMBus write block command
+    //! @return void
+    void extendedWriteBlock(uint8_t address,    //!< Slave Address
+                            uint16_t command,   //!< Command word
+                            uint8_t *block,     //!< Data to send
+                            uint16_t block_size
+                           );
 
     //! SMBus write then read block command
     //! @return actual size
@@ -210,11 +288,26 @@ class LT_SMBusGroup : public LT_SMBusBase
                       uint16_t block_size  //!< Size of receive data memory
                      );
 
+    //! SMBus read block command
+    //! @return actual size
+    uint8_t extendedReadBlock(uint8_t address,     //!< Slave Address
+                              uint16_t command,    //!< Command word
+                              uint8_t *block,      //!< Memory to receive data
+                              uint16_t block_size  //!< Size of receive data memory
+                             );
+
+
     //! SMBus send byte command
     //! @return void
     void sendByte(uint8_t address,    //!< Slave Address
                   uint8_t command     //!< Command byte
                  );
+
+    //! SMBus send byte command
+    //! @return void
+    void extendedSendByte(uint8_t address,    //!< Slave Address
+                          uint16_t command    //!< Command word
+                         );
 
     //! Group Protocol Begin
     //! @return void

--- a/LTSketchbook/libraries/LT_SMBUS/LT_Wire.cpp
+++ b/LTSketchbook/libraries/LT_SMBUS/LT_Wire.cpp
@@ -52,6 +52,7 @@ LT_TwoWire::LT_TwoWire()
 void LT_TwoWire::begin(uint32_t speed)
 {
   TwoWire::begin();
+  TwoWire::setClock(speed);
 }
 
 


### PR DESCRIPTION
A company porting the code found that the existing cast failed and the pointer was at the wrong location. Changing to uint8_t* is more universal and works on a Mega 2650 and on the Rasp Pi Linux version.