### PR TITLE
Bug in LTC681x. Most recent PEC is not reset.

### DIFF
--- a/LTSketchbook/libraries/LTC681x/LTC681x.cpp
+++ b/LTSketchbook/libraries/LTC681x/LTC681x.cpp
@@ -679,6 +679,10 @@ int8_t LTC681x_rdstat(uint8_t reg, //Determines which Stat  register is read bac
 				pec_error = -1;                  //The pec_error variable is simply set negative if any PEC errors
 				ic[c_ic].stat.pec_match[reg-1]=1;
 			}
+			else
+		        {
+				ic[c_ic].stat.pec_match[reg-1]=0;
+			}
 		
 			data_counter=data_counter+2;
 		}


### PR DESCRIPTION
In `LTC681x_rdstat()` if the user inputs a single register for example `reg == 1` or `reg == 2` then if a PEC mismatch occurs the `stat.pec_match[1]` variable is set. But the problem is it is never reset again if the PEC matches.

