### PR TITLE
Fixed a bug where oct was not kept within range for LTC6903 and LTC6904

### DIFF
--- a/LTSketchbook/libraries/LTC6903/LTC6903.cpp
+++ b/LTSketchbook/libraries/LTC6903/LTC6903.cpp
@@ -91,9 +91,9 @@ uint16_t LTC6903_frequency_to_code(float frequency, uint8_t clk)
 
   // Keep OCT within range
   if (oct_double>15)
-    oct = 15;
+    oct_double = 15;
   if (oct_double<0)
-    oct = 0;
+    oct_double = 0;
   oct = (uint8_t)oct_double;  // Cast as uint8_t , round down
 
   // Calculate DAC code

--- a/LTSketchbook/libraries/LTC6904/LTC6904.cpp
+++ b/LTSketchbook/libraries/LTC6904/LTC6904.cpp
@@ -92,9 +92,9 @@ uint16_t LTC6904_frequency_to_code(float frequency, uint8_t clk)
 
   // Keep OCT within range
   if (oct_double>15)
-    oct = 15;
+    oct_double = 15;
   if (oct_double<0)
-    oct = 0;
+    oct_double = 0;
   oct = (uint8_t)oct_double;  // Cast as uint8_t , round down
 
   // Calculate DAC code


### PR DESCRIPTION
In the original code there was a typo in the check and instead of updating oct_double, the updated variable was oct itself which is updated soon after the check, making this check senseless.  