### PR TITLE
LTC2662.h corrected 300mA Span Code

### DIFF
--- a/LTSketchbook/libraries/LTC2662/LTC2662.h
+++ b/LTSketchbook/libraries/LTC2662/LTC2662.h
@@ -122,7 +122,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define  LTC2662_SPAN_100MA               0x0006
 #define  LTC2662_SPAN_200MA               0x0007
 #define  LTC2662_SPAN_SW_TO_NEG_V         0x0008
-#define  LTC2662_SPAN_300MA               0x0009
+#define  LTC2662_SPAN_300MA               0x000F
 //! @}
 
 //! @name LTC2662 Minimums and Maximums for each Span


### PR DESCRIPTION
The 300mA Span code is wrong in this file, it should be 0x000F not 0x0009. This is shown in the datasheet. I've tested it and the datasheet is correct.
Page 17 on the bottom:
https://www.analog.com/media/en/technical-documentation/data-sheets/LTC2662.pdf